### PR TITLE
@Feature: synthesize initialState(), drop @dynamicMemberLookup guidance

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "1476c204db5156d2aa67ba76639556b02581ff9583d136d47109ad2c9d2b962c",
+  "originHash" : "9249e3631fa1816298ebc84d8cee92c8654069a5fdb698b25874525a22718816",
   "pins" : [
     {
       "identity" : "fp",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/FP.git",
       "state" : {
-        "revision" : "3868529570e57ebd307066d0c35eec05e3cc7d78",
-        "version" : "1.11.0"
+        "revision" : "7d94724b29c47cc60695fe6c4d6cb813f25341aa",
+        "version" : "1.11.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "SwiftRex.Testing", targets: ["SwiftRexTesting"])
     ],
     dependencies: [
-        .package(url: "https://github.com/luizmb/FP.git", from: "1.11.0"),
+        .package(url: "https://github.com/luizmb/FP.git", from: "1.11.1"),
         .package(url: "https://github.com/luizmb/Hourglass.git", from: "0.5.0"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.2.0"),

--- a/Sources/SwiftRexArchitecture/Feature.swift
+++ b/Sources/SwiftRexArchitecture/Feature.swift
@@ -25,7 +25,6 @@ import SwiftUI
 ///         var error:     Domain.NetworkError? = nil
 ///     }
 ///
-///     @dynamicMemberLookup
 ///     enum Action: Sendable {
 ///         case fetchMovies
 ///         case moviesResponse(Result<[Domain.Movie], Domain.NetworkError>)
@@ -46,7 +45,6 @@ import SwiftUI
 ///             }
 ///             var rows: [MovieRow]; var isLoading: Bool; var error: String?
 ///         }
-///         @dynamicMemberLookup
 ///         enum ViewAction: Sendable {
 ///             case onAppear
 ///             case didTapStar(id: String)

--- a/Sources/SwiftRexArchitecture/Macros.swift
+++ b/Sources/SwiftRexArchitecture/Macros.swift
@@ -16,13 +16,13 @@
 /// - Applies `@Prisms` to the nested `Action` enum (for ``TestStore`` `receive` assertions)
 /// - Applies `@Lenses` to the nested `State` struct (for `liftState` ergonomics)
 /// - Applies `@ViewModel` to the nested `ViewModel` class (no manual annotation needed)
+/// - Synthesizes `static func initialState() -> State { .init() }` when you don't write one
 ///
 /// ```swift
 /// @Feature
 /// enum MoviesFeature {
 ///     struct State: Sendable { ... }         // @Lenses applied automatically
 ///
-///     @dynamicMemberLookup                   // see note below
 ///     enum Action: Sendable { ... }          // @Prisms applied automatically
 ///
 ///     struct Environment: Sendable { ... }
@@ -31,7 +31,8 @@
 ///
 ///     static let mapState = ...
 ///     static let mapAction = ...
-///     static func initialState() -> State { .init() }
+///     // `initialState()` is synthesized as `State.init()` — declare your own only when
+///     // `State` lacks an empty initializer (a property without a default value).
 ///     static func behavior() -> Behavior<Action, State, Environment> { ... }
 ///
 ///     typealias Content = MovieListView      // still required — links feature to its view
@@ -40,18 +41,8 @@
 ///
 /// Because `@Feature` re-exports `FPMacros`, importing `SwiftRexArchitecture` is sufficient —
 /// no explicit `import FPMacros` is needed in the file where `@Feature` is used.
-///
-/// ## `@dynamicMemberLookup` is your job
-///
-/// `@Prisms` emits one focus-getter per case (`var caseName: Focus? { ... }`) and
-/// warns that you should add `@dynamicMemberLookup` to collapse them into a single
-/// subscript. Swift's macro expansion order prevents `@Feature` from attaching
-/// `@dynamicMemberLookup` automatically: when `@Prisms` expands on `Action`, it
-/// does not observe attributes added by `@Feature`'s sibling MemberAttributeMacro
-/// pass. Add `@dynamicMemberLookup` to `Action` (and to `ViewModel.ViewAction`)
-/// yourself if you want the subscript form and a clean build. Functionality is
-/// unchanged either way — only the generated shape differs.
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@attached(member, names: named(initialState))
 @attached(memberAttribute)
 @attached(extension, conformances: Feature)
 public macro Feature() = #externalMacro(module: "SwiftRexMacros", type: "FeatureMacro")

--- a/Sources/SwiftRexMacros/FeatureMacro.swift
+++ b/Sources/SwiftRexMacros/FeatureMacro.swift
@@ -7,15 +7,28 @@ import SwiftSyntaxMacros
 /// - `MemberAttributeMacro` — adds `@Prisms` to nested `Action` enum,
 ///                            `@Lenses` to nested `State` struct, and
 ///                            `@ViewModel` to nested `ViewModel` class.
-///
-/// `@Prisms` will emit a warning suggesting `@dynamicMemberLookup` to collapse
-/// per-case property accessors into a single subscript. Swift's macro expansion
-/// order prevents us from attaching `@dynamicMemberLookup` automatically here —
-/// when `@Prisms` expands on `Action`, it cannot observe attributes added by
-/// this same MemberAttributeMacro pass, so it always takes the per-case branch.
-/// Users wanting the subscript form should add `@dynamicMemberLookup` to their
-/// `Action` enum directly.
-public struct FeatureMacro: ExtensionMacro, MemberAttributeMacro {
+/// - `MemberMacro`          — synthesizes `static func initialState() -> State { .init() }`
+///                            when the feature has a nested `State` and hasn't written its own.
+public struct FeatureMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro {
+    // MARK: - MemberMacro
+
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        // `initialState()` defaults to `State.init()` — the common case where every
+        // `State` property has a default. Only synthesize when the feature has a nested
+        // `State` type and hasn't supplied its own `initialState()`; a `State` without an
+        // empty initializer must declare `initialState()` explicitly.
+        guard declaration.is(EnumDeclSyntax.self),
+              hasNestedType("State", in: declaration),
+              !hasInitialState(in: declaration)
+        else { return [] }
+        return ["static func initialState() -> State { .init() }"]
+    }
+
     // MARK: - ExtensionMacro
 
     public static func expansion(
@@ -40,20 +53,20 @@ public struct FeatureMacro: ExtensionMacro, MemberAttributeMacro {
         providingAttributesFor member: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [AttributeSyntax] {
-        // Add @Prisms to nested `enum Action`
+        // Add @Prisms (prism namespace + cases) to nested `enum Action`
         if let enumDecl = member.as(EnumDeclSyntax.self), enumDecl.name.text == "Action" {
             guard !hasAttribute("Prisms", on: enumDecl.attributes) else { return [] }
-            return [AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier("Prisms")))]
+            return ["@Prisms"]
         }
         // Add @Lenses to nested `struct State`
         if let structDecl = member.as(StructDeclSyntax.self), structDecl.name.text == "State" {
             guard !hasAttribute("Lenses", on: structDecl.attributes) else { return [] }
-            return [AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier("Lenses")))]
+            return ["@Lenses"]
         }
         // Add @ViewModel to nested `class ViewModel`
         if let classDecl = member.as(ClassDeclSyntax.self), classDecl.name.text == "ViewModel" {
             guard !hasAttribute("ViewModel", on: classDecl.attributes) else { return [] }
-            return [AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier("ViewModel")))]
+            return ["@ViewModel"]
         }
         return []
     }
@@ -66,6 +79,25 @@ public struct FeatureMacro: ExtensionMacro, MemberAttributeMacro {
                 .attributeName
                 .as(IdentifierTypeSyntax.self)?
                 .name.text == name
+        }
+    }
+
+    /// Whether the feature declares a nested type (struct/enum/class/actor/typealias) with `name`.
+    private static func hasNestedType(_ name: String, in declaration: some DeclGroupSyntax) -> Bool {
+        declaration.memberBlock.members.contains { member in
+            let decl = member.decl
+            return decl.as(StructDeclSyntax.self)?.name.text == name
+                || decl.as(EnumDeclSyntax.self)?.name.text == name
+                || decl.as(ClassDeclSyntax.self)?.name.text == name
+                || decl.as(ActorDeclSyntax.self)?.name.text == name
+                || decl.as(TypeAliasDeclSyntax.self)?.name.text == name
+        }
+    }
+
+    /// Whether the feature already declares an `initialState` function (user-supplied override).
+    private static func hasInitialState(in declaration: some DeclGroupSyntax) -> Bool {
+        declaration.memberBlock.members.contains {
+            $0.decl.as(FunctionDeclSyntax.self)?.name.text == "initialState"
         }
     }
 }

