### PR TITLE
Add liftEach broadcast lifting (Reducer/Behavior/Middleware)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "97fba0dd82ab3a4c757198f7c9d2f930a42db8fac415d7a019242545a6f78bb5",
+  "originHash" : "1476c204db5156d2aa67ba76639556b02581ff9583d136d47109ad2c9d2b962c",
   "pins" : [
     {
       "identity" : "fp",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/FP.git",
       "state" : {
-        "revision" : "fe049b5f09218153072d24613aa5ce8acde26a16",
-        "version" : "1.10.0"
+        "revision" : "3868529570e57ebd307066d0c35eec05e3cc7d78",
+        "version" : "1.11.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "SwiftRex.Testing", targets: ["SwiftRexTesting"])
     ],
     dependencies: [
-        .package(url: "https://github.com/luizmb/FP.git", from: "1.10.0"),
+        .package(url: "https://github.com/luizmb/FP.git", from: "1.11.0"),
         .package(url: "https://github.com/luizmb/Hourglass.git", from: "0.5.0"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.2.0"),

--- a/Sources/SwiftRex/Behavior/Behavior+LiftEach.swift
+++ b/Sources/SwiftRex/Behavior/Behavior+LiftEach.swift
@@ -1,0 +1,205 @@
+import CoreFP
+import DataStructure
+
+// MARK: - liftEach (broadcast — fan-out only)
+//
+// `liftEach` is the 0..n sibling of ``Behavior/liftCollection(action:embed:stateContainer:)-``:
+// where `liftCollection` routes a global action to ONE element (selected by id), `liftEach`
+// runs the per-element behavior on EVERY element at once and folds the results.
+//
+// It has ONE job — fan-out. Each element's mutation is applied to that element; each element's
+// effect is scoped to that element's id (so element A's `.debounce(id: .fetch)` is independent
+// of element B's) and its output is re-wrapped by `embed`. To handle the addressed actions those
+// effects emit, compose this with ``Behavior/liftCollection`` on the same container.
+//
+//     Behavior.combine(
+//         perElement.liftEach(action: …tickAll…, embed: …ElementAction…, stateCollection: \.items),
+//         perElement.liftCollection(action: …ElementAction prism…, stateCollection: \.items)
+//     )
+
+extension Behavior {
+    /// Primitive — broadcast across an enumerated, addressable container, with a `Lens` container.
+    ///
+    /// - Parameters:
+    ///   - action: Resolves a global action into the local `Action` to broadcast to every element.
+    ///     Returns `nil` for global actions this behavior should ignore (a no-op).
+    ///   - embed: Re-wraps an action produced by an element's effect into the global action type,
+    ///     addressed at that element's `id`.
+    ///   - ids: Enumerates the ids of the elements currently present in the container.
+    ///   - element: Addresses one element by id as an `AffineTraversal` inside the container.
+    ///   - stateContainer: A `Lens` from the global state to the element container.
+    public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        ids: @escaping @Sendable (Container) -> [ID],
+        element: @escaping @Sendable (ID) -> AffineTraversal<Container, State>,
+        stateContainer: Lens<GS, Container>
+    ) -> Behavior<GA, GS, Environment> {
+        Behavior<GA, GS, Environment> { globalAction, context in
+            guard let local = action(globalAction), let global = context.stateBefore
+            else { return .doNothing }
+            let consequences: [Consequence<GS, Environment, GA>] = ids(stateContainer.get(global)).map { id in
+                let traversal = stateContainer.compose(element(id))
+                let scope = AnyHashableSendable(id)
+                let c = self.handle(local, context.compactMap(traversal.preview))
+                return Consequence(
+                    mutation: c.mutation.map { traversal.lift($0) },
+                    effect: c.effect
+                        .map { (eff: Effect<Action>) in eff.map { embed($0, id) }.scopedToElement(scope) }
+                        .contramapEnvironment { $0.compactMap(traversal.preview) }
+                )
+            }
+            return consequences.reduce(.doNothing, Consequence.combine)
+        }
+    }
+
+    /// Primitive — broadcast across an enumerated, addressable container, with a `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        ids: @escaping @Sendable (Container) -> [ID],
+        element: @escaping @Sendable (ID) -> AffineTraversal<Container, State>,
+        stateContainer: WritableKeyPath<GS, Container>
+    ) -> Behavior<GA, GS, Environment> {
+        liftEach(action: action, embed: embed, ids: ids, element: element, stateContainer: lens(stateContainer))
+    }
+}
+
+// MARK: - liftEach (Identifiable element)
+
+extension Behavior where State: Identifiable {
+    /// Broadcasts to every element of a mutable collection, keyed by `Identifiable.id`.
+    /// State container via `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, State.ID) -> GA,
+        stateCollection: WritableKeyPath<GS, C>
+    ) -> Behavior<GA, GS, Environment> where C.Element == State, C.Index: Sendable, State.ID: Sendable {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { $0.map(\.id) },
+            element: { C.ix(id: $0) },
+            stateContainer: lens(stateCollection)
+        )
+    }
+
+    /// Broadcasts to every element of a mutable collection, keyed by `Identifiable.id`.
+    /// State container via `Lens`.
+    public func liftEach<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, State.ID) -> GA,
+        stateCollection: Lens<GS, C>
+    ) -> Behavior<GA, GS, Environment> where C.Element == State, C.Index: Sendable, State.ID: Sendable {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { $0.map(\.id) },
+            element: { C.ix(id: $0) },
+            stateContainer: stateCollection
+        )
+    }
+}
+
+// MARK: - liftEach (custom Hashable identifier)
+
+extension Behavior {
+    /// Broadcasts to every element of a mutable collection, keyed by a custom `Hashable` field.
+    /// State container via `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        stateCollection: WritableKeyPath<GS, C>,
+        identifier: @escaping @Sendable (State) -> ID
+    ) -> Behavior<GA, GS, Environment> where C.Element == State, C.Index: Sendable {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { $0.map(identifier) },
+            element: { C.ix(id: $0, by: identifier) },
+            stateContainer: lens(stateCollection)
+        )
+    }
+
+    /// Broadcasts to every element of a mutable collection, keyed by a custom `Hashable` field.
+    /// State container via `Lens`.
+    public func liftEach<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        stateCollection: Lens<GS, C>,
+        identifier: @escaping @Sendable (State) -> ID
+    ) -> Behavior<GA, GS, Environment> where C.Element == State, C.Index: Sendable {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { $0.map(identifier) },
+            element: { C.ix(id: $0, by: identifier) },
+            stateContainer: stateCollection
+        )
+    }
+}
+
+// MARK: - liftEach (Dictionary key-based)
+
+extension Behavior {
+    /// Broadcasts to every value of a dictionary, keyed by its key. State container via `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, Key: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, Key) -> GA,
+        stateDictionary: WritableKeyPath<GS, [Key: State]>
+    ) -> Behavior<GA, GS, Environment> {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { Array($0.keys) },
+            element: { [Key: State].ix(key: $0) },
+            stateContainer: lens(stateDictionary)
+        )
+    }
+
+    /// Broadcasts to every value of a dictionary, keyed by its key. State container via `Lens`.
+    public func liftEach<GA: Sendable, GS: Sendable, Key: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, Key) -> GA,
+        stateDictionary: Lens<GS, [Key: State]>
+    ) -> Behavior<GA, GS, Environment> {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { Array($0.keys) },
+            element: { [Key: State].ix(key: $0) },
+            stateContainer: stateDictionary
+        )
+    }
+}
+
+// MARK: - liftEach (general container — IndexedTraversal)
+
+extension Behavior {
+    /// Broadcasts across every focus of an ``IndexedTraversal`` (any container, not just
+    /// collections); each focus's index is its scoping id. State container via `Lens`.
+    public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        each: IndexedTraversal<Container, ID, State>,
+        stateContainer: Lens<GS, Container>
+    ) -> Behavior<GA, GS, Environment> {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { each.getAll($0).map(\.0) },
+            element: { each.element($0) },
+            stateContainer: stateContainer
+        )
+    }
+
+    /// Broadcasts across every focus of an ``IndexedTraversal``. State container via `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        each: IndexedTraversal<Container, ID, State>,
+        stateContainer: WritableKeyPath<GS, Container>
+    ) -> Behavior<GA, GS, Environment> {
+        liftEach(action: action, embed: embed, each: each, stateContainer: lens(stateContainer))
+    }
+}

