### PR TITLE
feat(Behavior/Middleware): liftCollection with per-element effect scoping

### DIFF
--- a/Sources/SwiftRex/Behavior/Behavior+LiftCollection.swift
+++ b/Sources/SwiftRex/Behavior/Behavior+LiftCollection.swift
@@ -1,0 +1,157 @@
+import CoreFP
+import DataStructure
+
+// MARK: - liftCollection (primitive — AffineTraversal)
+//
+// Lifts a per-element `Behavior` into one that operates on a whole collection living inside a
+// global state. Unlike ``Reducer/liftCollection(action:stateContainer:)-``, a `Behavior` also
+// carries effects, so the primitive needs two extra pieces beyond the state traversal:
+//
+//   • `embed` — re-wraps an action emitted by an element's effect back into the global action
+//     type, so it can re-enter the ``Store`` addressed at the same element.
+//   • the element `id` — used to scope each element's effect-scheduling ids (see below).
+//
+// ## Per-element effect-scheduling isolation
+//
+// Every lifted element shares the same `Behavior`, so two elements would otherwise collide on
+// any ``EffectScheduling`` id (`.debounce(id: .fetch)` from element A would cancel element B's).
+// `liftCollection` rewrites each element's scheduling ids to `ElementScopedID(element: id, …)`,
+// so element A's `.fetch` is independent of element B's `.fetch`.
+//
+// The user keeps owning the *inner* id: if two different features both use a `"fetch"` string,
+// that cross-feature collision is theirs to prevent (use distinct id enums), exactly as for
+// un-lifted effects. The scope only adds the element axis.
+
+extension Behavior {
+    /// Primitive — closure-driven extraction plus a `WritableKeyPath` state container.
+    ///
+    /// - Parameters:
+    ///   - action: Resolves a global action into the local `Action`, an `AffineTraversal`
+    ///     selecting the target element inside its container, and the element `id`. Returns
+    ///     `nil` for global actions that don't address an element (the behavior is a no-op).
+    ///   - embed: Re-wraps an action produced by the element's effect into the global action
+    ///     type, addressed at `id`.
+    ///   - stateContainer: A `WritableKeyPath` from the global state to the element container.
+    /// - Returns: A `Behavior<GA, GS, Environment>` operating on the whole collection.
+    public func liftCollection<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> (action: Action, element: AffineTraversal<Container, State>, id: ID)?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        stateContainer: WritableKeyPath<GS, Container>
+    ) -> Behavior<GA, GS, Environment> {
+        liftCollection(action: action, embed: embed, stateContainer: lens(stateContainer))
+    }
+
+    /// Primitive — closure-driven extraction plus a `Lens` state container (for composed or
+    /// `let`-property containers).
+    public func liftCollection<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> (action: Action, element: AffineTraversal<Container, State>, id: ID)?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        stateContainer: Lens<GS, Container>
+    ) -> Behavior<GA, GS, Environment> {
+        Behavior<GA, GS, Environment> { globalAction, context in
+            guard let resolved = action(globalAction) else { return .doNothing }
+            let traversal = stateContainer.compose(resolved.element)
+            let element = AnyHashableSendable(resolved.id)
+            let c = self.handle(resolved.action, context.compactMap(traversal.preview))
+            return Consequence(
+                mutation: c.mutation.map { traversal.lift($0) },
+                effect: c.effect
+                    .map { (eff: Effect<Action>) in
+                        eff.map { embed($0, resolved.id) }.scopedToElement(element)
+                    }
+                    .contramapEnvironment { $0.compactMap(traversal.preview) }
+            )
+        }
+    }
+}
+
+// MARK: - liftCollection (Identifiable element)
+
+extension Behavior where State: Identifiable {
+    /// Lifts to a mutable collection, locating the element by its `Identifiable.id`.
+    /// Action extraction and re-embedding go through a single `Prism` into the `ElementAction`
+    /// case of the global action. State container via `WritableKeyPath`.
+    public func liftCollection<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable>(
+        action prism: Prism<GA, ElementAction<State.ID, Action>>,
+        stateCollection: WritableKeyPath<GS, C>
+    ) -> Behavior<GA, GS, Environment> where C.Element == State, C.Index: Sendable, State.ID: Sendable {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: C.ix(id: $0.id), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateCollection
+        )
+    }
+
+    /// Lifts to a mutable collection, locating the element by its `Identifiable.id`.
+    /// State container via `Lens`.
+    public func liftCollection<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable>(
+        action prism: Prism<GA, ElementAction<State.ID, Action>>,
+        stateCollection: Lens<GS, C>
+    ) -> Behavior<GA, GS, Environment> where C.Element == State, C.Index: Sendable, State.ID: Sendable {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: C.ix(id: $0.id), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateCollection
+        )
+    }
+}
+
+// MARK: - liftCollection (custom Hashable identifier)
+
+extension Behavior {
+    /// Lifts to a mutable collection, locating the element by a custom `Hashable` field extracted
+    /// by `identifier`. State container via `WritableKeyPath`.
+    public func liftCollection<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable, ID: Hashable & Sendable>(
+        action prism: Prism<GA, ElementAction<ID, Action>>,
+        stateCollection: WritableKeyPath<GS, C>,
+        identifier: @escaping @Sendable (State) -> ID
+    ) -> Behavior<GA, GS, Environment> where C.Element == State, C.Element: Sendable, C.Index: Sendable {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: C.ix(id: $0.id, by: identifier), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateCollection
+        )
+    }
+
+    /// Lifts to a mutable collection, locating the element by a custom `Hashable` field.
+    /// State container via `Lens`.
+    public func liftCollection<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable, ID: Hashable & Sendable>(
+        action prism: Prism<GA, ElementAction<ID, Action>>,
+        stateCollection: Lens<GS, C>,
+        identifier: @escaping @Sendable (State) -> ID
+    ) -> Behavior<GA, GS, Environment> where C.Element == State, C.Element: Sendable, C.Index: Sendable {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: C.ix(id: $0.id, by: identifier), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateCollection
+        )
+    }
+}
+
+// MARK: - liftCollection (Dictionary key-based)
+
+extension Behavior {
+    /// Lifts to a `Dictionary`, locating the entry by its key. State container via `WritableKeyPath`.
+    public func liftCollection<GA: Sendable, GS: Sendable, Key: Hashable & Sendable>(
+        action prism: Prism<GA, ElementAction<Key, Action>>,
+        stateDictionary: WritableKeyPath<GS, [Key: State]>
+    ) -> Behavior<GA, GS, Environment> {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: [Key: State].ix(key: $0.id), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateDictionary
+        )
+    }
+
+    /// Lifts to a `Dictionary`, locating the entry by its key. State container via `Lens`.
+    public func liftCollection<GA: Sendable, GS: Sendable, Key: Hashable & Sendable>(
+        action prism: Prism<GA, ElementAction<Key, Action>>,
+        stateDictionary: Lens<GS, [Key: State]>
+    ) -> Behavior<GA, GS, Environment> {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: [Key: State].ix(key: $0.id), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateDictionary
+        )
+    }
+}