--- a/Tests/SwiftRexArchitectureTests/FeatureTests.swift
+++ b/Tests/SwiftRexArchitectureTests/FeatureTests.swift
@@ -207,4 +207,119 @@ struct ViewModelTests {
         #expect(vm.threatIndex == 3)
     }
 }
+
+// MARK: - @Feature macro — initialState synthesis
+//
+// Exercises the `@Feature` macro end-to-end (extension + memberAttribute + member roles).
+// This fixture deliberately omits `initialState()` — `@Feature` synthesizes it as `State.init()`.
+
+private struct CounterView: View, HasViewModel {
+    typealias VM = CounterFeature.ViewModel
+    let viewModel: CounterFeature.ViewModel
+    var body: Never { fatalError("test stub") }
+}
+
+@Feature
+private enum CounterFeature {
+    struct State: Sendable {
+        var count: Int = 7
+        var label: String = "ready"
+    }
+
+    enum Action: Sendable, Equatable {
+        case increment
+    }
+
+    struct Environment: Sendable {}
+
+    // swiftlint:disable:next convenience_type
+    final class ViewModel {
+        struct ViewState: Sendable, Equatable {
+            var count: Int
+        }
+        enum ViewAction: Sendable {
+            case tapped
+        }
+    }
+
+    static let mapState: @MainActor @Sendable (State) -> ViewModel.ViewState = { .init(count: $0.count) }
+    static let mapAction: @Sendable (ViewModel.ViewAction) -> Action = { _ in .increment }
+
+    // No `initialState()` here — synthesized by `@Feature`.
+
+    static func behavior() -> Behavior<Action, State, Environment> {
+        Reducer.reduce { (action: Action, state: inout State) in
+            switch action {
+            case .increment: state.count += 1
+            }
+        }.asBehavior()
+    }
+
+    typealias Content = CounterView
+}
+
+// A feature that supplies its own `initialState()` — `@Feature` must NOT also synthesize one
+// (a second declaration would be an "invalid redeclaration" compile error).
+
+private struct OverrideView: View, HasViewModel {
+    typealias VM = OverrideFeature.ViewModel
+    let viewModel: OverrideFeature.ViewModel
+    var body: Never { fatalError("test stub") }
+}
+
+@Feature
+private enum OverrideFeature {
+    struct State: Sendable {
+        var count: Int = 0
+    }
+
+    enum Action: Sendable, Equatable {
+        case noop
+    }
+
+    struct Environment: Sendable {}
+
+    // swiftlint:disable:next convenience_type
+    final class ViewModel {
+        struct ViewState: Sendable, Equatable {
+            var count: Int
+        }
+        enum ViewAction: Sendable {
+            case tapped
+        }
+    }
+
+    static let mapState: @MainActor @Sendable (State) -> ViewModel.ViewState = { .init(count: $0.count) }
+    static let mapAction: @Sendable (ViewModel.ViewAction) -> Action = { _ in .noop }
+
+    static func initialState() -> State { .init(count: 99) }
+
+    static func behavior() -> Behavior<Action, State, Environment> {
+        Reducer.reduce { (_: Action, _: inout State) in }.asBehavior()
+    }
+
+    typealias Content = OverrideView
+}
+
+@Suite("@Feature — initialState synthesis")
+struct FeatureInitialStateTests {
+    @Test func synthesizesInitialStateFromStateDefaults() {
+        let state = CounterFeature.initialState()
+        #expect(state.count == 7)
+        #expect(state.label == "ready")
+    }
+
+    @Test func attachesPrismsNamespaceToAction() {
+        // Confirms `@Feature` attaches `@Prisms`: the prism namespace exists…
+        #expect(CounterFeature.Action.prism.increment.preview(.increment) != nil)
+        // …and the cases mirror is emitted.
+        #expect(CounterFeature.Action.increment.is(.increment))
+    }
+
+    @Test func userSuppliedInitialStateWins() {
+        // Compiles only because `@Feature` skipped synthesis (no redeclaration), and returns
+        // the user's value rather than `State.init()` defaults.
+        #expect(OverrideFeature.initialState().count == 99)
+    }
+}
 #endif