--- a/Sources/SwiftRex/Foundation/IndexedTraversal+Element.swift
+++ b/Sources/SwiftRex/Foundation/IndexedTraversal+Element.swift
@@ -1,0 +1,17 @@
+import CoreFP
+
+extension IndexedTraversal where I: Hashable & Sendable, S: Sendable, A: Sendable {
+    /// Derives an ``AffineTraversal`` addressing the single focus tagged with `id`.
+    ///
+    /// `preview` finds the `(id, focus)` pair; `setMut` writes back through this traversal's
+    /// `modifyMut`, touching only the matching focus. Used by `liftEach` to lift a per-element
+    /// mutation/effect for one element of an `IndexedTraversal`-described container.
+    func element(_ id: I) -> AffineTraversal<S, A> {
+        AffineTraversal(
+            preview: { @Sendable whole in self.getAll(whole).first { $0.0 == id }?.1 },
+            setMut: { @Sendable whole, newValue in
+                self.modifyMut(&whole) { index, focus in if index == id { focus = newValue } }
+            }
+        )
+    }
+}

--- a/Sources/SwiftRex/Middleware/Middleware+LiftEach.swift
+++ b/Sources/SwiftRex/Middleware/Middleware+LiftEach.swift
@@ -1,0 +1,192 @@
+import CoreFP
+import DataStructure
+
+// MARK: - liftEach (broadcast — fan-out only)
+//
+// The middleware counterpart of ``Behavior/liftEach``. `Middleware` carries no mutation, so the
+// broadcast folds the per-element effect readers: each element's effect is scoped to its id and
+// re-wrapped by `embed`, and all are merged via `Effect.combine`. Like the behavior version it
+// has ONE job — fan-out; compose with ``Middleware/liftCollection`` to handle the addressed
+// actions those effects emit.
+
+extension Middleware {
+    /// Primitive — broadcast across an enumerated, addressable container, with a `Lens` container.
+    ///
+    /// - Parameters:
+    ///   - action: Resolves a global action into the local `Action` to broadcast. `nil` ⇒ no-op.
+    ///   - embed: Re-wraps an element effect's output into the global action, addressed at its `id`.
+    ///   - ids: Enumerates the ids of the elements currently present in the container.
+    ///   - element: Addresses one element by id as an `AffineTraversal` inside the container.
+    ///   - stateContainer: A `Lens` from the global state to the container (only `get` is used).
+    public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        ids: @escaping @Sendable (Container) -> [ID],
+        element: @escaping @Sendable (ID) -> AffineTraversal<Container, State>,
+        stateContainer: Lens<GS, Container>
+    ) -> Middleware<GA, GS, Environment> {
+        Middleware<GA, GS, Environment> { globalAction, context in
+            guard let local = action(globalAction), let global = context.stateBefore
+            else { return Reader { _ in .empty } }
+            let readers: [Reader<PostReducerContext<GS, Environment>, Effect<GA>>] =
+                ids(stateContainer.get(global)).map { id in
+                    let traversal = stateContainer.compose(element(id))
+                    let scope = AnyHashableSendable(id)
+                    return self.handle(local, context.compactMap(traversal.preview))
+                        .map { (eff: Effect<Action>) in eff.map { embed($0, id) }.scopedToElement(scope) }
+                        .contramapEnvironment { $0.compactMap(traversal.preview) }
+                }
+            return Reader { ctx in readers.map { $0.runReader(ctx) }.reduce(.empty, Effect.combine) }
+        }
+    }
+
+    /// Primitive — broadcast across an enumerated, addressable container, with a `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        ids: @escaping @Sendable (Container) -> [ID],
+        element: @escaping @Sendable (ID) -> AffineTraversal<Container, State>,
+        stateContainer: WritableKeyPath<GS, Container>
+    ) -> Middleware<GA, GS, Environment> {
+        liftEach(action: action, embed: embed, ids: ids, element: element, stateContainer: lens(stateContainer))
+    }
+}
+
+// MARK: - liftEach (Identifiable element)
+
+extension Middleware where State: Identifiable {
+    /// Broadcasts to every element of a mutable collection, keyed by `Identifiable.id`.
+    /// State container via `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, State.ID) -> GA,
+        stateCollection: WritableKeyPath<GS, C>
+    ) -> Middleware<GA, GS, Environment> where C.Element == State, C.Index: Sendable, State.ID: Sendable {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { $0.map(\.id) },
+            element: { C.ix(id: $0) },
+            stateContainer: lens(stateCollection)
+        )
+    }
+
+    /// Broadcasts to every element of a mutable collection, keyed by `Identifiable.id`.
+    /// State container via `Lens`.
+    public func liftEach<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, State.ID) -> GA,
+        stateCollection: Lens<GS, C>
+    ) -> Middleware<GA, GS, Environment> where C.Element == State, C.Index: Sendable, State.ID: Sendable {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { $0.map(\.id) },
+            element: { C.ix(id: $0) },
+            stateContainer: stateCollection
+        )
+    }
+}
+
+// MARK: - liftEach (custom Hashable identifier)
+
+extension Middleware {
+    /// Broadcasts to every element of a mutable collection, keyed by a custom `Hashable` field.
+    /// State container via `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        stateCollection: WritableKeyPath<GS, C>,
+        identifier: @escaping @Sendable (State) -> ID
+    ) -> Middleware<GA, GS, Environment> where C.Element == State, C.Index: Sendable {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { $0.map(identifier) },
+            element: { C.ix(id: $0, by: identifier) },
+            stateContainer: lens(stateCollection)
+        )
+    }
+
+    /// Broadcasts to every element of a mutable collection, keyed by a custom `Hashable` field.
+    /// State container via `Lens`.
+    public func liftEach<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        stateCollection: Lens<GS, C>,
+        identifier: @escaping @Sendable (State) -> ID
+    ) -> Middleware<GA, GS, Environment> where C.Element == State, C.Index: Sendable {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { $0.map(identifier) },
+            element: { C.ix(id: $0, by: identifier) },
+            stateContainer: stateCollection
+        )
+    }
+}
+
+// MARK: - liftEach (Dictionary key-based)
+
+extension Middleware {
+    /// Broadcasts to every value of a dictionary, keyed by its key. State container via `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, Key: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, Key) -> GA,
+        stateDictionary: WritableKeyPath<GS, [Key: State]>
+    ) -> Middleware<GA, GS, Environment> {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { Array($0.keys) },
+            element: { [Key: State].ix(key: $0) },
+            stateContainer: lens(stateDictionary)
+        )
+    }
+
+    /// Broadcasts to every value of a dictionary, keyed by its key. State container via `Lens`.
+    public func liftEach<GA: Sendable, GS: Sendable, Key: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, Key) -> GA,
+        stateDictionary: Lens<GS, [Key: State]>
+    ) -> Middleware<GA, GS, Environment> {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { Array($0.keys) },
+            element: { [Key: State].ix(key: $0) },
+            stateContainer: stateDictionary
+        )
+    }
+}
+
+// MARK: - liftEach (general container — IndexedTraversal)
+
+extension Middleware {
+    /// Broadcasts across every focus of an ``IndexedTraversal`` (any container); each focus's
+    /// index is its scoping id. State container via `Lens`.
+    public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        each: IndexedTraversal<Container, ID, State>,
+        stateContainer: Lens<GS, Container>
+    ) -> Middleware<GA, GS, Environment> {
+        liftEach(
+            action: action,
+            embed: embed,
+            ids: { each.getAll($0).map(\.0) },
+            element: { each.element($0) },
+            stateContainer: stateContainer
+        )
+    }
+
+    /// Broadcasts across every focus of an ``IndexedTraversal``. State container via `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> Action?,
+        embed: @escaping @Sendable (Action, ID) -> GA,
+        each: IndexedTraversal<Container, ID, State>,
+        stateContainer: WritableKeyPath<GS, Container>
+    ) -> Middleware<GA, GS, Environment> {
+        liftEach(action: action, embed: embed, each: each, stateContainer: lens(stateContainer))
+    }
+}

