### PR TITLE
[MINOR] : moving to iOS v9 for the platform dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftRex",
-    platforms: [.macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)],
+    platforms: [.macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v3)],
     products: [
         .library(name: "CombineRex", targets: ["SwiftRex", "CombineRex"]),
         .library(name: "ReactiveSwiftRex", targets: ["SwiftRex", "ReactiveSwiftRex"]),


### PR DESCRIPTION
This is in order to remove the warning in Xcode. However there might still be some warnings when leveraging RxSwift or ReactiveSwift because of their Package definition still mentioning iOS v8.