### PR TITLE
Lint: drop column-aligned switch cases in CounterAction.Cases

### DIFF
--- a/Tests/SwiftRexTests/TestStoreTests.swift
+++ b/Tests/SwiftRexTests/TestStoreTests.swift
@@ -60,10 +60,10 @@ extension CounterAction {
             switch (self, value) {
             case (.increment, .increment): true
             case (.decrement, .decrement): true
-            case (.set,       .set):       true
-            case (.load,      .load):      true
-            case (.loaded,    .loaded):    true
-            default:                       false
+            case (.set, .set): true
+            case (.load, .load): true
+            case (.loaded, .loaded): true
+            default: false
             }
         }
     }


### PR DESCRIPTION
## Summary

- Fixes the SwiftLint failure on `main` after `bb5b6f6e` (`comma` + `double_space` violations on `Tests/SwiftRexTests/TestStoreTests.swift:63-66`).
- The new `CounterAction.Cases.matches(_:)` switch had column-aligned `case` arms — the repo lint config forbids that.

## Test plan

- [ ] CI Lint job goes green
- [ ] CI Build & Test job still passes (logic unchanged — only whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)