### PR TITLE
Store: Void-env behavior init + dispatch reentrance diagnostics

### DIFF
--- a/Sources/SwiftRex/Store/Store.swift
+++ b/Sources/SwiftRex/Store/Store.swift
@@ -180,6 +180,24 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
         self.init(initial: state, behavior: reducer.asBehavior(), environment: ())
     }
 
+    /// Creates a `Store` from a ``Behavior`` when the environment is `Void`.
+    ///
+    /// Saves the `environment: ()` boilerplate for behaviors that need no dependencies:
+    ///
+    /// ```swift
+    /// let store = Store(initial: AppState.initial, behavior: appBehavior)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - state: The initial state value.
+    ///   - behavior: The single ``Behavior`` that handles all dispatched actions.
+    public convenience init(
+        initial state: State,
+        behavior: Behavior<Action, State, Environment>
+    ) where Environment == Void {
+        self.init(initial: state, behavior: behavior, environment: ())
+    }
+
     /// Creates a `Store` by composing a ``Reducer`` and a ``Middleware`` internally.
     ///
     /// Equivalent to calling `Behavior(reducer:middleware:)` then using the primary init.
@@ -263,7 +281,20 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
         guard !isProcessing else { return }
         isProcessing = true
         defer { isProcessing = false }
+        var drained = 0
         while !queue.isEmpty {
+            drained += 1
+            if drained > StoreHooks.reentranceThreshold {
+                let next = queue.first
+                StoreHooks.onReentranceDetected(StoreReentranceInfo(
+                    drainedCount: drained,
+                    threshold: StoreHooks.reentranceThreshold,
+                    source: next?.dispatcher,
+                    actionDescription: next.map { String(describing: $0.action) }
+                ))
+                queue.removeAll()   // drop the runaway so the app can't hang
+                break
+            }
             runPhases(queue.removeFirst())
         }
     }

--- a/Sources/SwiftRex/Store/StoreHooks.swift
+++ b/Sources/SwiftRex/Store/StoreHooks.swift
@@ -1,0 +1,41 @@
+/// Diagnostic passed to ``StoreHooks/onReentranceDetected`` when a single dispatch cycle drains
+/// more than ``StoreHooks/reentranceThreshold`` actions — the signature of a runaway re-dispatch
+/// loop (e.g. a `willChange`/`didChange` observer that dispatches on every change).
+public struct StoreReentranceInfo {
+    /// How many actions the drain processed before tripping the threshold.
+    public let drainedCount: Int
+    /// The configured threshold that was exceeded.
+    public let threshold: Int
+    /// The call-site provenance of the next (un-processed) action when the trip happened.
+    public let source: ActionSource?
+    /// A textual description of that action — the hook is non-generic, so the typed action can't
+    /// be carried directly.
+    public let actionDescription: String?
+}
+
+/// Global, configurable hooks for ``Store`` diagnostics — modelled on RxSwift's `Hooks`.
+///
+/// `Store` is generic, so a true *global* static can't live on it (`Store<…>.member` is
+/// per-specialisation); these live on a non-generic namespace instead. Configure them once at
+/// startup — they are `@MainActor`, matching the Store's dispatch isolation.
+public enum StoreHooks {
+    /// Maximum number of actions a single synchronous dispatch cycle may drain before
+    /// ``onReentranceDetected`` fires and the runaway queue is dropped. Default `1000`.
+    ///
+    /// Synchronous re-dispatch is rare — effects hop asynchronously — so only a genuine
+    /// re-dispatch loop ever reaches this.
+    @MainActor public static var reentranceThreshold: Int = 1_000
+
+    /// Invoked when a dispatch cycle exceeds ``reentranceThreshold``. The default **traps in
+    /// DEBUG** (`assertionFailure`) and is a no-op in release; either way the `Store` drops the
+    /// runaway queue afterwards so the app can't hang. Replace it to log, record telemetry, etc.
+    @MainActor public static var onReentranceDetected: @MainActor (StoreReentranceInfo) -> Void = { info in
+        #if DEBUG
+        assertionFailure(
+            "SwiftRex: dispatch reentrance — drained \(info.drainedCount) actions in one cycle "
+                + "(threshold \(info.threshold)). Likely an observer re-dispatching in a loop. "
+                + "Next action: \(info.actionDescription ?? "?") from \(info.source.map(String.init(describing:)) ?? "?")."
+        )
+        #endif
+    }
+}

--- a/Tests/SwiftRexTests/StoreTests/StoreHooksTests.swift
+++ b/Tests/SwiftRexTests/StoreTests/StoreHooksTests.swift
@@ -1,0 +1,38 @@
+@testable import SwiftRex
+import Testing
+
+@Suite("Store — Void init & reentrance diagnostics")
+@MainActor
+struct StoreHooksTests {
+    @Test func voidEnvironmentBehaviorConvenienceInit() {
+        // The new `Store(initial:behavior:)` overload defaults `environment` to `()`.
+        let store = Store(initial: 5, behavior: Reducer<Int, Int>.reduce { action, state in state += action }.asBehavior())
+        store.dispatch(3)
+        #expect(store.state == 8)
+    }
+
+    @Test func reentranceCycleFiresHookAndDropsQueue() {
+        let savedThreshold = StoreHooks.reentranceThreshold
+        let savedHandler = StoreHooks.onReentranceDetected
+        defer {
+            StoreHooks.reentranceThreshold = savedThreshold
+            StoreHooks.onReentranceDetected = savedHandler
+        }
+
+        var captured: StoreReentranceInfo?
+        StoreHooks.reentranceThreshold = 10
+        StoreHooks.onReentranceDetected = { captured = $0 }   // capture instead of trapping
+
+        let store = Store(initial: 0, reducer: Reducer<Int, Int>.reduce { _, state in state += 1 })
+        // A didChange observer that re-dispatches on every mutation → a runaway loop.
+        let token = store.observe(willChange: {}, didChange: { [weak store] in store?.dispatch(1) })
+
+        store.dispatch(1)   // kicks off the cycle; the diagnostic must stop it (no hang)
+
+        #expect(captured != nil)
+        #expect(captured?.drainedCount == 11)        // trips on the 11th drain (threshold 10)
+        #expect(captured?.threshold == 10)
+        #expect(store.state == 10)                   // 10 mutations ran before the queue was dropped
+        _ = token
+    }
+}


### PR DESCRIPTION
## What
Roadmap item 20 — two small `Store` additions:
1. A `Store(initial:behavior:)` convenience for `Environment == Void`.
2. Runaway dispatch-cycle (reentrance) detection with a configurable global hook.

## Why
- The Void overload removes the `environment: ()` boilerplate for dependency-free behaviors (the reducer-only init already had this; the behavior init didn't).
- A `willChange`/`didChange` observer that re-dispatches on every change can spin the dispatch drain forever and hang the app with no signal. This catches it.

## Changes
- `Store.swift` — `Store(initial:behavior:) where Environment == Void`; the drain loop now counts actions per synchronous cycle and, past the threshold, invokes the hook and drops the runaway queue.
- `StoreHooks.swift` (new) — a non-generic namespace (modelled on RxSwift's `Hooks`, since a true global static can't live on the generic `Store`):
  - `@MainActor reentranceThreshold` (default `1_000`),
  - `@MainActor onReentranceDetected` — default **traps in DEBUG** (`assertionFailure`), no-op in release; the Store drops the queue afterwards either way.
  - `StoreReentranceInfo` — drained count, threshold, action source, action description.
- Tests — Void init + a reentrance test that drives an observer re-dispatch loop and asserts the hook fires and the queue is dropped (no hang).

374 tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)