--- a/Sources/SwiftRex/Effect/Effect+ElementScope.swift
+++ b/Sources/SwiftRex/Effect/Effect+ElementScope.swift
@@ -1,0 +1,38 @@
+/// The scheduling id of a collection-lifted element's effect: the element's id paired with the
+/// user's own effect id.
+///
+/// When a `Behavior` is lifted into a collection, each element's effect-scheduling id is wrapped
+/// in this composite so element A's `.debounce(id: .fetch)` is independent of element B's — while
+/// the user keeps owning the inner id. Cross-collection / cross-feature collisions remain the
+/// user's responsibility (use distinct id enums), exactly as for un-lifted effects.
+package struct ElementScopedID: Hashable, Sendable {
+    package let element: AnyHashableSendable
+    package let inner: AnyHashableSendable
+}
+
+extension EffectScheduling {
+    /// Re-tags the id-carrying policies with `ElementScopedID(element:, inner: existing)`.
+    /// `.immediately` (which carries no id) is returned unchanged.
+    package func scopedToElement(_ element: AnyHashableSendable) -> EffectScheduling {
+        switch self {
+        case .immediately:                    .immediately
+        case .replacing(let id):              .replacing(id: scoped(element, id))
+        case let .debounce(id, delay):        .debounce(id: scoped(element, id), delay: delay)
+        case let .throttle(id, interval):     .throttle(id: scoped(element, id), interval: interval)
+        case .cancelInFlight(let id):         .cancelInFlight(id: scoped(element, id))
+        }
+    }
+}
+
+private func scoped(_ element: AnyHashableSendable, _ inner: AnyHashableSendable) -> AnyHashableSendable {
+    AnyHashableSendable(ElementScopedID(element: element, inner: inner))
+}
+
+extension Effect {
+    /// Scopes every component's scheduling id to `element` (see ``ElementScopedID``).
+    package func scopedToElement(_ element: AnyHashableSendable) -> Effect {
+        Effect(components: components.map {
+            Component(subscribe: $0.subscribe, scheduling: $0.scheduling.scopedToElement(element))
+        })
+    }
+}

