### PR TITLE
Xcode12 no internal warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftRex",
-    platforms: [.macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)],
+    platforms: [.macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v3)],
     products: [
         .library(name: "CombineRex", targets: ["SwiftRex", "CombineRex"]),
         .library(name: "ReactiveSwiftRex", targets: ["SwiftRex", "ReactiveSwiftRex"]),

--- a/ReactiveSwiftRex.podspec
+++ b/ReactiveSwiftRex.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.frameworks       = 'Foundation'
 
-  s.ios.deployment_target       = '8.0'
+  s.ios.deployment_target       = '9.0'
   s.osx.deployment_target       = '10.10'
   s.watchos.deployment_target   = '3.0'
   s.tvos.deployment_target      = '9.0'

--- a/RxSwiftRex.podspec
+++ b/RxSwiftRex.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.frameworks       = 'Foundation'
 
-  s.ios.deployment_target       = '8.0'
+  s.ios.deployment_target       = '9.0'
   s.osx.deployment_target       = '10.10'
   s.watchos.deployment_target   = '3.0'
   s.tvos.deployment_target      = '9.0'

--- a/SwiftRex.podspec
+++ b/SwiftRex.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.frameworks       = 'Foundation'
 
-  s.ios.deployment_target       = '8.0'
+  s.ios.deployment_target       = '9.0'
   s.osx.deployment_target       = '10.10'
   s.watchos.deployment_target   = '3.0'
   s.tvos.deployment_target      = '9.0'

--- a/Tests/SwiftRexTests/Mocks/Reducer/ReducerMock.swift
+++ b/Tests/SwiftRexTests/Mocks/Reducer/ReducerMock.swift
@@ -5,7 +5,7 @@ let createReducerMock: () -> (Reducer<AppAction, TestState>, ReducerMock<AppActi
 
     return (Reducer { action, state in
         mock.reduceCallsCount += 1
-        mock.reduceReceivedArguments = (currentState: state, action: action)
+        mock.reduceReceivedArguments = (action: action, currentState: state)
         return mock.reduceClosure.map { $0(action, state) } ?? mock.reduceReturnValue
     }, mock)
 }


### PR DESCRIPTION
Dropping iOS 8 as it's no longer supported by Xcode 12.
Fix tuple with wrong order in the tests.
Compiling for Xcode 12 without internal warnings. ReactiveSwift and RxSwift have warnings for targetting iOS 8.