### PR TITLE
FIX : added escaping clause as discussed in issue #94

### DIFF
--- a/Sources/CombineRex/Effect/Effect.swift
+++ b/Sources/CombineRex/Effect/Effect.swift
@@ -188,7 +188,7 @@ extension Effect {
     public static func promise<H: Hashable>(
         token: H,
         from dispatcher: ActionSource,
-        perform: @escaping (Context, (OutputAction) -> Void) -> Void
+        perform: @escaping (Context, @escaping (OutputAction) -> Void) -> Void
     ) -> Effect {
         Effect<Dependencies, OutputAction> { context in
             Deferred<Future<DispatchedAction<OutputAction>, Never>> {
@@ -207,7 +207,7 @@ extension Effect {
         function: String = #function,
         line: UInt = #line,
         info: String? = nil,
-        perform: @escaping (Context, (OutputAction) -> Void) -> Void
+        perform: @escaping (Context, @escaping (OutputAction) -> Void) -> Void
     ) -> Effect {
         promise(token: token,
                 from: ActionSource(file: file, function: function, line: line, info: info),

--- a/Sources/ReactiveSwiftRex/Effect/Effect.swift
+++ b/Sources/ReactiveSwiftRex/Effect/Effect.swift
@@ -184,7 +184,7 @@ extension Effect {
     public static func promise<H: Hashable>(
         token: H,
         from dispatcher: ActionSource,
-        perform: @escaping (Context, (OutputAction) -> Void) -> Disposable
+        perform: @escaping (Context, @escaping (OutputAction) -> Void) -> Disposable
     ) -> Effect {
         Effect<Dependencies, OutputAction> { context in
             SignalProducer { observer, lifetime in
@@ -202,7 +202,7 @@ extension Effect {
         function: String = #function,
         line: UInt = #line,
         info: String? = nil,
-        perform: @escaping (Context, (OutputAction) -> Void) -> Disposable
+        perform: @escaping (Context, @escaping (OutputAction) -> Void) -> Disposable
     ) -> Effect {
         promise(token: token,
                 from: ActionSource(file: file, function: function, line: line, info: info),

--- a/Sources/RxSwiftRex/Effect/Effect.swift
+++ b/Sources/RxSwiftRex/Effect/Effect.swift
@@ -181,7 +181,7 @@ extension Effect {
     public static func promise<H: Hashable>(
         token: H,
         from dispatcher: ActionSource,
-        perform: @escaping (Context, (OutputAction) -> Void) -> Disposable
+        perform: @escaping (Context, @escaping (OutputAction) -> Void) -> Disposable
     ) -> Effect {
         Effect<Dependencies, OutputAction> { context in
             Observable.create { observer -> Disposable in
@@ -199,7 +199,7 @@ extension Effect {
         function: String = #function,
         line: UInt = #line,
         info: String? = nil,
-        perform: @escaping (Context, (OutputAction) -> Void) -> Disposable
+        perform: @escaping (Context, @escaping (OutputAction) -> Void) -> Disposable
     ) -> Effect {
         promise(token: token,
                 from: ActionSource(file: file, function: function, line: line, info: info),


### PR DESCRIPTION
See [comment](https://github.com/SwiftRex/SwiftRex/issues/94#issuecomment-756227286) on issue #94 .

This fixes the compilation issues and seems to pass my cursory tests.