### PR TITLE
TestStore: drop Action: Equatable, validate via Prism

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -95,7 +95,10 @@ let package = Package(
 
         .target(
             name: "SwiftRexTesting",
-            dependencies: ["SwiftRex"],
+            dependencies: [
+                "SwiftRex",
+                .product(name: "CoreFP", package: "FP")
+            ],
             path: "Sources/SwiftRexTesting"
         ),
 
@@ -132,7 +135,11 @@ let package = Package(
         ),
         .testTarget(
             name: "SwiftRexTestingTests",
-            dependencies: ["SwiftRexTesting", "SwiftRex"],
+            dependencies: [
+                "SwiftRexTesting",
+                "SwiftRex",
+                .product(name: "CoreFP", package: "FP")
+            ],
             path: "Tests/SwiftRexTestingTests"
         )
     ],

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Build Status](https://github.com/SwiftRex/SwiftRex/actions/workflows/ci.yml/badge.svg?branch=main)
 [![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-orange.svg)](https://swiftpackageindex.com/SwiftRex/SwiftRex)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FSwiftRex%2FSwiftRex%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/SwiftRex/SwiftRex)
-[![Platform support](https://img.shields.io/badge/platform-iOS%20%7C%20watchOS%20%7C%20tvOS%20%7C%20macOS%20%7C%20Catalyst-252532.svg)](https://github.com/SwiftRex/SwiftRex)
+[![Platform support](https://img.shields.io/badge/platform-iOS%20%7C%20watchOS%20%7C%20tvOS%20%7C%20macOS%20%7C%20visionOS%20%7C%20Linux-252532.svg)](https://github.com/SwiftRex/SwiftRex)
 [![License Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/SwiftRex/SwiftRex/blob/main/LICENSE)
 
 # Introduction
@@ -97,22 +97,26 @@ That's the scenario where SwiftRex shines, because it:
 <details>
   <summary>offers tooling for development, tests and debugging [tap to expand]</summary>
   <p>Several projects offer SwiftRex tools to help developers when writing apps, tests, debugging it or evaluating crash reports.</p>
-  <p><a href="https://github.com/SwiftRex/TestingExtensions">TestingExtensions</a> has "test asserts" that will unlock testability of use cases in a fun and easy way, <a href="https://github.com/SwiftRex/InstrumentationMiddleware">InstrumentationMiddleware</a> allows you to use Instruments to see what's happening in a SwiftRex app, <a href="https://github.com/SwiftRex/SwiftRexMonitor">SwiftRexMonitor</a> will be a Swift version of well-known Redux DevTools where you can remotely monitor state and actions of an app from an external Mac or iOS device, and even inject actions to simulate side-effects (useful for UITests, for example), <a href="https://github.com/SwiftRex/GatedMiddleware">GatedMiddleware</a> is a middleware wrapper that can be used to enable or disable other middlewares in runtime, <a href="https://github.com/SwiftRex/LoggerMiddleware">LoggerMiddleware</a> is a very powerful logger to be used by developers to easily understand what's happening in runtime. More Middlewares will be open-sourced soon allowing, for example, to create good Crashlytics reports that tell the story of a crash as you've never had access before, and that way, recreate crashes or user reports. Also tools for generating code (Sourcery templates, Xcode snippets and templates, console tools). New dependency injection strategies are about to be released as well.</p>
-  <p>All these tools are already done and will be released any time soon, and more are expected for the future.</p>
+  <p><code>SwiftRex.Testing</code> ships a <code>TestStore</code> built directly into SwiftRex — no separate package needed. It gives you a deterministic, exhaustive test harness with mandatory state assertions on every dispatch and Prism-based action validation for <code>receive</code>. See the <a href="#testing">Testing</a> section below for full examples. <a href="https://github.com/SwiftRex/InstrumentationMiddleware">InstrumentationMiddleware</a> allows you to use Instruments to see what's happening in a SwiftRex app, and <a href="https://github.com/SwiftRex/LoggerMiddleware">LoggerMiddleware</a> is a very powerful logger to be used by developers to easily understand what's happening in runtime.</p>
 </details>
 
 I'm not gonna lie, it's a completely different way of writing apps, as most reactive approaches are; but once you get used to, it makes more sense and enables you to reuse much more code between your projects, gives you better tooling for writing software, testing, debugging, logging and finally thinking about events, state and mutation as you've never done before. And I promise you, it's gonna be a way with no return, a unidirectional journey.
 
 # Integration Options
 
-SwiftRex supports multiple concurrency styles. The core package is self-contained and sufficient on its own; the reactive and concurrency bridges are optional add-ons:
+SwiftRex supports multiple concurrency styles. The core package is self-contained and sufficient on its own; the reactive, concurrency, and testing bridges are optional add-ons:
 
-- **SwiftRex.Concurrency** — If you use async/await and don't want reactive framework dependencies, `SwiftRex.Concurrency` gives you Effect bridges for `Task`, `AsyncSequence`, and `DeferredStream` — no third-party dependencies.
-- **SwiftRex.Combine** — Integration with [Apple Combine](https://developer.apple.com/documentation/combine)
-- **SwiftRex.RxSwift** — Integration with [RxSwift](https://github.com/ReactiveX/RxSwift)
-- **SwiftRex.ReactiveSwift** — Integration with [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift)
+| Product | When to use |
+|---|---|
+| `SwiftRex` | Always — the core store, reducers, behaviors, effects |
+| `SwiftRex.Concurrency` | async/await — Effect bridges for `Task`, `AsyncSequence`, `DeferredStream` |
+| `SwiftRex.Combine` | Apple Combine integration |
+| `SwiftRex.RxSwift` | RxSwift integration |
+| `SwiftRex.ReactiveSwift` | ReactiveSwift integration |
+| `SwiftRex.SwiftUI` | SwiftUI helpers — `asObservableObject()`, `asObservableStore()` |
+| `SwiftRex.Testing` | Test target only — `TestStore` for deterministic unit tests |
 
-More can be easily added later by implementing some abstraction bridges. Pick the module that matches your project's reactive strategy, or stay with core SwiftRex and `SwiftRex.Concurrency` for a pure Swift Concurrency setup.
+Pick the module(s) that match your project's reactive strategy. For a pure Swift Concurrency setup with no third-party dependencies, `SwiftRex` + `SwiftRex.Concurrency` is sufficient.
 
 ## Swift Concurrency
 
@@ -1109,6 +1113,102 @@ You can think of Store as a very heavy "Model" layer, completely detached from t
 
 And what about SwiftUI? Is this architecture a good fit for the new UI framework? In fact, this architecture works even better in SwiftUI, because SwiftUI was inspired by several functional patterns and it's reactive and stateless by conception. In SwiftUI, the **View is a function of the state**, and we should always aim for single source of truth — data should always flow in a single direction.
 
+# Testing
+
+SwiftRex ships `SwiftRex.Testing` — a `TestStore` that drives the dispatch pipeline synchronously so you can assert mutations and verify effects without spinning up a real `Store`.
+
+## TestStore basics
+
+```swift
+import SwiftRexTesting
+import Testing
+
+@Test func counterIncrements() {
+    let store = TestStore(initial: CounterState(), reducer: counterReducer)
+
+    store.send(.increment) { $0.count += 1 }  // assert state after the action
+    store.send(.decrement) { $0.count -= 1 }
+}
+```
+
+`send(_:assert:)` runs the behavior's handle closure and state mutation synchronously, then validates the resulting state against the closure. The closure receives an `inout` copy of the state *before* the action and you mutate it to what you expect — a mismatch records a `Testing` failure pointing to the call site.
+
+## Testing effects
+
+Effects are captured in `pendingEffects` without running. Call `runEffects()` to drive them, then `receive` each resulting action:
+
+```swift
+@Test func fetchPopulatesItems() async {
+    let store = TestStore(
+        initial: AppState(),
+        behavior: appBehavior,
+        environment: AppEnvironment.mock
+    )
+
+    store.send(.fetchItems) { $0.isLoading = true }
+
+    await store.runEffects()
+
+    // receive(prism:assert:) validates the action case via Prism and gives
+    // you the extracted associated value for the state assertion
+    store.receive(AppAction.prism.didFetch) { items, state in
+        state.isLoading = false
+        state.items = items   // `items` is the [Item] extracted from .didFetch([Item])
+    }
+}
+```
+
+For action cases with no associated value, use a `Prism<Action, Void>` and the shorter closure:
+
+```swift
+store.receive(AppAction.prism.didReset) { $0 = .initial }
+```
+
+## Exhaustive mode
+
+By default `TestStore` is exhaustive — it fails the test if you:
+
+- call `send` while `receivedActions` is non-empty (unprocessed received actions)
+- let the store deallocate with leftover `pendingEffects` or `receivedActions`
+
+Pass `exhaustive: false` to opt out:
+
+```swift
+let store = TestStore(initial: s, behavior: b, environment: e, exhaustive: false)
+```
+
+## Chaining sends
+
+`send` returns `self`, so multiple dispatches can be chained:
+
+```swift
+store
+    .send(.increment) { $0.count = 1 }
+    .send(.increment) { $0.count = 2 }
+    .send(.reset)     { $0.count = 0 }
+```
+
+## Defining Prisms for your action type
+
+`receive` uses `Prism<Action, Value>` from the [FP](https://github.com/luizmb/FP) library to match action cases without requiring `Action: Equatable`. Define prisms for each case you want to assert:
+
+```swift
+extension AppAction {
+    enum prism {
+        static let didFetch = Prism<AppAction, [Item]>(
+            preview: { if case .didFetch(let items) = $0 { return items } else { return nil } },
+            review: AppAction.didFetch
+        )
+        static let didReset = Prism<AppAction, Void>(
+            preview: { if case .didReset = $0 { return () } else { return nil } },
+            review: { _ in .didReset }
+        )
+    }
+}
+```
+
+---
+
 # Installation
 
 ## Swift Package Manager
@@ -1122,7 +1222,7 @@ import PackageDescription
 
 let package = Package(
     name: "MyApp",
-    platforms: [.macOS(.v12), .iOS(.v15), .tvOS(.v15), .watchOS(.v8)],
+    platforms: [.macOS(.v12), .iOS(.v15), .tvOS(.v15), .watchOS(.v8), .visionOS(.v1)],
     products: [
         .executable(name: "MyApp", targets: ["MyApp"])
     ],
@@ -1140,11 +1240,36 @@ let package = Package(
                 .product(name: "SwiftRex.RxSwift", package: "SwiftRex"),       // RxSwift
                 .product(name: "SwiftRex.ReactiveSwift", package: "SwiftRex"), // ReactiveSwift
             ]
+        ),
+        .testTarget(
+            name: "MyAppTests",
+            dependencies: [
+                "MyApp",
+                .product(name: "SwiftRex.Testing", package: "SwiftRex"),       // TestStore
+            ]
         )
     ]
 )
 ```
 
-Platform minimums: macOS 12+, iOS 15+, tvOS 15+, watchOS 8+.
+Supported platforms: macOS 12+, iOS 15+, tvOS 15+, watchOS 8+, visionOS 1+, Linux (Swift 6+).
+
+`SwiftRex.Concurrency`, `SwiftRex`, and `SwiftRex.Testing` are fully cross-platform including Linux. `SwiftRex.Combine` and `SwiftRex.SwiftUI` require Apple platforms. `SwiftRex.RxSwift` and `SwiftRex.ReactiveSwift` require Apple platforms unless the respective frameworks add Linux support.
 
 You can also add SwiftRex directly in Xcode via **File > Add Package Dependencies** and entering the repository URL `https://github.com/SwiftRex/SwiftRex.git`.
+
+## XCFrameworks
+
+Pre-built XCFrameworks for the dependency-free products are attached to each [GitHub release](https://github.com/SwiftRex/SwiftRex/releases):
+
+| Framework | Contents |
+|---|---|
+| `SwiftRex.xcframework.zip` | Core store, reducers, behaviors, effects |
+| `SwiftRex.Operators.xcframework.zip` | Symbolic operators (`<>`, `\|>`, `>>>`, …) |
+| `SwiftRex.Concurrency.xcframework.zip` | async/await Effect bridges |
+| `SwiftRex.Combine.xcframework.zip` | Combine publisher bridge |
+| `SwiftRex.SwiftUI.xcframework.zip` | SwiftUI integration (`asObservableObject`, `asObservableStore`) |
+
+The reactive bridges (`SwiftRex.RxSwift`, `SwiftRex.ReactiveSwift`) depend on third-party frameworks that ship their own XCFrameworks; use SPM for those products.
+
+To integrate an XCFramework manually: download the `.zip` from the release, unzip it, and drag the `.xcframework` bundle into your Xcode project's **Frameworks, Libraries, and Embedded Content** section.

--- a/README.md
+++ b/README.md
@@ -535,13 +535,19 @@ Middleware is generic over 3 type parameters:
 
 In its most important function, `Middleware.handle`, the middleware is expected to return a `Reader<Environment, Effect<Action>>`. The `Reader` is a description of side-effects deferred until the environment is provided. `Effect<Action>` is a wrapper for any async or reactive work that may eventually produce more actions to dispatch.
 
-In some cases, we may want to not execute any side-effect. Use `.doNothing` — a SwiftRex convenience that reads naturally at call sites:
+SwiftRex defines two conveniences on `Reader<Environment, Effect<Action>>` that mirror the fluent API available in `Consequence`:
 
 ```swift
+// No effect — skip early
 guard case .myAction = action.action else { return .doNothing }
+
+// Produce an effect with environment access
+return .produce { env in
+    Effect.task { .result(await env.api.fetch()) }
+}
 ```
 
-This is equivalent to `Reader { _ in .empty }` but communicates intent clearly.
+`.doNothing` is equivalent to `Reader { _ in .empty }`. `.produce` is equivalent to `Reader { env in … }`. Either form is acceptable; the named versions communicate intent more clearly at the call site.
 
 #### Dependency Injection
 
@@ -570,7 +576,7 @@ let favoritesMiddleware = Middleware<FavoritesAction, FavoritesModel, API>.handl
     guard case let .toggleFavorite(movieId) = action.action else { return .doNothing }
     let currentList = stateAccess.snapshotState()
     let makeFavorite = !(currentList?.contains(where: { $0.id == movieId }) ?? false)
-    return Reader { api in
+    return .produce { api in
         Effect.task {
             let result = await api.changeFavorite(id: movieId, makeFavorite: makeFavorite)
             return .changedFavorite(movieId, isFavorite: result)
@@ -1126,8 +1132,8 @@ import Testing
 @Test func counterIncrements() {
     let store = TestStore(initial: CounterState(), reducer: counterReducer)
 
-    store.send(.increment) { $0.count += 1 }  // assert state after the action
-    store.send(.decrement) { $0.count -= 1 }
+    store.dispatch(.increment) { $0.count += 1 }  // assert state after the action
+    store.dispatch(.decrement) { $0.count -= 1 }
 }
 ```
 
@@ -1145,7 +1151,7 @@ Effects are captured in `pendingEffects` without running. Call `runEffects()` to
         environment: AppEnvironment.mock
     )
 
-    store.send(.fetchItems) { $0.isLoading = true }
+    store.dispatch(.fetchItems) { $0.isLoading = true }
 
     await store.runEffects()
 
@@ -1183,9 +1189,9 @@ let store = TestStore(initial: s, behavior: b, environment: e, exhaustive: false
 
 ```swift
 store
-    .send(.increment) { $0.count = 1 }
-    .send(.increment) { $0.count = 2 }
-    .send(.reset)     { $0.count = 0 }
+    .dispatch(.increment) { $0.count = 1 }
+    .dispatch(.increment) { $0.count = 2 }
+    .dispatch(.reset)     { $0.count = 0 }
 ```
 
 ## Defining Prisms for your action type

--- a/Sources/SwiftRex/Middleware/Reader+Monoid.swift
+++ b/Sources/SwiftRex/Middleware/Reader+Monoid.swift
@@ -17,15 +17,47 @@ extension Reader where Output: Monoid {
     /// ``Behavior/handle`` closure when an action is not relevant:
     ///
     /// ```swift
-    /// let fetchMiddleware = Middleware<AppAction, AppState, API>.handle { action, _ in
-    ///     guard case .fetchData(let query) = action.action else { return .doNothing }
-    ///     return Reader { api in
-    ///         Effect.task { try await api.search(query) }
-    ///             .map(AppAction.searchResult)
-    ///     }
-    /// }
+    /// guard case .fetchData(let query) = action.action else { return .doNothing }
     /// ```
     ///
     /// Equivalent to `Reader { _ in .empty }` but communicates intent clearly.
     public static var doNothing: Self { .identity }
+}
+
+// MARK: - .produce for Effect pipelines
+
+extension Reader {
+    /// Creates a `Reader<Environment, Effect<Action>>` from a closure that receives
+    /// the environment and returns an `Effect`.
+    ///
+    /// Mirrors ``Consequence/produce(_:)`` so `Middleware` and `Behavior` handlers
+    /// share the same vocabulary. The two forms below are equivalent:
+    ///
+    /// ```swift
+    /// // Explicit Reader init
+    /// return Reader { api in
+    ///     api.fetch(id: id).asEffect()
+    /// }
+    ///
+    /// // Shorthand — reads like Consequence.produce at the call site
+    /// return .produce { api in
+    ///     api.fetch(id: id).asEffect()
+    /// }
+    /// ```
+    ///
+    /// Full middleware example:
+    ///
+    /// ```swift
+    /// let favMiddleware = Middleware<AppAction, AppState, API>.handle { action, _ in
+    ///     guard case .toggleFavorite(let id) = action.action else { return .doNothing }
+    ///     return .produce { api in
+    ///         Effect.task { .favResult(await api.toggle(id: id)) }
+    ///     }
+    /// }
+    /// ```
+    public static func produce<Action: Sendable>(
+        _ f: @escaping @Sendable (Environment) -> Effect<Action>
+    ) -> Self where Output == Effect<Action> {
+        Reader(f)
+    }
 }

--- a/Sources/SwiftRexTesting/TestStore.swift
+++ b/Sources/SwiftRexTesting/TestStore.swift
@@ -4,8 +4,8 @@ import Testing
 
 /// A controllable, synchronous store for testing ``Behavior`` values.
 ///
-/// `TestStore` runs the behavior's dispatch pipeline deterministically:
-/// - ``send(_:sourceLocation:assert:)`` applies phases 1 and 2 immediately (handle → mutate),
+/// `TestStore` drives the dispatch pipeline deterministically:
+/// - ``dispatch(_:sourceLocation:assert:)`` applies phases 1 and 2 immediately (handle → mutate),
 ///   validates the resulting state against an assertion closure, and captures any produced
 ///   ``Effect`` into ``pendingEffects`` without starting it.
 /// - ``runEffects()`` drives all pending effects and collects their output actions into
@@ -17,23 +17,22 @@ import Testing
 ///
 /// ## State assertions
 ///
-/// ``send(_:sourceLocation:assert:)`` requires a trailing closure that describes the expected
-/// state change. The closure receives an `inout` copy of the state before the action and you
-/// mutate it to reflect what you expect after the action runs. Pass `{ _ in }` when no state
-/// change is expected.
+/// Both ``dispatch(_:sourceLocation:assert:)`` and ``receive`` require a trailing closure that
+/// describes the expected state change. The closure receives an `inout` copy of the state
+/// *before* the action and you mutate it to reflect what you expect *after* the action runs.
+/// Pass `{ _ in }` when no state change is expected.
 ///
-/// ``receive`` closures also describe expected state. For actions with an associated value the
-/// closure receives both the extracted value and `inout State`, so you can use the actual value
-/// from the action when specifying what the state should become:
+/// For `receive`, actions with an associated value give you that value in the closure so you
+/// can use the actual payload from the action rather than duplicating it:
 ///
 /// ```swift
-/// // send: describe what state should look like after the action
-/// store.send(.setPage(3)) { $0.currentPage = 3 }
+/// // dispatch: describe the expected state change
+/// store.dispatch(.setPage(3)) { $0.currentPage = 3 }
 ///
-/// // receive with associated value: value comes from the action itself
+/// // receive with associated value — value is extracted from the action by the prism
 /// store.receive(AppAction.prism.didLoad) { items, state in
 ///     state.isLoading = false
-///     state.items = items     // items is the [Item] extracted by the prism
+///     state.items = items
 /// }
 ///
 /// // receive without associated value (Void prism)
@@ -42,24 +41,27 @@ import Testing
 ///
 /// ## Action matching via Prism
 ///
-/// `receive` validates the received action by applying a ``Prism``. If the prism's `preview`
-/// returns `nil` (action is a different case), a failure is recorded but the action is still
-/// dispatched so subsequent assertions remain meaningful.
+/// `receive` validates the received action by applying a ``Prism``. If `preview` returns `nil`
+/// (different action case), a failure is recorded but the action is still dispatched so
+/// subsequent assertions remain meaningful.
 ///
-/// This design avoids requiring `Action: Equatable` — actions are often algebraic types whose
+/// This avoids requiring `Action: Equatable` — actions are often algebraic types whose
 /// associated values are not `Equatable`, and requiring conformance just for testing is
 /// unreasonably restrictive.
 ///
 /// ## Exhaustive mode (default)
 ///
-/// In exhaustive mode (`exhaustive: true`) the store enforces a strict discipline:
+/// When `exhaustive: true` (the default), the store enforces two checks:
 ///
-/// - Calling ``send(_:sourceLocation:assert:)`` while ``receivedActions`` is non-empty records a
-///   test failure — process all received actions first.
-/// - When the `TestStore` is deallocated (end of the test function), any remaining
-///   ``pendingEffects`` or ``receivedActions`` also record failures.
+/// 1. **Ordering** — calling ``dispatch(_:sourceLocation:assert:)`` while ``receivedActions``
+///    is non-empty records a failure. You must process all received actions with `receive`
+///    before dispatching again.
+/// 2. **End-of-test** — when the `TestStore` is deallocated, any remaining ``pendingEffects``
+///    or ``receivedActions`` record failures. Every effect and every action the behavior
+///    produced must be accounted for.
 ///
-/// Pass `exhaustive: false` to opt out of ordering enforcement and end-of-test checks.
+/// Pass `exhaustive: false` to disable **both** checks — neither the ordering check on
+/// dispatch nor the end-of-test check at dealloc will fire.
 @MainActor
 public final class TestStore<Action: Sendable, State: Sendable & Equatable, Environment: Sendable> {
     /// The current state after all dispatched and received actions have been processed.
@@ -84,7 +86,8 @@ public final class TestStore<Action: Sendable, State: Sendable & Equatable, Envi
     // storage. These are written on @MainActor and only read in deinit.
     nonisolated(unsafe) private var _pendingCount: Int = 0
     nonisolated(unsafe) private var _receivedCount: Int = 0
-    nonisolated(unsafe) private let _exhaustive: Bool
+    // Bool is Sendable; nonisolated(unsafe) is only needed for the var counts above.
+    private let _exhaustive: Bool
 
     // MARK: - Init
 
@@ -94,8 +97,9 @@ public final class TestStore<Action: Sendable, State: Sendable & Equatable, Envi
     ///   - initial: The starting state.
     ///   - behavior: The behavior under test.
     ///   - environment: The environment injected into effects via `Reader`.
-    ///   - exhaustive: When `true` (default), enforces ordering and end-of-test checks.
-    ///     Pass `false` to disable all checks.
+    ///   - exhaustive: When `true` (default), enforces both the ordering check (no dispatch
+    ///     while received actions are pending) and the end-of-test check (no leftover effects
+    ///     or actions at dealloc). Pass `false` to disable both checks.
     public init(
         initial: State,
         behavior: Behavior<Action, State, Environment>,
@@ -132,7 +136,7 @@ public final class TestStore<Action: Sendable, State: Sendable & Equatable, Envi
     /// to produce the expected post-action state; a mismatch records a test failure.
     ///
     /// In exhaustive mode, a failure is also recorded when ``receivedActions`` is non-empty —
-    /// process them with `receive` first.
+    /// process them with `receive` first. In non-exhaustive mode this check is skipped.
     ///
     /// - Parameters:
     ///   - action: The action to dispatch.
@@ -141,7 +145,7 @@ public final class TestStore<Action: Sendable, State: Sendable & Equatable, Envi
     ///     Pass `{ _ in }` when no state change is expected.
     /// - Returns: `self` for chaining.
     @discardableResult
-    public func send(
+    public func dispatch(
         _ action: Action,
         sourceLocation: SourceLocation = #_sourceLocation,
         assert expectedStateChange: (inout State) -> Void
@@ -149,15 +153,15 @@ public final class TestStore<Action: Sendable, State: Sendable & Equatable, Envi
         if _exhaustive && _receivedCount > 0 {
             Issue.record(
                 """
-                send(\(action)) called with \(_receivedCount) unprocessed received action(s). \
+                dispatch(\(action)) called with \(_receivedCount) unprocessed received action(s). \
                 Call receive() for each before dispatching again.
                 """,
                 sourceLocation: sourceLocation
             )
         }
         let before = state
-        dispatch(DispatchedAction(action))
-        assertState(before: before, after: state, label: "send(\(action))", sourceLocation: sourceLocation, expectedChange: expectedStateChange)
+        run(DispatchedAction(action))
+        assertState(before: before, after: state, label: "dispatch(\(action))", sourceLocation: sourceLocation, expectedChange: expectedStateChange)
         return self
     }
 
@@ -198,8 +202,8 @@ public final class TestStore<Action: Sendable, State: Sendable & Equatable, Envi
     /// - Parameters:
     ///   - prism: A ``Prism`` whose `preview` must return non-nil for the expected action case.
     ///   - sourceLocation: Captured automatically; points failures to the call site.
-    ///   - assert: Receives the value extracted by `prism` and an `inout` copy of the pre-action
-    ///     state; mutate the state to produce the expected post-action state.
+    ///   - assert: Receives the value extracted by `prism` and an `inout` copy of the
+    ///     pre-action state; mutate the state to produce the expected post-action state.
     @discardableResult
     public func receive<Value>(
         _ prism: Prism<Action, Value>,
@@ -220,11 +224,11 @@ public final class TestStore<Action: Sendable, State: Sendable & Equatable, Envi
                 "Action case mismatch in receive() — prism did not match the dequeued action\nActual: \(action)",
                 sourceLocation: sourceLocation
             )
-            dispatch(DispatchedAction(action))
+            run(DispatchedAction(action))
             return action
         }
         let before = state
-        dispatch(DispatchedAction(action))
+        run(DispatchedAction(action))
         var expected = before
         expectedStateChange(value, &expected)
         if state != expected {
@@ -267,7 +271,7 @@ public final class TestStore<Action: Sendable, State: Sendable & Equatable, Envi
 
     // MARK: - Private
 
-    private func dispatch(_ dispatched: DispatchedAction<Action>) {
+    private func run(_ dispatched: DispatchedAction<Action>) {
         let stateAccess = StateAccess { [weak self] in self?.state }
         let consequence = behavior.handle(dispatched, stateAccess)
         consequence.mutation.runEndoMut(&state)
@@ -327,7 +331,7 @@ extension TestStore where Environment == Void {
     ///
     /// ```swift
     /// let store = TestStore(initial: CounterState(), reducer: counterReducer)
-    /// store.send(.increment) { $0.count += 1 }
+    /// store.dispatch(.increment) { $0.count += 1 }
     /// ```
     public convenience init(
         initial: State,

--- a/Sources/SwiftRexTesting/TestStore.swift
+++ b/Sources/SwiftRexTesting/TestStore.swift
@@ -1,3 +1,4 @@
+import CoreFP
 import SwiftRex
 import Testing
 
@@ -9,62 +10,70 @@ import Testing
 ///   ``Effect`` into ``pendingEffects`` without starting it.
 /// - ``runEffects()`` drives all pending effects and collects their output actions into
 ///   ``receivedActions``.
-/// - ``receive(_:sourceLocation:assert:)`` asserts the next received action equals an expected
-///   value, dispatches it through the behavior, validates the resulting state, and returns the
-///   action.
+/// - ``receive(_:sourceLocation:assert:)-9ofio`` (with associated value) or
+///   ``receive(_:sourceLocation:assert:)-6yjj4`` (without associated value) validates that
+///   the next received action matches a ``Prism``, dispatches it through the behavior, and
+///   validates the resulting state.
 ///
 /// ## State assertions
 ///
-/// Both ``send(_:sourceLocation:assert:)`` and ``receive(_:sourceLocation:assert:)`` require a
-/// trailing closure that describes the **expected** state change. The closure receives an `inout`
-/// copy of the state before the action and you mutate it to what you expect:
+/// ``send(_:sourceLocation:assert:)`` requires a trailing closure that describes the expected
+/// state change. The closure receives an `inout` copy of the state before the action and you
+/// mutate it to reflect what you expect after the action runs. Pass `{ _ in }` when no state
+/// change is expected.
+///
+/// ``receive`` closures also describe expected state. For actions with an associated value the
+/// closure receives both the extracted value and `inout State`, so you can use the actual value
+/// from the action when specifying what the state should become:
 ///
 /// ```swift
-/// store.send(.increment) { $0.count += 1 }
-/// store.send(.setUsername("Alice")) { $0.profile.username = "Alice" }
+/// // send: describe what state should look like after the action
+/// store.send(.setPage(3)) { $0.currentPage = 3 }
+///
+/// // receive with associated value: value comes from the action itself
+/// store.receive(AppAction.prism.didLoad) { items, state in
+///     state.isLoading = false
+///     state.items = items     // items is the [Item] extracted by the prism
+/// }
+///
+/// // receive without associated value (Void prism)
+/// store.receive(AppAction.prism.didReset) { $0 = .initial }
 /// ```
 ///
-/// If the actual state after the action does not equal the expected state produced by the closure,
-/// a test failure is recorded. Pass `{ _ in }` when an action is expected to produce no state
-/// change.
+/// ## Action matching via Prism
+///
+/// `receive` validates the received action by applying a ``Prism``. If the prism's `preview`
+/// returns `nil` (action is a different case), a failure is recorded but the action is still
+/// dispatched so subsequent assertions remain meaningful.
+///
+/// This design avoids requiring `Action: Equatable` — actions are often algebraic types whose
+/// associated values are not `Equatable`, and requiring conformance just for testing is
+/// unreasonably restrictive.
 ///
 /// ## Exhaustive mode (default)
 ///
 /// In exhaustive mode (`exhaustive: true`) the store enforces a strict discipline:
 ///
 /// - Calling ``send(_:sourceLocation:assert:)`` while ``receivedActions`` is non-empty records a
-///   test failure — process all received actions with ``receive(_:sourceLocation:assert:)`` before
-///   dispatching again.
+///   test failure — process all received actions first.
 /// - When the `TestStore` is deallocated (end of the test function), any remaining
 ///   ``pendingEffects`` or ``receivedActions`` also record failures.
 ///
 /// Pass `exhaustive: false` to opt out of ordering enforcement and end-of-test checks.
-///
-/// ```swift
-/// @Test func effectDispatches() async {
-///     let store = TestStore(initial: AppState(), behavior: appBehavior, environment: testEnv)
-///
-///     store.send(.load) { $0.isLoading = true }
-///
-///     await store.runEffects()
-///     store.receive(.didLoad(mockData)) { $0.isLoading = false; $0.data = mockData }
-/// }
-/// ```
 @MainActor
-public final class TestStore<Action: Sendable & Equatable, State: Sendable & Equatable, Environment: Sendable> {
+public final class TestStore<Action: Sendable, State: Sendable & Equatable, Environment: Sendable> {
     /// The current state after all dispatched and received actions have been processed.
     public private(set) var state: State
 
     /// Effects captured from dispatched or received actions that have not yet been run.
     ///
-    /// Each ``send(_:sourceLocation:assert:)`` or ``receive(sourceLocation:assert:)`` call
-    /// appends any produced ``Effect`` here. Call ``runEffects()`` to execute them and collect
-    /// their output.
+    /// Call ``runEffects()`` to execute them and collect their output into ``receivedActions``.
     public private(set) var pendingEffects: [Effect<Action>] = []
 
     /// Actions produced by effects that have not yet been dispatched through the behavior.
     ///
-    /// Call ``receive(sourceLocation:assert:)`` for each entry to propagate it through the
+    /// Call ``receive(_:sourceLocation:assert:)-9ofio`` or
+    /// ``receive(_:sourceLocation:assert:)-6yjj4`` for each entry to propagate it through the
     /// behavior, updating ``state`` and potentially adding new entries to ``pendingEffects``.
     public private(set) var receivedActions: [Action] = []
 
@@ -85,9 +94,8 @@ public final class TestStore<Action: Sendable & Equatable, State: Sendable & Equ
     ///   - initial: The starting state.
     ///   - behavior: The behavior under test.
     ///   - environment: The environment injected into effects via `Reader`.
-    ///   - exhaustive: When `true` (default), enforces ordering: all received actions must be
-    ///     processed before dispatching again, and all pending work must be exhausted by the time
-    ///     the store is released. Pass `false` to disable all checks.
+    ///   - exhaustive: When `true` (default), enforces ordering and end-of-test checks.
+    ///     Pass `false` to disable all checks.
     public init(
         initial: State,
         behavior: Behavior<Action, State, Environment>,
@@ -120,18 +128,17 @@ public final class TestStore<Action: Sendable & Equatable, State: Sendable & Equ
 
     /// Dispatches `action` through the behavior and validates the resulting state.
     ///
-    /// The `assert` closure receives an `inout` copy of the state **before** the action was
-    /// dispatched. Mutate it to produce the **expected** post-action state. If the actual state
-    /// does not equal the expected state, a test failure is recorded.
+    /// The `assert` closure receives an `inout` copy of the state **before** dispatch. Mutate it
+    /// to produce the expected post-action state; a mismatch records a test failure.
     ///
     /// In exhaustive mode, a failure is also recorded when ``receivedActions`` is non-empty —
-    /// call ``receive(sourceLocation:assert:)`` to process all received actions first.
+    /// process them with `receive` first.
     ///
     /// - Parameters:
     ///   - action: The action to dispatch.
     ///   - sourceLocation: Captured automatically; points failures to the call site.
-    ///   - assert: A closure that mutates the pre-action state to produce the expected
-    ///     post-action state. Pass `{ _ in }` when no state change is expected.
+    ///   - assert: Mutates the pre-action state to produce the expected post-action state.
+    ///     Pass `{ _ in }` when no state change is expected.
     /// - Returns: `self` for chaining.
     @discardableResult
     public func send(
@@ -156,11 +163,8 @@ public final class TestStore<Action: Sendable & Equatable, State: Sendable & Equ
 
     /// Executes all ``pendingEffects`` and appends their output actions to ``receivedActions``.
     ///
-    /// After this call, ``pendingEffects`` is empty. Use ``receive(sourceLocation:assert:)`` to
-    /// process each collected action through the behavior.
-    ///
-    /// Effects are run in order; components within each effect run sequentially. Each component
-    /// is driven to completion before the next one starts.
+    /// Effects run in order; components within each effect run sequentially, each driven to
+    /// completion before the next starts.
     public func runEffects() async {
         var toRun: [Effect<Action>] = []
         swap(&toRun, &pendingEffects)
@@ -174,57 +178,91 @@ public final class TestStore<Action: Sendable & Equatable, State: Sendable & Equ
         _receivedCount = receivedActions.count
     }
 
-    /// Dequeues the next action from ``receivedActions``, asserts it equals `expected`,
-    /// dispatches it through the behavior, and validates the resulting state.
+    /// Dequeues the next action from ``receivedActions``, validates it via `prism`, dispatches
+    /// it through the behavior, and validates the resulting state.
     ///
-    /// Both the **action** and the **state change** are validated:
-    /// - If the dequeued action does not equal `expected`, a failure is recorded and the action
-    ///   is still dispatched so subsequent assertions remain meaningful.
-    /// - The `assert` closure receives an `inout` copy of the state **before** dispatch. Mutate
-    ///   it to produce the expected post-action state; a mismatch records a failure.
-    ///
-    /// A failure is also recorded when ``receivedActions`` is empty — call ``runEffects()`` first
-    /// if you expect effect output.
+    /// The `assert` closure receives both the **value extracted by the prism** and an `inout`
+    /// copy of the state before dispatch — use the extracted value when specifying what the
+    /// state should become:
     ///
     /// ```swift
-    /// await store.runEffects()
-    /// store.receive(.didLoad(data)) { $0.isLoading = false; $0.items = data }
+    /// store.receive(AppAction.prism.didLoad) { items, state in
+    ///     state.isLoading = false
+    ///     state.items = items
+    /// }
     /// ```
     ///
+    /// If the prism does not match the dequeued action, an action-mismatch failure is recorded
+    /// and the action is still dispatched so subsequent assertions remain meaningful.
+    ///
     /// - Parameters:
-    ///   - expected: The action you expect to find at the front of ``receivedActions``.
+    ///   - prism: A ``Prism`` whose `preview` must return non-nil for the expected action case.
     ///   - sourceLocation: Captured automatically; points failures to the call site.
-    ///   - assert: Mutates the pre-action state to produce the expected post-action state.
-    ///     Pass `{ _ in }` when the action is expected to produce no state change.
+    ///   - assert: Receives the value extracted by `prism` and an `inout` copy of the pre-action
+    ///     state; mutate the state to produce the expected post-action state.
     @discardableResult
-    public func receive(
-        _ expected: Action,
+    public func receive<Value>(
+        _ prism: Prism<Action, Value>,
         sourceLocation: SourceLocation = #_sourceLocation,
-        assert expectedStateChange: (inout State) -> Void
+        assert expectedStateChange: (Value, inout State) -> Void
     ) -> Action? {
         guard !receivedActions.isEmpty else {
             Issue.record(
-                "receive(\(expected)) called but receivedActions is empty — call runEffects() first if you expect effect output",
+                "receive() called but receivedActions is empty — call runEffects() first if you expect effect output",
                 sourceLocation: sourceLocation
             )
             return nil
         }
         let action = receivedActions.removeFirst()
         _receivedCount = receivedActions.count
-        if action != expected {
+        guard let value = prism.preview(action) else {
+            Issue.record(
+                "Action case mismatch in receive() — prism did not match the dequeued action\nActual: \(action)",
+                sourceLocation: sourceLocation
+            )
+            dispatch(DispatchedAction(action))
+            return action
+        }
+        let before = state
+        dispatch(DispatchedAction(action))
+        var expected = before
+        expectedStateChange(value, &expected)
+        if state != expected {
             Issue.record(
                 """
-                Action mismatch in receive()
+                State mismatch after receive(\(action))
                 Expected: \(expected)
-                  Actual: \(action)
+                  Actual: \(state)
                 """,
                 sourceLocation: sourceLocation
             )
         }
-        let before = state
-        dispatch(DispatchedAction(action))
-        assertState(before: before, after: state, label: "receive(\(action))", sourceLocation: sourceLocation, expectedChange: expectedStateChange)
         return action
+    }
+
+    /// Dequeues the next action from ``receivedActions``, validates it via `prism` (no associated
+    /// value), dispatches it through the behavior, and validates the resulting state.
+    ///
+    /// Use this overload for action cases that carry no associated value:
+    ///
+    /// ```swift
+    /// store.receive(AppAction.prism.didReset) { $0 = .initial }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - prism: A ``Prism<Action, Void>`` matching an action case with no associated value.
+    ///   - sourceLocation: Captured automatically; points failures to the call site.
+    ///   - assert: Mutates the pre-action state to produce the expected post-action state.
+    ///     Pass `{ _ in }` when no state change is expected.
+    @discardableResult
+    public func receive(
+        _ prism: Prism<Action, Void>,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        assert expectedStateChange: (inout State) -> Void
+    ) -> Action? {
+        receive(prism, sourceLocation: sourceLocation) { (_, state: inout State) in
+            expectedStateChange(&state)
+        }
     }
 
     // MARK: - Private

--- a/Tests/SwiftRexTestingTests/TestStoreTests.swift
+++ b/Tests/SwiftRexTestingTests/TestStoreTests.swift
@@ -72,31 +72,31 @@ private let counterBehavior = Behavior<CounterAction, CounterState, Void> { acti
 struct TestStoreReducerTests {
     @Test func sendIncrement() {
         let store = TestStore(initial: CounterState(), reducer: counterReducer)
-        store.send(.increment) { $0.count = 1 }
+        store.dispatch(.increment) { $0.count = 1 }
     }
 
     @Test func sendDecrement() {
         let store = TestStore(initial: CounterState(), reducer: counterReducer)
-        store.send(.decrement) { $0.count = -1 }
+        store.dispatch(.decrement) { $0.count = -1 }
     }
 
     @Test func chainedSends() {
         let store = TestStore(initial: CounterState(), reducer: counterReducer)
         store
-            .send(.increment) { $0.count = 1 }
-            .send(.increment) { $0.count = 2 }
-            .send(.decrement) { $0.count = 1 }
+            .dispatch(.increment) { $0.count = 1 }
+            .dispatch(.increment) { $0.count = 2 }
+            .dispatch(.decrement) { $0.count = 1 }
     }
 
     @Test func setOverridesCount() {
         let store = TestStore(initial: CounterState(), reducer: counterReducer)
-        store.send(.increment) { $0.count = 1 }
-        store.send(.set(42)) { $0.count = 42 }
+        store.dispatch(.increment) { $0.count = 1 }
+        store.dispatch(.set(42)) { $0.count = 42 }
     }
 
     @Test func noPendingEffectsForPureReducer() {
         let store = TestStore(initial: CounterState(), reducer: counterReducer)
-        store.send(.increment) { $0.count = 1 }
+        store.dispatch(.increment) { $0.count = 1 }
         #expect(store.pendingEffects.isEmpty)
         #expect(store.receivedActions.isEmpty)
     }
@@ -104,7 +104,7 @@ struct TestStoreReducerTests {
     @Test func stateMismatchRecordsFailure() {
         let store = TestStore(initial: CounterState(), reducer: counterReducer, exhaustive: false)
         withKnownIssue("wrong expected value should record a mismatch failure") {
-            store.send(.increment) { $0.count = 99 }  // wrong — actual becomes 1
+            store.dispatch(.increment) { $0.count = 99 }  // wrong — actual becomes 1
         }
         #expect(store.state.count == 1)
     }
@@ -122,14 +122,14 @@ struct TestStoreEffectTests {
             environment: (),
             exhaustive: false
         )
-        store.send(.load) { $0.isLoading = true }
+        store.dispatch(.load) { $0.isLoading = true }
         #expect(!store.pendingEffects.isEmpty)
         #expect(store.receivedActions.isEmpty)
     }
 
     @Test func noEffectForNonMatchingAction() {
         let store = TestStore(initial: CounterState(), behavior: counterBehavior, environment: ())
-        store.send(.increment) { $0.count = 1 }
+        store.dispatch(.increment) { $0.count = 1 }
         #expect(store.pendingEffects.isEmpty)
     }
 
@@ -139,10 +139,10 @@ struct TestStoreEffectTests {
             behavior: counterBehavior,
             environment: ()
         )
-        store.send(.load) { $0.isLoading = true }
+        store.dispatch(.load) { $0.isLoading = true }
         await store.runEffects()
         withKnownIssue("must process received actions before dispatching again") {
-            store.send(.increment) { $0.isLoading = true; $0.count = 1 }
+            store.dispatch(.increment) { $0.isLoading = true; $0.count = 1 }
         }
         store.receive(CounterAction.Prisms.loaded) { value, state in
             state.isLoading = false
@@ -158,7 +158,7 @@ struct TestStoreEffectTests {
 struct TestStoreRunEffectsTests {
     @Test func runEffectsPopulatesReceivedActions() async {
         let store = TestStore(initial: CounterState(), behavior: counterBehavior, environment: ())
-        store.send(.load) { $0.isLoading = true }
+        store.dispatch(.load) { $0.isLoading = true }
         await store.runEffects()
         #expect(store.pendingEffects.isEmpty)
         store.receive(CounterAction.Prisms.loaded) { value, state in
@@ -169,7 +169,7 @@ struct TestStoreRunEffectsTests {
 
     @Test func receiveValidatesActionCaseAndExtractsValue() async {
         let store = TestStore(initial: CounterState(), behavior: counterBehavior, environment: ())
-        store.send(.load) { $0.isLoading = true }
+        store.dispatch(.load) { $0.isLoading = true }
         await store.runEffects()
         let action = store.receive(CounterAction.Prisms.loaded) { value, state in
             #expect(value == 99)
@@ -201,7 +201,7 @@ struct TestStoreRunEffectsTests {
             environment: (),
             exhaustive: false
         )
-        store.send(.load) { $0.isLoading = true }
+        store.dispatch(.load) { $0.isLoading = true }
         await store.runEffects()
         withKnownIssue("wrong prism should record an action-mismatch failure") {
             // Actual action is .loaded(99); prism expects .increment (Void prism)
@@ -220,7 +220,7 @@ struct TestStoreRunEffectsTests {
             }
         }
         let store = TestStore(initial: CounterState(), behavior: behavior, environment: ())
-        store.send(.load) { _ in }
+        store.dispatch(.load) { _ in }
         await store.runEffects()
         // Use the Void-prism overload — no value to extract, just (inout State) -> Void
         store.receive(CounterAction.Prisms.increment) { $0.count += 1 }
@@ -228,7 +228,7 @@ struct TestStoreRunEffectsTests {
 
     @Test func receiveEmptiesReceivedActions() async {
         let store = TestStore(initial: CounterState(), behavior: counterBehavior, environment: ())
-        store.send(.load) { $0.isLoading = true }
+        store.dispatch(.load) { $0.isLoading = true }
         await store.runEffects()
         store.receive(CounterAction.Prisms.loaded) { value, state in
             state.isLoading = false; state.count = value
@@ -252,7 +252,7 @@ struct TestStoreRunEffectsTests {
             }
         }
         let store = TestStore(initial: CounterState(), behavior: chainedBehavior, environment: ())
-        store.send(.load) { $0.isLoading = true }
+        store.dispatch(.load) { $0.isLoading = true }
 
         await store.runEffects()
         store.receive(CounterAction.Prisms.loaded) { value, state in
@@ -281,7 +281,7 @@ struct TestStoreRunEffectsTests {
             }
         }
         let store = TestStore(initial: CounterState(), behavior: behavior, environment: ())
-        store.send(.load) { _ in }
+        store.dispatch(.load) { _ in }
         await store.runEffects()
         #expect(store.receivedActions.count == 3)
         store.receive(CounterAction.Prisms.set) { value, state in state.count = value }
@@ -291,7 +291,7 @@ struct TestStoreRunEffectsTests {
 
     @Test func runEffectsOnEmptyIsNoop() async {
         let store = TestStore(initial: CounterState(), reducer: counterReducer)
-        store.send(.increment) { $0.count = 1 }
+        store.dispatch(.increment) { $0.count = 1 }
         await store.runEffects()
         #expect(store.receivedActions.isEmpty)
     }
@@ -304,12 +304,12 @@ struct TestStoreRunEffectsTests {
 struct TestStoreInitTests {
     @Test func reducerConvenienceInit() {
         let store = TestStore(initial: CounterState(), reducer: counterReducer)
-        store.send(.set(7)) { $0.count = 7 }
+        store.dispatch(.set(7)) { $0.count = 7 }
     }
 
     @Test func voidBehaviorConvenienceInit() {
         let store = TestStore(initial: CounterState(), behavior: counterBehavior)
-        store.send(.set(7)) { $0.count = 7 }
+        store.dispatch(.set(7)) { $0.count = 7 }
     }
 
     @Test func fullBehaviorInit() {
@@ -318,7 +318,7 @@ struct TestStoreInitTests {
             behavior: counterBehavior,
             environment: ()
         )
-        store.send(.set(7)) { $0.count = 7 }
+        store.dispatch(.set(7)) { $0.count = 7 }
     }
 
     @Test func nonExhaustiveSkipsDeinitCheck() {
@@ -328,7 +328,7 @@ struct TestStoreInitTests {
             environment: (),
             exhaustive: false
         )
-        store.send(.load) { $0.isLoading = true }
+        store.dispatch(.load) { $0.isLoading = true }
         // Pending effect intentionally not drained — non-exhaustive: no deinit failure
     }
 }

--- a/Tests/SwiftRexTestingTests/TestStoreTests.swift
+++ b/Tests/SwiftRexTestingTests/TestStoreTests.swift
@@ -1,15 +1,42 @@
+import CoreFP
 import SwiftRex
 import SwiftRexTesting
 import Testing
 
 // MARK: - Fixtures
 
-private enum CounterAction: Equatable, Sendable {
+private enum CounterAction: Sendable {
     case increment
     case decrement
     case set(Int)
     case load
     case loaded(Int)
+}
+
+// Prisms for CounterAction — used in receive() to validate action case + extract value
+extension CounterAction {
+    enum Prisms {
+        static let increment = prism(
+            preview: { if case .increment = $0 { return () } else { return nil } },
+            review: { _ in CounterAction.increment }
+        )
+        static let decrement = prism(
+            preview: { if case .decrement = $0 { return () } else { return nil } },
+            review: { _ in CounterAction.decrement }
+        )
+        static let set = prism(
+            preview: { if case .set(let v) = $0 { return v } else { return nil } },
+            review: CounterAction.set
+        )
+        static let load = prism(
+            preview: { if case .load = $0 { return () } else { return nil } },
+            review: { _ in CounterAction.load }
+        )
+        static let loaded = prism(
+            preview: { if case .loaded(let v) = $0 { return v } else { return nil } },
+            review: CounterAction.loaded
+        )
+    }
 }
 
 private struct CounterState: Equatable, Sendable {
@@ -75,7 +102,6 @@ struct TestStoreReducerTests {
     }
 
     @Test func stateMismatchRecordsFailure() {
-        // non-exhaustive so deinit doesn't add noise
         let store = TestStore(initial: CounterState(), reducer: counterReducer, exhaustive: false)
         withKnownIssue("wrong expected value should record a mismatch failure") {
             store.send(.increment) { $0.count = 99 }  // wrong — actual becomes 1
@@ -90,7 +116,6 @@ struct TestStoreReducerTests {
 @MainActor
 struct TestStoreEffectTests {
     @Test func effectCapturedAsPending() {
-        // non-exhaustive so the un-drained effect doesn't fail at deinit
         let store = TestStore(
             initial: CounterState(),
             behavior: counterBehavior,
@@ -116,12 +141,13 @@ struct TestStoreEffectTests {
         )
         store.send(.load) { $0.isLoading = true }
         await store.runEffects()
-        // receivedActions = [.loaded(99)]; calling send now should record a failure
         withKnownIssue("must process received actions before dispatching again") {
             store.send(.increment) { $0.isLoading = true; $0.count = 1 }
         }
-        // process the pending received action so deinit is clean
-        store.receive(.loaded(99)) { $0.isLoading = false; $0.count = 99 }
+        store.receive(CounterAction.Prisms.loaded) { value, state in
+            state.isLoading = false
+            state.count = value
+        }
     }
 }
 
@@ -135,16 +161,25 @@ struct TestStoreRunEffectsTests {
         store.send(.load) { $0.isLoading = true }
         await store.runEffects()
         #expect(store.pendingEffects.isEmpty)
-        #expect(store.receivedActions == [.loaded(99)])
-        store.receive(.loaded(99)) { $0.isLoading = false; $0.count = 99 }
+        store.receive(CounterAction.Prisms.loaded) { value, state in
+            state.isLoading = false
+            state.count = value  // value == 99, extracted from .loaded(99)
+        }
     }
 
-    @Test func receiveProcessesActionThroughBehavior() async {
+    @Test func receiveValidatesActionCaseAndExtractsValue() async {
         let store = TestStore(initial: CounterState(), behavior: counterBehavior, environment: ())
         store.send(.load) { $0.isLoading = true }
         await store.runEffects()
-        let action = store.receive(.loaded(99)) { $0.isLoading = false; $0.count = 99 }
-        #expect(action == .loaded(99))
+        let action = store.receive(CounterAction.Prisms.loaded) { value, state in
+            #expect(value == 99)
+            state.isLoading = false
+            state.count = value
+        }
+        #expect(store.state.count == 99)
+        #expect(!store.state.isLoading)
+        // Returned action is the dequeued one (for inspection if needed)
+        if case .loaded(let v) = action { #expect(v == 99) }
     }
 
     @Test func receiveWhenEmptyRecordsFailure() {
@@ -155,16 +190,49 @@ struct TestStoreRunEffectsTests {
             exhaustive: false
         )
         withKnownIssue("receive() on empty receivedActions should record a failure") {
-            let result = store.receive(.loaded(0)) { _ in }
-            #expect(result == nil)
+            store.receive(CounterAction.Prisms.loaded) { _, _ in }
         }
+    }
+
+    @Test func receiveActionMismatchRecordsFailure() async {
+        let store = TestStore(
+            initial: CounterState(),
+            behavior: counterBehavior,
+            environment: (),
+            exhaustive: false
+        )
+        store.send(.load) { $0.isLoading = true }
+        await store.runEffects()
+        withKnownIssue("wrong prism should record an action-mismatch failure") {
+            // Actual action is .loaded(99); prism expects .increment (Void prism)
+            store.receive(CounterAction.Prisms.increment) { _ in }
+        }
+    }
+
+    @Test func receiveVoidPrism() async {
+        // .load produces .increment (a case with no associated value) — exercises the Void overload
+        let behavior = Behavior<CounterAction, CounterState, Void> { action, _ in
+            switch action.action {
+            case .load:
+                return .produce { _ in Effect.just(.increment) }
+            default:
+                return .reduce { state in counterReducer.reduce(action.action).runEndoMut(&state) }
+            }
+        }
+        let store = TestStore(initial: CounterState(), behavior: behavior, environment: ())
+        store.send(.load) { _ in }
+        await store.runEffects()
+        // Use the Void-prism overload — no value to extract, just (inout State) -> Void
+        store.receive(CounterAction.Prisms.increment) { $0.count += 1 }
     }
 
     @Test func receiveEmptiesReceivedActions() async {
         let store = TestStore(initial: CounterState(), behavior: counterBehavior, environment: ())
         store.send(.load) { $0.isLoading = true }
         await store.runEffects()
-        store.receive(.loaded(99)) { $0.isLoading = false; $0.count = 99 }
+        store.receive(CounterAction.Prisms.loaded) { value, state in
+            state.isLoading = false; state.count = value
+        }
         #expect(store.receivedActions.isEmpty)
     }
 
@@ -187,11 +255,13 @@ struct TestStoreRunEffectsTests {
         store.send(.load) { $0.isLoading = true }
 
         await store.runEffects()
-        store.receive(.loaded(5)) { $0.isLoading = false; $0.count = 5 }
+        store.receive(CounterAction.Prisms.loaded) { value, state in
+            state.isLoading = false; state.count = value
+        }
         #expect(!store.pendingEffects.isEmpty)
 
         await store.runEffects()
-        store.receive(.set(100)) { $0.count = 100 }
+        store.receive(CounterAction.Prisms.set) { value, state in state.count = value }
         #expect(store.pendingEffects.isEmpty)
         #expect(store.receivedActions.isEmpty)
     }
@@ -204,36 +274,19 @@ struct TestStoreRunEffectsTests {
             ),
             Effect<CounterAction>.just(.set(3))
         )
-        // Behavior handles .load (effect) + all others via reducer
         let behavior = Behavior<CounterAction, CounterState, Void> { action, _ in
             switch action.action {
-            case .load:
-                return .produce { _ in combined }
-            default:
-                return .reduce { state in counterReducer.reduce(action.action).runEndoMut(&state) }
+            case .load:   return .produce { _ in combined }
+            default:      return .reduce { state in counterReducer.reduce(action.action).runEndoMut(&state) }
             }
         }
         let store = TestStore(initial: CounterState(), behavior: behavior, environment: ())
-        store.send(.load) { _ in }  // .load produces no state change in this behavior
+        store.send(.load) { _ in }
         await store.runEffects()
         #expect(store.receivedActions.count == 3)
-        store.receive(.set(1)) { $0.count = 1 }
-        store.receive(.set(2)) { $0.count = 2 }
-        store.receive(.set(3)) { $0.count = 3 }
-    }
-
-    @Test func receiveActionMismatchRecordsFailure() async {
-        let store = TestStore(
-            initial: CounterState(),
-            behavior: counterBehavior,
-            environment: (),
-            exhaustive: false
-        )
-        store.send(.load) { $0.isLoading = true }
-        await store.runEffects()
-        withKnownIssue("wrong expected action should record a mismatch failure") {
-            store.receive(.increment) { $0.isLoading = false; $0.count = 99 }
-        }
+        store.receive(CounterAction.Prisms.set) { value, state in state.count = value }
+        store.receive(CounterAction.Prisms.set) { value, state in state.count = value }
+        store.receive(CounterAction.Prisms.set) { value, state in state.count = value }
     }
 
     @Test func runEffectsOnEmptyIsNoop() async {
@@ -276,6 +329,6 @@ struct TestStoreInitTests {
             exhaustive: false
         )
         store.send(.load) { $0.isLoading = true }
-        // Pending effect intentionally not drained — non-exhaustive mode means no deinit failure
+        // Pending effect intentionally not drained — non-exhaustive: no deinit failure
     }
 }


### PR DESCRIPTION
## Summary

- Removes `Action: Equatable` constraint from `TestStore` — algebraic action types often have associated values that aren't `Equatable`, making that constraint unreasonably restrictive
- `receive()` now takes a `Prism<Action, Value>` to validate the action case structurally
- Two overloads: one that passes the extracted `Value` to the state assertion closure (so you can use the actual payload when describing expected state), and one for `Void` cases (no associated value)
- If the prism doesn't match the dequeued action, a failure is recorded and the action is still dispatched so subsequent assertions remain meaningful
- `CoreFP` added as a direct dependency of `SwiftRexTesting` and `SwiftRexTestingTests`

## Example

```swift
// With associated value — value extracted by prism flows into state assertion
store.receive(AppAction.prism.didLoad) { items, state in
    state.isLoading = false
    state.items = items          // `items` comes from the action, not hardcoded
}

// Without associated value (Void prism)
store.receive(AppAction.prism.didReset) { $0 = .initial }
```

## Test plan

- [ ] `swift test --filter SwiftRexTestingTests` passes (22 tests)
- [ ] `mint run swiftlint lint --strict` passes (0 violations)
- [ ] Full `swift test` passes (283 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)