### PR TITLE
Add convenience method just with Context

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,9 +28,9 @@ let package = Package(
         .target(name: "RxSwiftRex", dependencies: ["SwiftRex", "RxSwift"]),
 
         .testTarget(name: "SwiftRexTests", dependencies: ["SwiftRex"]),
-//        .testTarget(name: "CombineRexTests", dependencies: ["CombineRex"]),
-//        .testTarget(name: "ReactiveSwiftRexTests", dependencies: ["ReactiveSwiftRex"]),
-//        .testTarget(name: "RxSwiftRexTests", dependencies: ["RxSwiftRex"]),
+        .testTarget(name: "CombineRexTests", dependencies: ["CombineRex"]),
+        .testTarget(name: "ReactiveSwiftRexTests", dependencies: ["ReactiveSwiftRex"]),
+        .testTarget(name: "RxSwiftRexTests", dependencies: ["RxSwiftRex"]),
 
         .testTarget(
             name: "SwiftRexDeprecationTests",

--- a/Sources/CombineRex/Effect/Effect.swift
+++ b/Sources/CombineRex/Effect/Effect.swift
@@ -132,6 +132,12 @@ extension Effect where Dependencies == Void {
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Effect {
+    public static func just(_ upstream: @escaping (Context) -> OutputAction) -> Effect<Dependencies, OutputAction> {
+        Effect { context in
+            Just(DispatchedAction(upstream(context)))
+        }
+    }
+
     public static func just(_ value: OutputAction, from dispatcher: ActionSource) -> Effect {
         Effect { _ in
             Just(DispatchedAction(value, dispatcher: dispatcher))

--- a/Sources/ReactiveSwiftRex/Effect/Effect.swift
+++ b/Sources/ReactiveSwiftRex/Effect/Effect.swift
@@ -129,6 +129,12 @@ extension Effect where Dependencies == Void {
 }
 
 extension Effect {
+    public static func just(_ upstream: @escaping (Context) -> OutputAction) -> Effect<Dependencies, OutputAction> {
+        Effect { context in
+            SignalProducer(value: DispatchedAction(upstream(context)))
+        }
+    }
+
     public static func just(_ value: OutputAction, from dispatcher: ActionSource) -> Effect {
         Effect { _ in
             SignalProducer(value: DispatchedAction(value, dispatcher: dispatcher))

--- a/Sources/RxSwiftRex/Effect/Effect.swift
+++ b/Sources/RxSwiftRex/Effect/Effect.swift
@@ -126,6 +126,12 @@ extension Effect where Dependencies == Void {
 }
 
 extension Effect {
+    public static func just(_ upstream: @escaping (Context) -> OutputAction) -> Effect<Dependencies, OutputAction> {
+        Effect { context in
+            Observable.just(DispatchedAction(upstream(context)))
+        }
+    }
+
     public static func just(_ value: OutputAction, from dispatcher: ActionSource) -> Effect {
         Effect { _ in
             Observable.just(DispatchedAction(value, dispatcher: dispatcher))

--- a/Tests/CombineRexTests/Effect/EffectTests.swift
+++ b/Tests/CombineRexTests/Effect/EffectTests.swift
@@ -4,6 +4,8 @@ import CombineRex
 import SwiftRex
 import XCTest
 
+// swiftlint:disable type_body_length
+
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class EffectTests: XCTestCase {
     func testInitWithCancellation() {

--- a/Tests/CombineRexTests/Effect/EffectTests.swift
+++ b/Tests/CombineRexTests/Effect/EffectTests.swift
@@ -110,6 +110,19 @@ class EffectTests: XCTestCase {
         XCTAssertEqual([.finished], completion)
     }
 
+    func testJustWithDependencies() {
+        let sut = Effect<Int, Int>.just { context in
+            context.dependencies + 42
+        }
+        var completion = [Subscribers.Completion<Never>]()
+        var received = [Int]()
+        _ = sut
+            .run((dependencies: 1, toCancel: { _ in FireAndForget { } }))?
+            .sink(receiveCompletion: { completion += [$0] }, receiveValue: { received += [$0.action] })
+        XCTAssertEqual([43], received)
+        XCTAssertEqual([.finished], completion)
+    }
+
     func testSequenceArray() {
         let sut = Effect<Void, Int>.sequence([1, 1, 2, 3, 5, 8, 13, 21, 34, 55])
         var completion = [Subscribers.Completion<Never>]()

--- a/Tests/ReactiveSwiftRexTests/Effect/EffectTests.swift
+++ b/Tests/ReactiveSwiftRexTests/Effect/EffectTests.swift
@@ -144,6 +144,23 @@ class EffectTests: XCTestCase {
         XCTAssertEqual(1, completion)
     }
 
+    func testJustWithDependencies() {
+        let sut = Effect<Int, Int>.just { context in
+            context.dependencies + 42
+        }
+        var completion = 0
+        var received = [Int]()
+        _ = sut
+            .run((dependencies: 1, toCancel: { _ in FireAndForget { } }))?
+            .on(
+                completed: { completion += 1 },
+                interrupted: { XCTFail("should not interrupt") },
+                value: { received += [$0.action] })
+            .start()
+        XCTAssertEqual([43], received)
+        XCTAssertEqual(1, completion)
+    }
+
     func testSequenceArray() {
         let sut = Effect<Void, Int>.sequence([1, 1, 2, 3, 5, 8, 13, 21, 34, 55])
         var completion = 0

--- a/Tests/RxSwiftRexTests/Effect/EffectTests.swift
+++ b/Tests/RxSwiftRexTests/Effect/EffectTests.swift
@@ -135,6 +135,23 @@ class EffectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(1, completion)
     }
 
+    func testJustWithDependencies() {
+        let sut = Effect<Int, Int>.just { context in
+            context.dependencies + 42
+        }
+        var completion = 0
+        var received = [Int]()
+        _ = sut
+            .run((dependencies: 1, toCancel: { _ in FireAndForget { } }))?
+            .subscribe(
+                onNext: { received += [$0.action] },
+                onError: { _ in XCTFail("should not fail") },
+                onCompleted: { completion += 1 }
+            )
+        XCTAssertEqual([43], received)
+        XCTAssertEqual(1, completion)
+    }
+
     func testSequenceArray() {
         let sut = Effect<Void, Int>.sequence([1, 1, 2, 3, 5, 8, 13, 21, 34, 55])
         var completion = 0


### PR DESCRIPTION
This PR adds another convenience method `Effect.just`, taking a closure which accepts a Context.