### PR TITLE
Inject clock + RNG co-effects; Duration-based scheduling

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5299b59820bba0ef710ee23eb60fb33ef9279066f7fdf23ceeb4db5ba93e6f41",
+  "originHash" : "97fba0dd82ab3a4c757198f7c9d2f930a42db8fac415d7a019242545a6f78bb5",
   "pins" : [
     {
       "identity" : "fp",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "fe049b5f09218153072d24613aa5ce8acde26a16",
         "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "hourglass",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/luizmb/Hourglass.git",
+      "state" : {
+        "revision" : "6d35df23dcce1477bb244d51eb045707eec5506c",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
     name: "SwiftRex",
     platforms: [
-        .macOS(.v12),
-        .iOS(.v15),
-        .tvOS(.v15),
-        .watchOS(.v8)
+        .macOS(.v13),
+        .iOS(.v16),
+        .tvOS(.v16),
+        .watchOS(.v9)
     ],
     products: [
         .library(name: "SwiftRex", targets: ["SwiftRex"]),
@@ -23,6 +23,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/luizmb/FP.git", from: "1.10.0"),
+        .package(url: "https://github.com/luizmb/Hourglass.git", from: "0.5.0"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.2.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.1"),
@@ -35,7 +36,8 @@ let package = Package(
             name: "SwiftRex",
             dependencies: [
                 .product(name: "CoreFP", package: "FP"),
-                .product(name: "DataStructure", package: "FP")
+                .product(name: "DataStructure", package: "FP"),
+                .product(name: "Hourglass", package: "Hourglass")
             ],
             path: "Sources/SwiftRex"
         ),
@@ -144,7 +146,8 @@ let package = Package(
                 "SwiftRex",
                 "SwiftRexTesting",
                 .product(name: "CoreFP", package: "FP"),
-                .product(name: "DataStructure", package: "FP")
+                .product(name: "DataStructure", package: "FP"),
+                .product(name: "Hourglass", package: "Hourglass")
             ],
             path: "Tests/SwiftRexTests"
         ),

--- a/Sources/SwiftRex/Effect/Effect+Factories.swift
+++ b/Sources/SwiftRex/Effect/Effect+Factories.swift
@@ -16,7 +16,7 @@ extension Effect {
     ///
     /// // Debounce a single action
     /// return .produce { _ in
-    ///     .just(.refreshFeed, scheduling: .debounce(id: "refresh", delay: 1.0))
+    ///     .just(.refreshFeed, scheduling: .debounce(id: "refresh", delay: .seconds(1)))
     /// }
     /// ```
     ///

--- a/Sources/SwiftRex/Effect/Effect.swift
+++ b/Sources/SwiftRex/Effect/Effect.swift
@@ -147,7 +147,7 @@ extension Effect {
     /// ```swift
     /// // Debounce a search effect by 300 ms
     /// let searchEffect = apiEffect
-    ///     .scheduling(.debounce(id: "search", delay: 0.3))
+    ///     .scheduling(.debounce(id: "search", delay: .milliseconds(300)))
     ///
     /// // Ensure only one fetch runs at a time
     /// let fetchEffect = fetchData()

--- a/Sources/SwiftRex/Effect/EffectScheduling.swift
+++ b/Sources/SwiftRex/Effect/EffectScheduling.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Declares how the ``Store`` should schedule and manage the lifecycle of an ``Effect`` component.
 ///
 /// Every `Effect` component carries an `EffectScheduling` value. The Store reads it after every
@@ -32,13 +30,13 @@ import Foundation
 /// // Debounce live search: reset the 300 ms timer on every keystroke
 /// return .produce { env in
 ///     env.api.search(query).asEffect()
-///         .scheduling(.debounce(id: "liveSearch", delay: 0.3))
+///         .scheduling(.debounce(id: "liveSearch", delay: .milliseconds(300)))
 /// }
 ///
 /// // Throttle location updates to at most once every 5 seconds
 /// return .produce { env in
 ///     env.gps.currentLocation().asEffect()
-///         .scheduling(.throttle(id: "gps", interval: 5.0))
+///         .scheduling(.throttle(id: "gps", interval: .seconds(5)))
 /// }
 ///
 /// // Cancel any in-flight upload when the user taps "Discard"
@@ -88,14 +86,14 @@ public enum EffectScheduling: Sendable {
     /// // Trigger a search no sooner than 300 ms after the last keystroke
     /// return .produce { env in
     ///     env.api.search(query).asEffect()
-    ///         .scheduling(.debounce(id: "search", delay: 0.3))
+    ///         .scheduling(.debounce(id: "search", delay: .milliseconds(300)))
     /// }
     /// ```
     ///
     /// - Parameters:
     ///   - id: The shared key in the Store's effect registry.
-    ///   - delay: Seconds to wait after the latest dispatch before starting the component.
-    case debounce(id: AnyHashableSendable, delay: TimeInterval)
+    ///   - delay: Duration to wait after the latest dispatch before starting the component.
+    case debounce(id: AnyHashableSendable, delay: Duration)
 
     /// Start the component immediately, but only if no component with `id` ran within the last
     /// `interval` seconds.
@@ -110,14 +108,14 @@ public enum EffectScheduling: Sendable {
     /// // Update the UI at most once every second when scrolling
     /// return .produce { env in
     ///     env.analytics.trackScroll(position).asEffect()
-    ///         .scheduling(.throttle(id: "scroll", interval: 1.0))
+    ///         .scheduling(.throttle(id: "scroll", interval: .seconds(1)))
     /// }
     /// ```
     ///
     /// - Parameters:
     ///   - id: The shared key in the Store's effect registry.
-    ///   - interval: Minimum seconds between consecutive executions.
-    case throttle(id: AnyHashableSendable, interval: TimeInterval)
+    ///   - interval: Minimum duration between consecutive executions.
+    case throttle(id: AnyHashableSendable, interval: Duration)
 
     /// Remove `id` from the registry and cancel whatever was registered there.
     ///
@@ -138,7 +136,7 @@ public enum EffectScheduling: Sendable {
 
 // Enum cases cannot be generic and `AnyHashableSendable` has no implicit conversion, so these
 // same-name factories keep the natural call-site spelling: `.replacing(id: "fetch")`,
-// `.debounce(id: EffectID.search, delay: 0.3)`. `AnyHashableSendable` itself satisfies
+// `.debounce(id: EffectID.search, delay: .milliseconds(300))`. `AnyHashableSendable` itself satisfies
 // `some Hashable & Sendable`, so without `@_disfavoredOverload` a call passing the wrapper
 // (including the delegation inside each factory) would be ambiguous between the case
 // constructor and the factory.
@@ -152,13 +150,13 @@ extension EffectScheduling {
 
     /// Creates a ``debounce(id:delay:)`` policy from any `Hashable & Sendable` id.
     @_disfavoredOverload
-    public static func debounce(id: some Hashable & Sendable, delay: TimeInterval) -> Self {
+    public static func debounce(id: some Hashable & Sendable, delay: Duration) -> Self {
         .debounce(id: AnyHashableSendable(id), delay: delay)
     }
 
     /// Creates a ``throttle(id:interval:)`` policy from any `Hashable & Sendable` id.
     @_disfavoredOverload
-    public static func throttle(id: some Hashable & Sendable, interval: TimeInterval) -> Self {
+    public static func throttle(id: some Hashable & Sendable, interval: Duration) -> Self {
         .throttle(id: AnyHashableSendable(id), interval: interval)
     }
 

--- a/Sources/SwiftRex/Foundation/AnyHashableSendable.swift
+++ b/Sources/SwiftRex/Foundation/AnyHashableSendable.swift
@@ -27,7 +27,7 @@
 ///
 /// return .produce { ctx in
 ///     ctx.environment.api.search(query).asEffect()
-///         .scheduling(.debounce(id: EffectID.search, delay: 0.3))
+///         .scheduling(.debounce(id: EffectID.search, delay: .milliseconds(300)))
 /// }
 /// ```
 ///

--- a/Sources/SwiftRex/Store/Store.swift
+++ b/Sources/SwiftRex/Store/Store.swift
@@ -1,6 +1,7 @@
 import CoreFP
 import DataStructure
 import Foundation
+import Hourglass
 
 /// The sole owner of mutable `State` and the central coordinator of the three-phase dispatch pipeline.
 ///
@@ -96,20 +97,39 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
 
     // MARK: - Registries
 
-    /// All effects — both named (user-provided id) and anonymous (UUID key).
-    /// UUID is Hashable & Sendable, so AnyHashableSendable(UUID()) fits naturally
+    /// All effects — both named (user-provided id) and anonymous (UUID key drawn from ``idGen``).
+    /// UUID is Hashable & Sendable, so `AnyHashableSendable(idGen(&rng))` fits naturally
     /// alongside named keys. Each `SubscriptionToken` cancels its effect when released, so
     /// removing/replacing an entry — or deallocating the Store, which releases this whole
     /// dictionary — cancels the corresponding in-flight work automatically (no `deinit` needed).
     private var effects: [AnyHashableSendable: SubscriptionToken] = [:]
 
-    /// Last-fire timestamps for `.throttle` keys, each paired with the interval that produced it
-    /// so expired entries can be pruned — keeps the dictionary bounded under unbounded distinct keys.
-    private var throttleTimestamps: [AnyHashableSendable: (last: Date, interval: TimeInterval)] = [:]
+    /// Last-fire instants for `.throttle` keys (measured on the injected ``clock``), each paired
+    /// with the interval that produced it so expired entries can be pruned — keeps the dictionary
+    /// bounded under unbounded distinct keys.
+    private var throttleTimestamps: [AnyHashableSendable: (last: AnyClock<Swift.Duration>.Instant, interval: Duration)] = [:]
 
-    /// Both observer closures are stored together under one UUID so a single token cancels both.
-    private var stateObservers: [UUID: (willChange: @MainActor @Sendable () -> Void,
-                                        didChange: @MainActor @Sendable () -> Void)] = [:]
+    /// Both observer closures are stored together under one key so a single token cancels both.
+    /// Keys come from ``nextObserverKey`` — a monotonic counter; these keys are internal and never
+    /// surfaced, so no `UUID`/RNG is needed (a wrapping `UInt64` cannot realistically collide).
+    private var stateObservers: [UInt64: (willChange: @MainActor @Sendable () -> Void,
+                                          didChange: @MainActor @Sendable () -> Void)] = [:]
+    private var nextObserverKey: UInt64 = 0
+
+    // MARK: - Injected co-effects
+
+    /// Clock used for all ``EffectScheduling`` timing (debounce sleep, throttle window). Erased to
+    /// ``AnyClock`` so the Store carries no clock generic; injected at `init` (defaults to
+    /// `ContinuousClock`, swappable for a `TestClock`/`ImmediateClock` of the same `Duration`).
+    private let clock: AnyClock<Swift.Duration>
+
+    /// Source of randomness for anonymous effect ids, threaded through ``idGen``. A seeded generator
+    /// yields reproducible ids; defaults to the system RNG. Only mutated on `@MainActor`.
+    private var rng: AnyRandomNumberGenerator
+
+    /// Pure recipe turning ``rng`` into anonymous effect-registry ids — the `Gen`-based replacement
+    /// for `UUID()`.
+    private let idGen = Gen<UUID>.uuid()
 
     // MARK: - Dispatch serialization
     //
@@ -131,7 +151,8 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
 
     // MARK: - Init
 
-    /// Creates a `Store` with a pre-composed ``Behavior`` and an environment.
+    /// Creates a `Store` with a pre-composed ``Behavior`` and an environment, driving
+    /// ``EffectScheduling`` timing with a live `ContinuousClock`.
     ///
     /// Use this when you have already assembled your feature behaviors into a single
     /// `Behavior` using ``Behavior/combine(_:_:)`` or the `Monoid` fold:
@@ -144,18 +165,51 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
     /// )
     /// ```
     ///
+    /// To drive scheduling with a `TestClock`/`ImmediateClock` — or to read the clock from the
+    /// environment — use ``init(initial:behavior:environment:clock:rng:)``.
+    ///
     /// - Parameters:
     ///   - state: The initial state value. The store takes exclusive ownership.
     ///   - behavior: The single ``Behavior`` that handles all dispatched actions.
     ///   - environment: The environment injected into ``Effect`` readers in phase 3.
-    public init(
+    ///   - rng: Extracts the randomness source for anonymous effect ids from the environment.
+    ///     Defaults to the system RNG; inject a seeded `SplitMix64` for reproducible ids.
+    public convenience init(
         initial state: State,
         behavior: Behavior<Action, State, Environment>,
-        environment: Environment
+        environment: Environment,
+        rng: (Environment) -> AnyRandomNumberGenerator = { _ in AnyRandomNumberGenerator(SystemRandomNumberGenerator()) }
     ) {
+        self.init(initial: state, behavior: behavior, environment: environment, clock: { _ in ContinuousClock() }, rng: rng)
+    }
+
+    /// Creates a `Store` extracting the scheduling clock — and optionally the RNG — from the
+    /// environment.
+    ///
+    /// The concrete clock `C` is inferred at the call site and erased to ``AnyClock`` at
+    /// construction, so `Store` carries no clock generic. Pass a `TestClock`/`ImmediateClock`
+    /// for deterministic ``EffectScheduling`` in tests.
+    ///
+    /// - Parameters:
+    ///   - state: The initial state value. The store takes exclusive ownership.
+    ///   - behavior: The single ``Behavior`` that handles all dispatched actions.
+    ///   - environment: The environment injected into ``Effect`` readers in phase 3.
+    ///   - clock: Extracts the clock driving ``EffectScheduling`` timing from the environment.
+    ///     Must have `Duration == Swift.Duration` (`ContinuousClock`, `TestClock`, `ImmediateClock`).
+    ///   - rng: Extracts the randomness source for anonymous effect ids from the environment.
+    ///     Defaults to the system RNG; inject a seeded `SplitMix64` for reproducible ids.
+    public init<C: Clock>(
+        initial state: State,
+        behavior: Behavior<Action, State, Environment>,
+        environment: Environment,
+        clock: (Environment) -> C,
+        rng: (Environment) -> AnyRandomNumberGenerator = { _ in AnyRandomNumberGenerator(SystemRandomNumberGenerator()) }
+    ) where C: Sendable, C.Duration == Swift.Duration {
         self.state = state
         self.behavior = behavior
         self.environment = environment
+        self.clock = clock(environment).eraseToAnyClock()
+        self.rng = rng(environment)
     }
 
     /// Creates a `Store` with a ``Reducer`` only (no side effects, `Environment == Void`).
@@ -261,7 +315,8 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
         willChange: @escaping @MainActor @Sendable () -> Void,
         didChange: @escaping @MainActor @Sendable () -> Void
     ) -> SubscriptionToken {
-        let id = UUID()
+        let id = nextObserverKey
+        nextObserverKey &+= 1
         stateObservers[id] = (willChange: willChange, didChange: didChange)
         return SubscriptionToken { [weak self] in
             Task { @MainActor [weak self] in self?.stateObservers.removeValue(forKey: id) }
@@ -336,7 +391,7 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
     private func schedule(_ component: Effect<Action>.Component) {
         switch component.scheduling {
         case .immediately:
-            let key = AnyHashableSendable(UUID())
+            let key = AnyHashableSendable(idGen(&rng))
             let token = component.subscribe(makeSend()) { [weak self] in
                 Task { @MainActor [weak self] in self?.effects.removeValue(forKey: key) }
             }
@@ -356,9 +411,10 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
         case let .debounce(key, delay):
             effects[key]?.cancel()
             let send = makeSend()
+            let clock = clock
             let task = Task { @MainActor [weak self] in
-                // Clamp negative delays to zero — `UInt64(negative)` traps.
-                try await Task.sleep(nanoseconds: UInt64(max(0, delay) * 1_000_000_000))
+                // Clamp negative delays to zero so a past deadline resolves immediately.
+                try await clock.sleep(for: max(.zero, delay))
                 guard !Task.isCancelled, let self else { return }
                 let token = component.subscribe(send) { [weak self] in
                     Task { @MainActor [weak self] in self?.effects.removeValue(forKey: key) }
@@ -368,10 +424,10 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
             effects[key] = SubscriptionToken { task.cancel() }
 
         case let .throttle(key, interval):
-            let now = Date()
+            let now = clock.now
             // Prune entries whose interval has elapsed so the dictionary stays bounded.
-            throttleTimestamps = throttleTimestamps.filter { now.timeIntervalSince($0.value.last) < $0.value.interval }
-            if let entry = throttleTimestamps[key], now.timeIntervalSince(entry.last) < interval { return }
+            throttleTimestamps = throttleTimestamps.filter { $0.value.last.duration(to: now) < $0.value.interval }
+            if let entry = throttleTimestamps[key], entry.last.duration(to: now) < interval { return }
             throttleTimestamps[key] = (last: now, interval: interval)
             effects[key]?.cancel()
             let token = component.subscribe(makeSend()) { [weak self] in

--- a/Sources/SwiftRex/Store/StoreBuffer.swift
+++ b/Sources/SwiftRex/Store/StoreBuffer.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A reference-type store wrapper that caches state and gates observer notifications
 /// through a `hasChanged` predicate.
 ///
@@ -67,8 +65,10 @@ public final class StoreBuffer<Action: Sendable, State: Sendable>
     private let underlying: any StoreType<Action, State>
     private let hasChanged: @Sendable (State, State) -> Bool
     private var token: SubscriptionToken?
-    private var observers: [UUID: (willChange: @MainActor @Sendable () -> Void,
-                                   didChange: @MainActor @Sendable () -> Void)] = [:]
+    // Observer keys are a monotonic counter — internal, never surfaced, so no UUID/RNG is needed.
+    private var observers: [UInt64: (willChange: @MainActor @Sendable () -> Void,
+                                     didChange: @MainActor @Sendable () -> Void)] = [:]
+    private var nextObserverKey: UInt64 = 0
 
     /// Creates a `StoreBuffer` wrapping `store` with a custom change predicate.
     ///
@@ -129,7 +129,8 @@ public final class StoreBuffer<Action: Sendable, State: Sendable>
         willChange: @escaping @MainActor @Sendable () -> Void,
         didChange: @escaping @MainActor @Sendable () -> Void
     ) -> SubscriptionToken {
-        let id = UUID()
+        let id = nextObserverKey
+        nextObserverKey &+= 1
         observers[id] = (willChange: willChange, didChange: didChange)
         return SubscriptionToken { [weak self] in
             Task { @MainActor [weak self] in self?.observers.removeValue(forKey: id) }

--- a/Sources/SwiftRex/Store/StoreProjection.swift
+++ b/Sources/SwiftRex/Store/StoreProjection.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A type-erasing, stateless projection of a ``StoreType`` that presents a narrower
 /// action and state interface.
 ///

--- a/Sources/SwiftRexTesting/TestStore.swift
+++ b/Sources/SwiftRexTesting/TestStore.swift
@@ -1,5 +1,4 @@
 import CoreFP
-import Foundation
 import SwiftRex
 import Testing
 
@@ -100,9 +99,11 @@ public final class TestStore<Action: Sendable, State: Sendable & Equatable, Envi
     /// not retroactively rebind already-pending effects.
     public var environment: Environment
 
-    /// Registered will/didChange callbacks — keyed by UUID so a single token cancels both.
-    private var stateObservers: [UUID: (willChange: @MainActor @Sendable () -> Void,
-                                        didChange: @MainActor @Sendable () -> Void)] = [:]
+    /// Registered will/didChange callbacks — keyed by a monotonic counter (internal, never
+    /// surfaced) so a single token cancels both.
+    private var stateObservers: [UInt64: (willChange: @MainActor @Sendable () -> Void,
+                                          didChange: @MainActor @Sendable () -> Void)] = [:]
+    private var nextObserverKey: UInt64 = 0
 
     // Mirrored counts for deinit — Swift 6 deinit is nonisolated and cannot read @MainActor
     // storage. These are written on @MainActor and only read in deinit.
@@ -179,7 +180,8 @@ public final class TestStore<Action: Sendable, State: Sendable & Equatable, Envi
         willChange: @escaping @MainActor @Sendable () -> Void,
         didChange: @escaping @MainActor @Sendable () -> Void
     ) -> SubscriptionToken {
-        let id = UUID()
+        let id = nextObserverKey
+        nextObserverKey &+= 1
         stateObservers[id] = (willChange: willChange, didChange: didChange)
         return SubscriptionToken { [weak self] in
             Task { @MainActor [weak self] in self?.stateObservers.removeValue(forKey: id) }

--- a/Tests/SwiftRexTests/EffectTests/EffectTests.swift
+++ b/Tests/SwiftRexTests/EffectTests/EffectTests.swift
@@ -31,7 +31,7 @@ struct EffectMonoidTests {
 
     @Test func combinePreservesIndividualScheduling() {
         let a = Effect<Int>.just(1).scheduling(.replacing(id: "a"))
-        let b = Effect<Int>.just(2).scheduling(.debounce(id: "b", delay: 0.3))
+        let b = Effect<Int>.just(2).scheduling(.debounce(id: "b", delay: .milliseconds(300)))
         let combined = Effect.combine(a, b)
         guard combined.components.count == 2 else { Issue.record("Expected 2 components"); return }
         if case .replacing(let id) = combined.components[0].scheduling {

--- a/Tests/SwiftRexTests/FoundationTests/AnyHashableSendableTests.swift
+++ b/Tests/SwiftRexTests/FoundationTests/AnyHashableSendableTests.swift
@@ -72,22 +72,22 @@ struct EffectSchedulingIdFactoryTests {
     @Test("UUID id round-trips through debounce")
     func debounceUUIDId() {
         let uuid = UUID(uuidString: "00000000-0000-0000-0000-000000000042")!
-        guard case .debounce(let id, let delay) = EffectScheduling.debounce(id: uuid, delay: 0.3) else {
+        guard case .debounce(let id, let delay) = EffectScheduling.debounce(id: uuid, delay: .milliseconds(300)) else {
             Issue.record("Expected .debounce")
             return
         }
         #expect(id == AnyHashableSendable(uuid))
-        #expect(delay == 0.3)
+        #expect(delay == .milliseconds(300))
     }
 
     @Test("Enum id round-trips through throttle")
     func throttleEnumId() {
-        guard case .throttle(let id, let interval) = EffectScheduling.throttle(id: FeatureAID.search, interval: 1.0) else {
+        guard case .throttle(let id, let interval) = EffectScheduling.throttle(id: FeatureAID.search, interval: .seconds(1)) else {
             Issue.record("Expected .throttle")
             return
         }
         #expect(id == AnyHashableSendable(FeatureAID.search))
-        #expect(interval == 1.0)
+        #expect(interval == .seconds(1))
     }
 
     @Test("Enum id round-trips through cancelInFlight, distinct across enum types")

--- a/Tests/SwiftRexTests/StoreTests/StoreTests.swift
+++ b/Tests/SwiftRexTests/StoreTests/StoreTests.swift
@@ -1,5 +1,6 @@
 import CoreFP
 import DataStructure
+import Hourglass
 @testable import SwiftRex
 import Testing
 
@@ -164,14 +165,14 @@ struct StoreEffectSchedulingTests {
         #expect(store.state == 0)
     }
 
-    /// A negative debounce delay must not trap in `UInt64(delay * 1e9)`; it is clamped to zero,
-    /// so the effect fires (effectively immediately) and loops its action back.
+    /// A negative debounce delay must not trap; it is clamped to `.zero`, so the effect fires
+    /// (effectively immediately) and loops its action back.
     @Test func negativeDebounceDelayIsClampedAndFires() async {
         let store = Store(
             initial: 0,
             behavior: Behavior<Int, Int, Void>.handle { action, _ in
                 action == 0
-                    ? .produce { _ in Effect<Int>.just(5).scheduling(.debounce(id: "d", delay: -1)) }
+                    ? .produce { _ in Effect<Int>.just(5).scheduling(.debounce(id: "d", delay: .seconds(-1))) }
                     : .reduce { $0 = action }
             },
             environment: ()
@@ -179,6 +180,89 @@ struct StoreEffectSchedulingTests {
         store.dispatch(0)
         try? await Task.sleep(nanoseconds: 100_000_000)
         #expect(store.state == 5)
+    }
+}
+
+// MARK: - Clock injection (deterministic scheduling)
+
+@Suite("Store clock injection")
+@MainActor
+struct StoreClockInjectionTests {
+    /// Drains `@MainActor` `Task` hops (effect → action loopback) until `condition` holds or a
+    /// bounded number of yields elapse.
+    private func poll(until condition: @MainActor () -> Bool) async {
+        for _ in 0..<1_000 {
+            if condition() { return }
+            await Task.yield()
+        }
+    }
+
+    @Test func debounceFiresOnlyAfterInjectedClockAdvancesPastDelay() async {
+        let clock = TestClock()
+        let store = Store(
+            initial: 0,
+            behavior: Behavior<Int, Int, Void>.handle { action, _ in
+                action == 0
+                    ? .produce { _ in Effect<Int>.just(5).scheduling(.debounce(id: "d", delay: .seconds(1))) }
+                    : .reduce { $0 = action }
+            },
+            environment: (),
+            clock: { _ in clock }
+        )
+        store.dispatch(0)
+        await clock.waitForSleepers()          // the debounce task is parked on clock.sleep
+        #expect(store.state == 0)              // nothing fired before the delay elapses
+        await clock.advance(by: .seconds(1))
+        await poll { store.state == 5 }        // delay elapsed → effect fires, loops 5 back
+        #expect(store.state == 5)
+    }
+
+    @Test func debounceCollapsesRapidDispatchesOnInjectedClock() async {
+        enum A: Sendable { case trigger, fired }
+        let clock = TestClock()
+        let store = Store(
+            initial: 0,
+            behavior: Behavior<A, Int, Void>.handle { action, _ in
+                switch action {
+                case .trigger: .produce { _ in Effect<A>.just(.fired).scheduling(.debounce(id: "d", delay: .seconds(1))) }
+                case .fired: .reduce { $0 += 1 }
+                }
+            },
+            environment: (),
+            clock: { _ in clock }
+        )
+        store.dispatch(.trigger)
+        await clock.waitForSleepers()
+        store.dispatch(.trigger)               // resets the timer: cancels the first pending task
+        await clock.waitForSleepers()
+        await clock.advance(by: .seconds(1))
+        await poll { store.state == 1 }
+        #expect(store.state == 1)              // collapsed to a single fire
+    }
+
+    @Test func throttleDropsWithinIntervalThenFiresAfterAdvance() async {
+        enum A: Sendable { case ping, tick }
+        let clock = TestClock()
+        let store = Store(
+            initial: 0,
+            behavior: Behavior<A, Int, Void>.handle { action, _ in
+                switch action {
+                case .ping: .produce { _ in Effect<A>.just(.tick).scheduling(.throttle(id: "t", interval: .seconds(1))) }
+                case .tick: .reduce { $0 += 1 }
+                }
+            },
+            environment: (),
+            clock: { _ in clock }
+        )
+        store.dispatch(.ping)
+        await poll { store.state == 1 }        // first one fires immediately
+        store.dispatch(.ping)                  // still within the interval → dropped
+        for _ in 0..<20 { await Task.yield() }
+        #expect(store.state == 1)
+        await clock.advance(by: .seconds(1))   // interval elapses on the injected clock
+        store.dispatch(.ping)
+        await poll { store.state == 2 }        // now fires again
+        #expect(store.state == 2)
     }
 }
 


### PR DESCRIPTION
## What
Replaces the `Store`'s ambient `Date()` / `UUID()` / `Task.sleep` with injected co-effects, so `EffectScheduling` timing and anonymous effect ids become pure and deterministic under test. Adds the `Hourglass` dependency for the type-erased clock.

## Why
Scheduling (debounce/throttle) previously read wall-clock `Date` and slept on `Task.sleep`, so timing-dependent behavior couldn't be tested deterministically and the Store reached for ambient global state. Injecting a clock lets tests drive debounce/throttle with a `TestClock`; injecting an RNG makes anonymous effect ids reproducible under a seed. This is also the groundwork for the upcoming decomposed effect engine.

## Changes
- **Store**
  - `init` now extracts co-effects from the environment: a generic `clock: (Environment) -> C` (erased to `Hourglass.AnyClock<Swift.Duration>` via `eraseToAnyClock()`, so `Store` carries no clock generic) and an `rng: (Environment) -> AnyRandomNumberGenerator` factory. Both default to a live `ContinuousClock` / system RNG through a non-generic convenience init (a generic parameter can't be inferred from an omitted defaulted argument, hence the split).
  - debounce sleeps on the injected clock (`clock.sleep(for:)`, negative delays clamped to `.zero`); throttle compares monotonic `clock.now` instants; anonymous `.immediately` ids come from `Gen<UUID>.uuid()` threaded through the injected RNG.
- **EffectScheduling**: `delay` / `interval` migrate `TimeInterval` -> `Duration` (cases + `@_disfavoredOverload` factories + docs).
- **Observer keys**: `Store` / `StoreBuffer` / `TestStore` observer-dictionary keys move from `UUID()` to a `UInt64` counter — they're internal and never surfaced, so no RNG is needed. Dropped now-stale `import Foundation` from `StoreProjection` / `StoreBuffer` / `TestStore` / `EffectScheduling`.
- **Package**: add `Hourglass` `from: 0.5.0`; bump the deployment floor to **macOS 13 / iOS 16 / tvOS 16 / watchOS 9** (required for `Duration` / `Clock`).
- **Tests**: new `StoreClockInjectionTests` (debounce fires only after `TestClock.advance`; debounce collapses rapid dispatches; throttle drops-within-interval-then-fires); migrated scheduling literals to `Duration`.

387 tests pass; SwiftLint `--strict` clean. `TestStore` still operates below the scheduling layer (honoring scheduling + manual time control is tracked as a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)