--- a/Sources/SwiftRex/Reducer/Reducer+LiftEach.swift
+++ b/Sources/SwiftRex/Reducer/Reducer+LiftEach.swift
@@ -1,0 +1,81 @@
+import CoreFP
+import DataStructure
+
+// MARK: - liftEach (broadcast — Traversal)
+//
+// `liftEach` is the 0..n sibling of ``Reducer/liftCollection(action:stateContainer:)-``: where
+// `liftCollection` routes a global action to ONE element (selected by id), `liftEach` applies the
+// resolved local action to EVERY focus of a ``Traversal`` at once.
+//
+// A `Reducer` carries no effects, so the broadcast is just `Traversal.lift` of the per-element
+// reduce: each focus gets the same `EndoMut<StateType>` applied to its own state, zero-copy on
+// the array buffer. (Per-element effect-id scoping only matters for `Behavior`/`Middleware`.)
+
+extension Reducer {
+    /// Primitive — broadcast across a ``Traversal``, with a `Lens` state container.
+    ///
+    /// - Parameters:
+    ///   - action: Resolves a global action into the local `ActionType` to broadcast. Returns
+    ///     `nil` for global actions this reducer should ignore (a no-op).
+    ///   - each: The traversal selecting every target focus inside its container.
+    ///   - stateContainer: A `Lens` from the global state to the container.
+    public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable>(
+        action: @escaping @Sendable (GA) -> ActionType?,
+        each: Traversal<Container, StateType>,
+        stateContainer: Lens<GS, Container>
+    ) -> Reducer<GA, GS> {
+        .reduce { globalAction in
+            guard let local = action(globalAction) else { return .identity }
+            return stateContainer.compose(each).lift(self.reduce(local))
+        }
+    }
+
+    /// Primitive — broadcast across a ``Traversal``, with a `WritableKeyPath` state container.
+    public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable>(
+        action: @escaping @Sendable (GA) -> ActionType?,
+        each: Traversal<Container, StateType>,
+        stateContainer: WritableKeyPath<GS, Container>
+    ) -> Reducer<GA, GS> {
+        liftEach(action: action, each: each, stateContainer: lens(stateContainer))
+    }
+}
+
+// MARK: - liftEach (every element of a collection)
+
+extension Reducer {
+    /// Broadcasts to **every** element of a mutable collection. State container via `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable>(
+        action: @escaping @Sendable (GA) -> ActionType?,
+        stateCollection: WritableKeyPath<GS, C>
+    ) -> Reducer<GA, GS> where C.Element == StateType {
+        liftEach(action: action, each: C.each, stateContainer: lens(stateCollection))
+    }
+
+    /// Broadcasts to **every** element of a mutable collection. State container via `Lens`.
+    public func liftEach<GA: Sendable, GS: Sendable, C: MutableCollection & Sendable>(
+        action: @escaping @Sendable (GA) -> ActionType?,
+        stateCollection: Lens<GS, C>
+    ) -> Reducer<GA, GS> where C.Element == StateType {
+        liftEach(action: action, each: C.each, stateContainer: stateCollection)
+    }
+}
+
+// MARK: - liftEach (every value of a dictionary)
+
+extension Reducer {
+    /// Broadcasts to **every** value of a dictionary. State container via `WritableKeyPath`.
+    public func liftEach<GA: Sendable, GS: Sendable, Key: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> ActionType?,
+        stateDictionary: WritableKeyPath<GS, [Key: StateType]>
+    ) -> Reducer<GA, GS> {
+        liftEach(action: action, each: [Key: StateType].eachValue, stateContainer: lens(stateDictionary))
+    }
+
+    /// Broadcasts to **every** value of a dictionary. State container via `Lens`.
+    public func liftEach<GA: Sendable, GS: Sendable, Key: Hashable & Sendable>(
+        action: @escaping @Sendable (GA) -> ActionType?,
+        stateDictionary: Lens<GS, [Key: StateType]>
+    ) -> Reducer<GA, GS> {
+        liftEach(action: action, each: [Key: StateType].eachValue, stateContainer: stateDictionary)
+    }
+}