--- a/Sources/SwiftRex/Middleware/Middleware+LiftCollection.swift
+++ b/Sources/SwiftRex/Middleware/Middleware+LiftCollection.swift
@@ -1,0 +1,152 @@
+import CoreFP
+import DataStructure
+
+// MARK: - liftCollection (primitive — AffineTraversal)
+//
+// Lifts a per-element `Middleware` into one that operates on a whole collection living inside a
+// global state. `Middleware` is read-only on state, so — unlike ``Behavior/liftCollection`` —
+// there is no mutation to lift; only the effect side is transformed. Two extra pieces beyond the
+// state traversal are still needed:
+//
+//   • `embed` — re-wraps an action emitted by an element's effect back into the global action
+//     type, so it can re-enter the ``Store`` addressed at the same element.
+//   • the element `id` — used to scope each element's effect-scheduling ids.
+//
+// ## Per-element effect-scheduling isolation
+//
+// Every lifted element shares the same `Middleware`, so two elements would otherwise collide on
+// any ``EffectScheduling`` id. `liftCollection` rewrites each element's scheduling ids to
+// `ElementScopedID(element: id, …)`, so element A's `.debounce(id: .fetch)` is independent of
+// element B's. The user keeps owning the inner id; cross-feature collisions remain theirs to
+// prevent (use distinct id enums), exactly as for un-lifted effects.
+
+extension Middleware {
+    /// Primitive — closure-driven extraction plus a `WritableKeyPath` state container.
+    ///
+    /// - Parameters:
+    ///   - action: Resolves a global action into the local `Action`, an `AffineTraversal`
+    ///     selecting the target element inside its container, and the element `id`. Returns
+    ///     `nil` for global actions that don't address an element (the middleware is a no-op).
+    ///   - embed: Re-wraps an action produced by the element's effect into the global action
+    ///     type, addressed at `id`.
+    ///   - stateContainer: A `WritableKeyPath` from the global state to the element container
+    ///     (only its `get` is used — middleware never mutates).
+    /// - Returns: A `Middleware<GA, GS, Environment>` operating on the whole collection.
+    public func liftCollection<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> (action: Action, element: AffineTraversal<Container, State>, id: ID)?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        stateContainer: WritableKeyPath<GS, Container>
+    ) -> Middleware<GA, GS, Environment> {
+        liftCollection(action: action, embed: embed, stateContainer: lens(stateContainer))
+    }
+
+    /// Primitive — closure-driven extraction plus a `Lens` state container (for composed or
+    /// `let`-property containers). Only the lens `get` is used.
+    public func liftCollection<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> (action: Action, element: AffineTraversal<Container, State>, id: ID)?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        stateContainer: Lens<GS, Container>
+    ) -> Middleware<GA, GS, Environment> {
+        Middleware<GA, GS, Environment> { globalAction, context in
+            guard let resolved = action(globalAction) else { return Reader { _ in .empty } }
+            let traversal = stateContainer.compose(resolved.element)
+            let element = AnyHashableSendable(resolved.id)
+            return self.handle(resolved.action, context.compactMap(traversal.preview))
+                .map { (eff: Effect<Action>) in
+                    eff.map { embed($0, resolved.id) }.scopedToElement(element)
+                }
+                .contramapEnvironment { $0.compactMap(traversal.preview) }
+        }
+    }
+}
+
+// MARK: - liftCollection (Identifiable element)
+
+extension Middleware where State: Identifiable {
+    /// Lifts to a mutable collection, locating the element by its `Identifiable.id`.
+    /// Action extraction and re-embedding go through a single `Prism` into the `ElementAction`
+    /// case of the global action. State container via `WritableKeyPath`.
+    public func liftCollection<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable>(
+        action prism: Prism<GA, ElementAction<State.ID, Action>>,
+        stateCollection: WritableKeyPath<GS, C>
+    ) -> Middleware<GA, GS, Environment> where C.Element == State, C.Index: Sendable, State.ID: Sendable {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: C.ix(id: $0.id), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateCollection
+        )
+    }
+
+    /// Lifts to a mutable collection, locating the element by its `Identifiable.id`.
+    /// State container via `Lens`.
+    public func liftCollection<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable>(
+        action prism: Prism<GA, ElementAction<State.ID, Action>>,
+        stateCollection: Lens<GS, C>
+    ) -> Middleware<GA, GS, Environment> where C.Element == State, C.Index: Sendable, State.ID: Sendable {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: C.ix(id: $0.id), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateCollection
+        )
+    }
+}
+
+// MARK: - liftCollection (custom Hashable identifier)
+
+extension Middleware {
+    /// Lifts to a mutable collection, locating the element by a custom `Hashable` field extracted
+    /// by `identifier`. State container via `WritableKeyPath`.
+    public func liftCollection<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable, ID: Hashable & Sendable>(
+        action prism: Prism<GA, ElementAction<ID, Action>>,
+        stateCollection: WritableKeyPath<GS, C>,
+        identifier: @escaping @Sendable (State) -> ID
+    ) -> Middleware<GA, GS, Environment> where C.Element == State, C.Element: Sendable, C.Index: Sendable {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: C.ix(id: $0.id, by: identifier), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateCollection
+        )
+    }
+
+    /// Lifts to a mutable collection, locating the element by a custom `Hashable` field.
+    /// State container via `Lens`.
+    public func liftCollection<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable, ID: Hashable & Sendable>(
+        action prism: Prism<GA, ElementAction<ID, Action>>,
+        stateCollection: Lens<GS, C>,
+        identifier: @escaping @Sendable (State) -> ID
+    ) -> Middleware<GA, GS, Environment> where C.Element == State, C.Element: Sendable, C.Index: Sendable {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: C.ix(id: $0.id, by: identifier), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateCollection
+        )
+    }
+}
+
+// MARK: - liftCollection (Dictionary key-based)
+
+extension Middleware {
+    /// Lifts to a `Dictionary`, locating the entry by its key. State container via `WritableKeyPath`.
+    public func liftCollection<GA: Sendable, GS: Sendable, Key: Hashable & Sendable>(
+        action prism: Prism<GA, ElementAction<Key, Action>>,
+        stateDictionary: WritableKeyPath<GS, [Key: State]>
+    ) -> Middleware<GA, GS, Environment> {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: [Key: State].ix(key: $0.id), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateDictionary
+        )
+    }
+
+    /// Lifts to a `Dictionary`, locating the entry by its key. State container via `Lens`.
+    public func liftCollection<GA: Sendable, GS: Sendable, Key: Hashable & Sendable>(
+        action prism: Prism<GA, ElementAction<Key, Action>>,
+        stateDictionary: Lens<GS, [Key: State]>
+    ) -> Middleware<GA, GS, Environment> {
+        liftCollection(
+            action: { ga in prism.preview(ga).map { (action: $0.action, element: [Key: State].ix(key: $0.id), id: $0.id) } },
+            embed: { action, id in prism.review(ElementAction(id, action: action)) },
+            stateContainer: stateDictionary
+        )
+    }
+}

