### PR TITLE
[ADD] : provided a way to use annotations for import statements

### DIFF
--- a/docs/markdown/SourceryTemplates/Prism.stencil
+++ b/docs/markdown/SourceryTemplates/Prism.stencil
@@ -1,3 +1,6 @@
+{# Make sure to use an array of 1 for a single import declaration#}
+{# such as :  args: imports = ["SomeModule"]#}
+{# Note that this will be added for all files. If you want more granularity, see below... #}
 {% for import in argument.imports %}
 import {{ import }}
 {% endfor %}
@@ -34,6 +37,13 @@ import {{ import }}
 
 {% endmacro %}
 {% for type in types.enums where type.based.Prism or type|annotated:"Prism" %}{% if type.name != "Prism" %}
+{# Make sure to use an array of 1 for a single import declaration #}
+{# such as : // sourcery: imports = ["SomeModule"] #}
+{# This is for targeted imports applying only to the types that have been annotated. #}
+{% for import in type.annotations.imports %}
+import {{ import }}
+{% endfor %}
+
 extension {{ type.name }} {
 {% for case in type.cases %}
     {% call caseOptics type.accessLevel case %}


### PR DESCRIPTION
### Description
The current Prism.stencil template allows for import statements to be added to the beginning of the generated file by specifying an argument, either as an option to the command line or via the .sourcery.yml configuration file : 

```
sources:
  include:
    - Sources
templates:
  include:
    - Sources/SwiftRex/CodeGeneration/Templates
  exclude:
    - Sources/SwiftRex/CodeGeneration/Templates/AutoCases.stencil
output: Sources/SwiftRex/CodeGeneration
args:
  imports: ["Foundation", "RxSwift", "SwiftUI"]
  testable-imports: ["SwiftUI"]
```

While this is great, it conflates (just a little !) the arguments applied to all templates. In other words, if another template uses `imports` as an argument variable, then both generated files will have some imports they might not care about.

In order to solve this problem, we provide annotations, per type (so it's more explicit which type requires which import), that are not included in the command line or the configuration file.

### Usage
In order to leverage annotations to add import statements in the Prism generation, you can add the following to your code : 

```
...
// MARK: - ACTIONS

// sourcery: Prism, imports = ["AppLifecycleMiddleware", "ProfileMiddleware"]
enum AppAction {
    case appLifecycle(AppLifecycleAction)
    case profile(ProfileAction)
    case navigation(NavigationAction)
}
```

If you only need to import 1 single module use an array with 1 element : 

`// sourcery: Prism, imports = ["AppLifecycleMiddleware"]
`

We also added _a few comments_ in the stencil code...