--- a/Tests/SwiftRexTests/BehaviorTests/Behavior+LiftEachTests.swift
+++ b/Tests/SwiftRexTests/BehaviorTests/Behavior+LiftEachTests.swift
@@ -1,0 +1,79 @@
+import CoreFP
+@testable import SwiftRex
+import Testing
+
+@Suite("Behavior liftEach")
+@MainActor
+struct BehaviorLiftEachTests {
+    private struct Timer: Identifiable, Equatable, Sendable {
+        let id: Int
+        var count: Int = 0
+        var ticked: Bool = false
+    }
+
+    private struct AppState: Equatable, Sendable {
+        var timers: [Timer]
+    }
+
+    private enum TimerAction: Sendable {
+        case tick
+        case didTick
+    }
+
+    private enum AppAction: Sendable {
+        case tickAll
+        case timer(ElementAction<Int, TimerAction>)
+    }
+
+    private static let timerPrism = CoreFP.prism(
+        preview: { (a: AppAction) -> ElementAction<Int, TimerAction>? in
+            guard case .timer(let ea) = a else { return nil }
+            return ea
+        },
+        review: { AppAction.timer($0) }
+    )
+
+    private func poll(until condition: @MainActor () -> Bool) async {
+        for _ in 0..<1_000 where !condition() { await Task.yield() }
+    }
+
+    @Test func broadcastsMutationToEveryElement() {
+        let perElement = Behavior<TimerAction, Timer, Void>.handle { action, _ in
+            switch action {
+            case .tick: .reduce { $0.count += 1 }
+            case .didTick: .doNothing
+            }
+        }
+        let lifted = perElement.liftEach(
+            action: { if case .tickAll = $0 { return TimerAction.tick } else { return nil } },
+            embed: { local, id in AppAction.timer(ElementAction(id, action: local)) },
+            stateCollection: \AppState.timers
+        )
+        let store = Store(initial: AppState(timers: [Timer(id: 1), Timer(id: 2), Timer(id: 3)]), behavior: lifted, environment: ())
+        store.dispatch(.tickAll)
+        #expect(store.state.timers.map(\.count) == [1, 1, 1])
+    }
+
+    // The recommended composition: liftEach fans out the trigger; each element's effect emits an
+    // addressed action that a combined liftCollection routes back to that element.
+    @Test func fansOutEffectsThatLoopBackPerElement() async {
+        let perElement = Behavior<TimerAction, Timer, Void>.handle { action, _ in
+            switch action {
+            case .tick: .produce { _ in Effect.just(.didTick) }
+            case .didTick: .reduce { $0.ticked = true }
+            }
+        }
+        let lifted = Behavior.combine(
+            perElement.liftEach(
+                action: { if case .tickAll = $0 { return TimerAction.tick } else { return nil } },
+                embed: { local, id in AppAction.timer(ElementAction(id, action: local)) },
+                stateCollection: \AppState.timers
+            ),
+            perElement.liftCollection(action: Self.timerPrism, stateCollection: \AppState.timers)
+        )
+        let store = Store(initial: AppState(timers: [Timer(id: 1), Timer(id: 2)]), behavior: lifted, environment: ())
+        store.dispatch(.tickAll)
+        await poll { store.state.timers.allSatisfy(\.ticked) }
+        #expect(store.state.timers.map(\.ticked) == [true, true])
+    }
+}

