### PR TITLE
Fix Memory Leak

### DIFF
--- a/Sources/CombineRex/SwiftUI/ObservableViewModel.swift
+++ b/Sources/CombineRex/SwiftUI/ObservableViewModel.swift
@@ -57,7 +57,9 @@ open class ObservableViewModel<ViewAction, ViewState>: StoreType, ObservableObje
                 }
             )
     }
-
+    deinit {
+      cancellableBinding?.cancel()
+    }
     open func dispatch(_ dispatchedAction: DispatchedAction<ViewAction>) {
         store.dispatch(dispatchedAction)
     }


### PR DESCRIPTION
Fix Memory leak when creating viewModel inside View
It happens because ViewModel deinits a lot in this case