### PR DESCRIPTION
## What
`@Feature` now synthesizes `initialState()` and stops shipping the obsolete `@dynamicMemberLookup` guidance, on the back of FP 1.11.1.

## Why
Two things were boilerplate or stale:
- Every feature whose `State` has an empty initializer still had to hand-write `static func initialState() -> State { .init() }`.
- `@Feature` and its docs told users to add `@dynamicMemberLookup` to `Action` to silence a `@Prisms` warning. FP 1.11.1 removed that warning (and the per-case accessor it came from), so the guidance is now misleading.

## Changes
- **`FeatureMacro`**: add a `MemberMacro` role that emits `static func initialState() -> State { .init() }` — only when the host is an enum with a nested `State` and no existing `initialState()` (so a feature that writes its own is untouched, no redeclaration).
- **Docs cleanup**: remove the "`@dynamicMemberLookup` is your job" section from `Macros.swift`, the matching note in `FeatureMacro.swift`, and the `@dynamicMemberLookup` lines from the `Feature.swift` doc example; drop the now-synthesized `initialState()` line from the `@Feature` example.
- **Tests**: first end-to-end `@Feature` macro fixtures — one that omits `initialState()` (proves synthesis), one that supplies its own (proves no redeclaration), plus a prism-namespace assertion.
- **Dependency**: bump FP to `1.11.1`.

403 tests pass; `swiftlint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)