--- a/Tests/SwiftRexTests/MiddlewareTests/Middleware+LiftEachTests.swift
+++ b/Tests/SwiftRexTests/MiddlewareTests/Middleware+LiftEachTests.swift
@@ -1,0 +1,65 @@
+import CoreFP
+import DataStructure
+@testable import SwiftRex
+import Testing
+
+private struct Timer: Identifiable, Equatable, Sendable {
+    let id: Int
+    var ticked: Bool = false
+}
+
+private struct AppState: Equatable, Sendable {
+    var timers: [Timer]
+}
+
+private enum TimerAction: Sendable {
+    case tick
+    case didTick
+}
+
+private enum AppAction: Sendable {
+    case tickAll
+    case timer(ElementAction<Int, TimerAction>)
+}
+
+private let timerPrism = CoreFP.prism(
+    preview: { (a: AppAction) -> ElementAction<Int, TimerAction>? in
+        guard case .timer(let ea) = a else { return nil }
+        return ea
+    },
+    review: { AppAction.timer($0) }
+)
+
+@Suite("Middleware liftEach")
+@MainActor
+struct MiddlewareLiftEachTests {
+    private func poll(until condition: @MainActor () -> Bool) async {
+        for _ in 0..<1_000 where !condition() { await Task.yield() }
+    }
+
+    // Middleware fans out the trigger as effects; each element's effect loops back an addressed
+    // action that a liftCollection-lifted Reducer records — proving parity with Behavior.liftEach.
+    @Test func fansOutEffectsThatLoopBackPerElement() async {
+        let perElement = Middleware<TimerAction, Timer, Void>.handle { action, _ in
+            switch action {
+            case .tick: Reader { _ in Effect.just(.didTick) }
+            case .didTick: Reader { _ in .empty }
+            }
+        }
+        let recorder = Reducer<TimerAction, Timer>.reduce { action, timer in
+            if case .didTick = action { timer.ticked = true }
+        }
+        let behavior = Behavior(
+            reducer: recorder.liftCollection(action: { timerPrism.preview($0) }, stateCollection: \AppState.timers),
+            middleware: perElement.liftEach(
+                action: { if case .tickAll = $0 { return TimerAction.tick } else { return nil } },
+                embed: { local, id in AppAction.timer(ElementAction(id, action: local)) },
+                stateCollection: \AppState.timers
+            )
+        )
+        let store = Store(initial: AppState(timers: [Timer(id: 1), Timer(id: 2)]), behavior: behavior, environment: ())
+        store.dispatch(.tickAll)
+        await poll { store.state.timers.allSatisfy(\.ticked) }
+        #expect(store.state.timers.map(\.ticked) == [true, true])
+    }
+}

