### PR TITLE
Docs: use combined doccarchive so /SwiftRex/ resolves

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,7 @@ jobs:
             --target SwiftRexRxSwift \
             --target SwiftRexReactiveSwift \
             --target SwiftRexSwiftUI \
+            --enable-experimental-combined-documentation \
             --output-path .docs \
             --transform-for-static-hosting \
             --hosting-base-path SwiftRex

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,16 @@ jobs:
             --transform-for-static-hosting \
             --hosting-base-path SwiftRex
 
+      - name: Redirect site root to /documentation/
+        run: |
+          cat > .docs/index.html <<'EOF'
+          <!doctype html>
+          <meta http-equiv="refresh" content="0; url=./documentation/">
+          <link rel="canonical" href="./documentation/">
+          <title>SwiftRex — Documentation</title>
+          <a href="./documentation/">Redirecting to documentation…</a>
+          EOF
+
       - name: Configure Pages
         uses: actions/configure-pages@v4
 


### PR DESCRIPTION
## Summary

Pass `--enable-experimental-combined-documentation` to the docc plugin so all targets are merged into a single archive whose contents sit at the artifact root.

## Why

Without this flag, each `--target` produces its own `<Target>.doccarchive/` directory and the Pages site root 404s — only `/<base>/<Target>.doccarchive/documentation/<target>/` paths resolve. With the flag, generation produces a flat layout (`index.html` + `documentation/<module>/...` at the root), so `/SwiftRex/` serves the docs hub.

## Test plan

- [x] Local verification on the equivalent FP setup confirmed the flat-artifact layout.
- [ ] After merge + next `v*` tag: `https://swiftrex.github.io/SwiftRex/` (or the configured custom domain) returns 200 and lists all modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)