--- a/Tests/SwiftRexTests/BehaviorTests/Behavior+LiftCollectionTests.swift
+++ b/Tests/SwiftRexTests/BehaviorTests/Behavior+LiftCollectionTests.swift
@@ -1,0 +1,198 @@
+import CoreFP
+import DataStructure
+import Foundation
+@testable import SwiftRex
+import Testing
+
+@Suite @MainActor
+struct BehaviorLiftCollectionTests {
+    private static let anySource = ActionSource(file: #file, function: #function, line: #line)
+
+    // MARK: - Domain
+
+    private enum LocalAction: Equatable, Sendable {
+        case bump
+        case done
+    }
+
+    private struct Item: Identifiable, Sendable {
+        let id: UUID
+        var value: Int
+    }
+
+    private struct Named: Sendable {
+        let tag: String
+        var value: Int
+    }
+
+    private struct AppState: Sendable {
+        var items: [Item] = []
+        var named: [Named] = []
+        var lookup: [String: Item] = [:]
+    }
+
+    private enum AppAction: Sendable {
+        case item(ElementAction<UUID, LocalAction>)
+        case named(ElementAction<String, LocalAction>)
+        case keyed(ElementAction<String, LocalAction>)
+        case unrelated
+    }
+
+    private let id1 = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+    private let id2 = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+
+    // A behavior that mutates its element on `.bump` and schedules a `.replacing(id: "fetch")`
+    // effect emitting `.done`. The shared inner id "fetch" is what `liftCollection` must scope
+    // per element.
+    private let elementBehavior = Behavior<LocalAction, Item, Void> { action, _ in
+        switch action {
+        case .bump:
+            .reduce { $0.value += 1 }
+                .produce { _ in .just(.done, scheduling: .replacing(id: "fetch")) }
+        case .done:
+            .doNothing
+        }
+    }
+
+    private let itemPrism = Prism<AppAction, ElementAction<UUID, LocalAction>>(
+        preview: { if case .item(let ea) = $0 { ea } else { nil } },
+        review: { .item($0) }
+    )
+
+    // MARK: - Helpers
+
+    private func consequence(
+        _ sut: Behavior<AppAction, AppState, Void>,
+        action: AppAction,
+        state: AppState
+    ) -> Consequence<AppState, Void, AppAction> {
+        sut.handle(action, PreReducerContext(source: Self.anySource, getter: { state }))
+    }
+
+    // MARK: - Identifiable mutation
+
+    @Test func identifiableMutatesTargetedElement() {
+        let sut = elementBehavior.liftCollection(action: itemPrism, stateCollection: \AppState.items)
+        var state = AppState(items: [Item(id: id1, value: 0), Item(id: id2, value: 10)])
+        consequence(sut, action: .item(ElementAction(id1, action: .bump)), state: state)
+            .mutation.runEndoMut(&state)
+        #expect(state.items[0].value == 1)
+        #expect(state.items[1].value == 10)
+    }
+
+    @Test func unmatchedActionIsNoOp() {
+        let sut = elementBehavior.liftCollection(action: itemPrism, stateCollection: \AppState.items)
+        var state = AppState(items: [Item(id: id1, value: 5)])
+        let c = consequence(sut, action: .unrelated, state: state)
+        c.mutation.runEndoMut(&state)
+        #expect(state.items[0].value == 5)
+        #expect(c.effect(PostReducerContext(environment: (), getter: { state })).components.isEmpty)
+    }
+
+    // MARK: - Output action re-embedding
+
+    @Test func emittedActionIsReEmbeddedAtSameElement() {
+        let sut = elementBehavior.liftCollection(action: itemPrism, stateCollection: \AppState.items)
+        let state = AppState(items: [Item(id: id1, value: 0)])
+        let c = consequence(sut, action: .item(ElementAction(id1, action: .bump)), state: state)
+        let effect = c.effect(PostReducerContext(environment: (), getter: { state }))
+        let received = LockProtected([AppAction]())
+        subscribeAll(effect) { d in received.mutate { $0.append(d.action) } }
+        guard case .item(let ea) = received.value.first else {
+            Issue.record("Expected a re-embedded .item action")
+            return
+        }
+        #expect(ea.id == id1)
+        #expect(ea.action == .done)
+    }
+
+    // MARK: - Per-element effect-scheduling scope
+
+    @Test func schedulingIdIsScopedPerElement() {
+        let sut = elementBehavior.liftCollection(action: itemPrism, stateCollection: \AppState.items)
+        let state = AppState(items: [Item(id: id1, value: 0), Item(id: id2, value: 0)])
+
+        let effA = consequence(sut, action: .item(ElementAction(id1, action: .bump)), state: state)
+            .effect(PostReducerContext(environment: (), getter: { state }))
+        let effB = consequence(sut, action: .item(ElementAction(id2, action: .bump)), state: state)
+            .effect(PostReducerContext(environment: (), getter: { state }))
+
+        let expectedA = AnyHashableSendable(
+            ElementScopedID(element: AnyHashableSendable(id1), inner: AnyHashableSendable("fetch"))
+        )
+        let expectedB = AnyHashableSendable(
+            ElementScopedID(element: AnyHashableSendable(id2), inner: AnyHashableSendable("fetch"))
+        )
+
+        guard case .replacing(let idA) = effA.components.first?.scheduling,
+              case .replacing(let idB) = effB.components.first?.scheduling else {
+            Issue.record("Expected .replacing scheduling on both elements")
+            return
+        }
+        #expect(idA == expectedA)
+        #expect(idB == expectedB)
+        #expect(idA != idB)   // same inner "fetch", different element → independent
+    }
+
+    // MARK: - Custom Hashable identifier
+
+    @Test func customIdentifierMutatesAndScopes() {
+        let namedBehavior = Behavior<LocalAction, Named, Void> { action, _ in
+            switch action {
+            case .bump:
+                .reduce { $0.value += 1 }
+                    .produce { _ in .just(.done, scheduling: .replacing(id: "fetch")) }
+            case .done:
+                .doNothing
+            }
+        }
+        let prism = Prism<AppAction, ElementAction<String, LocalAction>>(
+            preview: { if case .named(let ea) = $0 { ea } else { nil } },
+            review: { .named($0) }
+        )
+        let sut = namedBehavior.liftCollection(
+            action: prism,
+            stateCollection: \AppState.named,
+            identifier: { $0.tag }
+        )
+        var state = AppState(named: [Named(tag: "a", value: 0), Named(tag: "b", value: 5)])
+        let c = consequence(sut, action: .named(ElementAction("b", action: .bump)), state: state)
+        c.mutation.runEndoMut(&state)
+        #expect(state.named[0].value == 0)
+        #expect(state.named[1].value == 6)
+
+        let eff = c.effect(PostReducerContext(environment: (), getter: { state }))
+        let expected = AnyHashableSendable(
+            ElementScopedID(element: AnyHashableSendable("b"), inner: AnyHashableSendable("fetch"))
+        )
+        guard case .replacing(let id) = eff.components.first?.scheduling else {
+            Issue.record("Expected .replacing scheduling")
+            return
+        }
+        #expect(id == expected)
+    }
+
+    // MARK: - Dictionary key-based
+
+    @Test func dictionaryMutatesAndScopes() {
+        let prism = Prism<AppAction, ElementAction<String, LocalAction>>(
+            preview: { if case .keyed(let ea) = $0 { ea } else { nil } },
+            review: { .keyed($0) }
+        )
+        let sut = elementBehavior.liftCollection(action: prism, stateDictionary: \AppState.lookup)
+        var state = AppState(lookup: ["x": Item(id: id1, value: 1)])
+        let c = consequence(sut, action: .keyed(ElementAction("x", action: .bump)), state: state)
+        c.mutation.runEndoMut(&state)
+        #expect(state.lookup["x"]?.value == 2)
+
+        let eff = c.effect(PostReducerContext(environment: (), getter: { state }))
+        let expected = AnyHashableSendable(
+            ElementScopedID(element: AnyHashableSendable("x"), inner: AnyHashableSendable("fetch"))
+        )
+        guard case .replacing(let id) = eff.components.first?.scheduling else {
+            Issue.record("Expected .replacing scheduling")
+            return
+        }
+        #expect(id == expected)
+    }
+}

--- a/Tests/SwiftRexTests/MiddlewareTests/Middleware+LiftCollectionTests.swift
+++ b/Tests/SwiftRexTests/MiddlewareTests/Middleware+LiftCollectionTests.swift
@@ -1,0 +1,132 @@
+import CoreFP
+import DataStructure
+import Foundation
+@testable import SwiftRex
+import Testing
+
+@Suite @MainActor
+struct MiddlewareLiftCollectionTests {
+    private static let anySource = ActionSource(file: #file, function: #function, line: #line)
+
+    // MARK: - Domain
+
+    private enum LocalAction: Equatable, Sendable {
+        case bump
+        case done
+    }
+
+    private struct Item: Identifiable, Sendable {
+        let id: UUID
+        var value: Int
+    }
+
+    private struct AppState: Sendable {
+        var items: [Item] = []
+        var lookup: [String: Item] = [:]
+    }
+
+    private enum AppAction: Sendable {
+        case item(ElementAction<UUID, LocalAction>)
+        case keyed(ElementAction<String, LocalAction>)
+        case unrelated
+    }
+
+    private let id1 = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+    private let id2 = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+
+    // On `.bump`, schedule a `.replacing(id: "fetch")` effect emitting `.done`. The shared inner
+    // id "fetch" is what `liftCollection` must scope per element.
+    private let elementMiddleware = Middleware<LocalAction, Item, Void> { action, _ in
+        switch action {
+        case .bump:
+            Reader { _ in .just(.done, scheduling: .replacing(id: "fetch")) }
+        case .done:
+            Reader { _ in .empty }
+        }
+    }
+
+    private let itemPrism = Prism<AppAction, ElementAction<UUID, LocalAction>>(
+        preview: { if case .item(let ea) = $0 { ea } else { nil } },
+        review: { .item($0) }
+    )
+
+    // MARK: - Helpers
+
+    private func effect(
+        _ sut: Middleware<AppAction, AppState, Void>,
+        action: AppAction,
+        state: AppState
+    ) -> Effect<AppAction> {
+        sut.handle(action, PreReducerContext(source: Self.anySource, getter: { state }))
+            .runReader(PostReducerContext(environment: (), getter: { state }))
+    }
+
+    // MARK: - Output action re-embedding
+
+    @Test func emittedActionIsReEmbeddedAtSameElement() {
+        let sut = elementMiddleware.liftCollection(action: itemPrism, stateCollection: \AppState.items)
+        let state = AppState(items: [Item(id: id1, value: 0)])
+        let received = LockProtected([AppAction]())
+        subscribeAll(effect(sut, action: .item(ElementAction(id1, action: .bump)), state: state)) { d in
+            received.mutate { $0.append(d.action) }
+        }
+        guard case .item(let ea) = received.value.first else {
+            Issue.record("Expected a re-embedded .item action")
+            return
+        }
+        #expect(ea.id == id1)
+        #expect(ea.action == .done)
+    }
+
+    @Test func unmatchedActionIsNoOp() {
+        let sut = elementMiddleware.liftCollection(action: itemPrism, stateCollection: \AppState.items)
+        let state = AppState(items: [Item(id: id1, value: 5)])
+        #expect(effect(sut, action: .unrelated, state: state).components.isEmpty)
+    }
+
+    // MARK: - Per-element effect-scheduling scope
+
+    @Test func schedulingIdIsScopedPerElement() {
+        let sut = elementMiddleware.liftCollection(action: itemPrism, stateCollection: \AppState.items)
+        let state = AppState(items: [Item(id: id1, value: 0), Item(id: id2, value: 0)])
+
+        let effA = effect(sut, action: .item(ElementAction(id1, action: .bump)), state: state)
+        let effB = effect(sut, action: .item(ElementAction(id2, action: .bump)), state: state)
+
+        let expectedA = AnyHashableSendable(
+            ElementScopedID(element: AnyHashableSendable(id1), inner: AnyHashableSendable("fetch"))
+        )
+        let expectedB = AnyHashableSendable(
+            ElementScopedID(element: AnyHashableSendable(id2), inner: AnyHashableSendable("fetch"))
+        )
+
+        guard case .replacing(let idA) = effA.components.first?.scheduling,
+              case .replacing(let idB) = effB.components.first?.scheduling else {
+            Issue.record("Expected .replacing scheduling on both elements")
+            return
+        }
+        #expect(idA == expectedA)
+        #expect(idB == expectedB)
+        #expect(idA != idB)
+    }
+
+    // MARK: - Dictionary key-based
+
+    @Test func dictionaryScopesScheduling() {
+        let prism = Prism<AppAction, ElementAction<String, LocalAction>>(
+            preview: { if case .keyed(let ea) = $0 { ea } else { nil } },
+            review: { .keyed($0) }
+        )
+        let sut = elementMiddleware.liftCollection(action: prism, stateDictionary: \AppState.lookup)
+        let state = AppState(lookup: ["x": Item(id: id1, value: 1)])
+        let eff = effect(sut, action: .keyed(ElementAction("x", action: .bump)), state: state)
+        let expected = AnyHashableSendable(
+            ElementScopedID(element: AnyHashableSendable("x"), inner: AnyHashableSendable("fetch"))
+        )
+        guard case .replacing(let id) = eff.components.first?.scheduling else {
+            Issue.record("Expected .replacing scheduling")
+            return
+        }
+        #expect(id == expected)
+    }
+}


### PR DESCRIPTION
## What
Adds `liftCollection` to `Behavior` and `Middleware`, lifting a per-element unit into one that operates over a whole collection inside a global state — with each element's effects re-addressed and its effect-scheduling ids isolated per element.

## Why
`Reducer.liftCollection` already exists, but it is state-only. `Behavior`/`Middleware` also carry effects, so a collection lift must additionally (a) re-embed actions emitted by an element's effect back into the global action type, and (b) keep one element's effect scheduling from colliding with another's. Without per-element scoping, element A's `.debounce(id: .fetch)` would cancel element B's identical policy.

## Changes
- `Effect+ElementScope.swift` — `ElementScopedID(element, inner)` plus `EffectScheduling.scopedToElement` / `Effect.scopedToElement` that wrap each id-carrying policy's id with the element axis. `.immediately` is unchanged.
- `Behavior+LiftCollection.swift` — primitive (closure + `AffineTraversal`) and convenience families (Identifiable, custom `Hashable` identifier, Dictionary key), each with `WritableKeyPath` and `Lens` state containers. Action extraction/re-embedding go through a `Prism<GA, ElementAction<ID, Action>>`; the mutation is lifted through the element traversal and the effect's output actions are re-embedded and scoped.
- `Middleware+LiftCollection.swift` — same families; `Middleware` is read-only on state, so only the effect side is transformed.
- Tests for both, proving targeted-element mutation, output-action re-embedding at the same element, and that the same inner id under two different elements yields distinct `ElementScopedID`s (independent scheduling).

Design note: the user owns the inner id — cross-feature collisions remain their responsibility (use distinct id enums), exactly as for un-lifted effects. The lift only adds the element axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)