--- a/Tests/SwiftRexTests/ReducerTests/Reducer+LiftEachTests.swift
+++ b/Tests/SwiftRexTests/ReducerTests/Reducer+LiftEachTests.swift
@@ -1,0 +1,51 @@
+import CoreFP
+@testable import SwiftRex
+import Testing
+
+@Suite
+struct ReducerLiftEachTests {
+    private struct AppState: Equatable {
+        var nums: [Int] = []
+        var lookup: [String: Int] = [:]
+    }
+
+    private enum AppAction {
+        case bumpAll(Int)
+        case other
+    }
+
+    private let bump = Reducer<Int, Int>.reduce { delta, n in n += delta }
+
+    private func delta(_ action: AppAction) -> Int? {
+        guard case .bumpAll(let d) = action else { return nil }
+        return d
+    }
+
+    @Test func broadcastsToEveryArrayElement() {
+        let lifted = bump.liftEach(action: delta, stateCollection: \AppState.nums)
+        var state = AppState(nums: [1, 2, 3])
+        lifted.reduce(.bumpAll(10))(&state)
+        #expect(state.nums == [11, 12, 13])
+    }
+
+    @Test func ignoresUnmatchedAction() {
+        let lifted = bump.liftEach(action: delta, stateCollection: \AppState.nums)
+        var state = AppState(nums: [1, 2, 3])
+        lifted.reduce(.other)(&state)
+        #expect(state.nums == [1, 2, 3])
+    }
+
+    @Test func emptyCollectionIsNoOp() {
+        let lifted = bump.liftEach(action: delta, stateCollection: \AppState.nums)
+        var state = AppState(nums: [])
+        lifted.reduce(.bumpAll(10))(&state)
+        #expect(state.nums == [])
+    }
+
+    @Test func broadcastsToEveryDictionaryValue() {
+        let lifted = bump.liftEach(action: delta, stateDictionary: \AppState.lookup)
+        var state = AppState(lookup: ["a": 1, "b": 2])
+        lifted.reduce(.bumpAll(5))(&state)
+        #expect(state.lookup == ["a": 6, "b": 7])
+    }
+}


### PR DESCRIPTION
## What
Adds `liftEach` — the 0..n generalization of `liftCollection`. Where `liftCollection` routes a global action to **one** element (by id), `liftEach` applies a per-element `Reducer`/`Behavior`/`Middleware` across **every** element of a collection/traversal at once. Built on the `Traversal`/`IndexedTraversal` optics from FP **1.11.0**.

## Why
Some features broadcast: a single global action (a tick, a refresh, a "select all") must run the same per-element logic on every element, with each element's effects kept independent. `liftCollection` only addresses one element; this fills the broadcast gap.

## Design — one job each
`liftEach` is **fan-out only**:
- Each element's **mutation** is applied to that element.
- Each element's **effect** is scoped to its id (`ElementScopedID`, so element A's `.debounce(id: .fetch)` can't cancel B's) and its output is re-wrapped by `embed`.
- The addressed actions those effects emit are handled by a **separately composed `liftCollection`** — the two compose, and neither re-implements the other:

```swift
Behavior.combine(
    perElement.liftEach(action: …tickAll…, embed: { l, id in .timer(ElementAction(id, action: l)) }, stateCollection: \.timers),
    perElement.liftCollection(action: timerPrism, stateCollection: \.timers)
)
```

## Changes
- `Sources/SwiftRex/Reducer/Reducer+LiftEach.swift` — pure broadcast (no effects): `stateContainer.compose(each).lift(self.reduce(local))`. Collection (`each`) + dictionary (`eachValue`) sugar.
- `Sources/SwiftRex/Behavior/Behavior+LiftEach.swift` — folds per-element `Consequence`s (`Consequence` Monoid). `handle` is `@MainActor`, so it enumerates the present elements via `context.stateBefore`.
- `Sources/SwiftRex/Middleware/Middleware+LiftEach.swift` — folds per-element effect `Reader`s via `Effect.combine` (no mutation).
- `Sources/SwiftRex/Foundation/IndexedTraversal+Element.swift` — internal helper deriving a per-focus `AffineTraversal` from an `IndexedTraversal`.
- All three identity mechanisms (Identifiable `\.id`, custom `(State) -> ID` extractor, general `IndexedTraversal`) + dictionary-by-key, in `Lens` and `WritableKeyPath` container forms.
- `Package.swift`: FP pin `1.10.0` → `1.11.0` (released tag).

## Tests
- Reducer: array/dict broadcast, unmatched-action no-op, empty-collection no-op.
- Behavior: mutation broadcast to all; end-to-end fan-out → per-element effect → addressed loop-back via the `liftEach` + `liftCollection` composition.
- Middleware: fan-out effect looping back per element.

394 tests pass; SwiftLint `--strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)