### PR TITLE
feat: add package-benchmark suite (nested package, non-gating CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,27 @@ jobs:
 
       - name: Test
         run: swift test 2>&1
+
+  # Non-gating: builds and runs the nested BenchmarkSuite package (which pulls in
+  # package-benchmark + jemalloc — kept out of the main package). `continue-on-error`
+  # ensures it never blocks a PR; it exists to surface dispatch-throughput and
+  # CoW/allocation numbers, not to gate. Baselines/thresholds can be added later.
+  benchmarks:
+    name: Benchmarks (non-gating)
+    runs-on: macos-26
+    continue-on-error: true
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+
+      - name: Install jemalloc
+        run: brew install jemalloc
+
+      - name: Run benchmarks
+        working-directory: BenchmarkSuite
+        run: swift package --disable-sandbox benchmark --no-progress

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,6 +44,7 @@ excluded:
   - Sources/SwiftRex/__Generated__
   - Pods
   - .build
+  - BenchmarkSuite/.build
   - DerivedData
   - "Tests/*/XCTestManifests.swift"
   - .claude

--- a/BenchmarkSuite/Benchmarks/SwiftRexBenchmarks/Fixtures.swift
+++ b/BenchmarkSuite/Benchmarks/SwiftRexBenchmarks/Fixtures.swift
@@ -1,0 +1,65 @@
+import CoreFP
+import SwiftRex
+
+// MARK: - Single-feature fixtures
+
+struct BenchState: Sendable, Equatable {
+    var counter: Int = 0
+    // A large copy-on-write array used to detect accidental whole-state copies.
+    var payload: [Int] = []
+}
+
+enum BenchAction: Sendable {
+    case tick
+}
+
+// A trivial leaf reducer that mutates only the scalar field, leaving `payload` untouched.
+let tickReducer = Reducer<BenchAction, BenchState>.reduce { _, state in
+    state.counter += 1
+}
+
+// 800 KB of Ints — large enough that a stray whole-array copy would dominate wall clock.
+let largePayloadSize = 100_000
+
+// MARK: - Collection fixtures (lift / liftEach / liftCollection / projection)
+
+struct Item: Sendable, Equatable {
+    var id: Int
+    var n: Int = 0
+}
+
+enum ItemAction: Sendable {
+    case bump
+}
+
+let itemReducer = Reducer<ItemAction, Item>.reduce { _, item in
+    item.n += 1
+}
+
+struct ListState: Sendable, Equatable {
+    var items: [Item]
+}
+
+enum ListAction: Sendable {
+    case bumpAll
+    case item(ElementAction<Int, ItemAction>)
+}
+
+// A list of `count` items with ids 0..<count.
+func makeList(_ count: Int) -> ListState {
+    ListState(items: (0..<count).map { Item(id: $0) })
+}
+
+let collectionSize = 1_000
+
+// MARK: - Global fixtures (single-target lift)
+
+struct GlobalState: Sendable, Equatable {
+    var local: BenchState = .init()
+    var other: Int = 0
+}
+
+enum GlobalAction: Sendable {
+    case local(BenchAction)
+    case other
+}

--- a/BenchmarkSuite/Benchmarks/SwiftRexBenchmarks/StoreBenchmarks.swift
+++ b/BenchmarkSuite/Benchmarks/SwiftRexBenchmarks/StoreBenchmarks.swift
@@ -1,0 +1,92 @@
+import Benchmark
+import CoreFP
+import SwiftRex
+
+// Store, StoreProjection and StoreBuffer are all `@MainActor`, so these run the measured loop
+// inside a single `MainActor.run` hop (amortised across all scaled iterations). `scaledIterations`
+// is captured before the hop so the non-Sendable `benchmark` never crosses the actor boundary.
+// Behaviors used here are effect-free, so each `dispatch` completes synchronously on the main actor.
+
+func storeDispatchBenchmarks() {
+    // End-to-end dispatch through the full three-phase pipeline (DispatchedAction wrapping,
+    // phase 1 handle, phase 2 mutation, observer hooks) — the real per-action cost.
+    Benchmark("Store.dispatch — reducer only") { benchmark in
+        let iterations = benchmark.scaledIterations
+        await MainActor.run {
+            let store = Store(initial: BenchState(), reducer: tickReducer)
+            for _ in iterations {
+                store.dispatch(.tick)
+                blackHole(store.state.counter)
+            }
+        }
+    }
+
+    // Same, but the behavior is reducer + (identity) middleware — isolates the cost of routing
+    // through the Consequence's effect half vs the reducer-only path above.
+    Benchmark("Store.dispatch — reducer + middleware") { benchmark in
+        let iterations = benchmark.scaledIterations
+        await MainActor.run {
+            let store: Store<BenchAction, BenchState, Void> = Store(
+                initial: BenchState(),
+                reducer: tickReducer,
+                middleware: Middleware.identity,
+                environment: ()
+            )
+            for _ in iterations {
+                store.dispatch(.tick)
+                blackHole(store.state.counter)
+            }
+        }
+    }
+
+    // Dispatch through 8 combined behaviors — exercises Behavior.combine / Consequence.combine
+    // execution (each phase-1 handle runs and the consequences are merged) per dispatch.
+    let combinedBehavior: Behavior<BenchAction, BenchState, Void> =
+        mconcat(Array(repeating: tickReducer.asBehavior(), count: 8))
+    Benchmark("Store.dispatch — combined behavior x8") { benchmark in
+        let iterations = benchmark.scaledIterations
+        await MainActor.run {
+            let store: Store<BenchAction, BenchState, Void> = Store(initial: BenchState(), behavior: combinedBehavior)
+            for _ in iterations {
+                store.dispatch(.tick)
+                blackHole(store.state.counter)
+            }
+        }
+    }
+}
+
+func storeReadBenchmarks() {
+    // StoreProjection element read — `state` recomputes `collection.first { id matches }` on every
+    // access: O(n) per read over a 1,000-element collection. This is roadmap item 23's baseline.
+    let targetId = collectionSize - 1
+    Benchmark("StoreProjection.state — by id in \(collectionSize)") { benchmark in
+        let iterations = benchmark.scaledIterations
+        await MainActor.run {
+            let store: Store<ListAction, ListState, Void> = Store(initial: makeList(collectionSize), reducer: .identity)
+            let projection = StoreProjection<ItemAction, Item?>(
+                store: store,
+                element: targetId,
+                actionReview: { (ea: ElementAction<Int, ItemAction>) in ListAction.item(ea) },
+                stateCollection: \ListState.items,
+                identifier: { (item: Item) in item.id }
+            )
+            for _ in iterations {
+                blackHole(projection.state?.n)
+            }
+        }
+    }
+
+    // Dispatch through a StoreBuffer — the underlying mutation fires `didChange`, the buffer runs
+    // its `hasChanged` (Equatable) predicate and gates its own observers. Measures the dedup path.
+    Benchmark("StoreBuffer.dispatch — gated") { benchmark in
+        let iterations = benchmark.scaledIterations
+        await MainActor.run {
+            let store = Store(initial: BenchState(), reducer: tickReducer)
+            let buffer = StoreBuffer(store)
+            for _ in iterations {
+                buffer.dispatch(.tick)
+                blackHole(buffer.state.counter)
+            }
+        }
+    }
+}

--- a/BenchmarkSuite/Benchmarks/SwiftRexBenchmarks/SwiftRexBenchmarks.swift
+++ b/BenchmarkSuite/Benchmarks/SwiftRexBenchmarks/SwiftRexBenchmarks.swift
@@ -2,54 +2,40 @@ import Benchmark
 import CoreFP
 import SwiftRex
 
-// MARK: - Fixtures
-
-private struct BenchState: Sendable {
-    var counter: Int = 0
-    // A large copy-on-write array used to detect accidental whole-state copies.
-    var payload: [Int]
-}
-
-private enum BenchAction: Sendable {
-    case tick
-}
-
-// A trivial leaf reducer that mutates only the scalar field, leaving `payload` untouched.
-private let tickReducer = Reducer<BenchAction, BenchState>.reduce { _, state in
-    state.counter += 1
-}
-
-// 800 KB of Ints — large enough that a stray whole-array copy would dominate wall clock.
-private let largePayloadSize = 100_000
-
-// MARK: - Benchmarks
-
 let benchmarks: @Sendable () -> Void = {
-    // 1. Single-reducer dispatch throughput — the synchronous hot path
-    //    (`reduce(action).runEndoMut(&state)`) the Store runs in phase 2 of every dispatch.
+    reduceBenchmarks()
+    liftBenchmarks()
+    storeDispatchBenchmarks()
+    storeReadBenchmarks()
+}
+
+// MARK: - Reducer / EndoMut (synchronous reduce path)
+
+func reduceBenchmarks() {
+    // Single-reducer dispatch throughput — the synchronous hot path
+    // (`reduce(action).runEndoMut(&state)`) the Store runs in phase 2 of every dispatch.
     Benchmark("Reducer.reduce — single") { benchmark in
-        var state = BenchState(payload: [])
+        var state = BenchState()
         for _ in benchmark.scaledIterations {
             tickReducer.reduce(.tick).runEndoMut(&state)
             blackHole(state.counter)
         }
     }
 
-    // 2. Composition of 64 reducers via `mconcat` — the N-deep closure tree that roadmap
-    //    item 21 (flat array-based folds) aims to flatten. This is the before-baseline.
+    // Composition of 64 reducers via `mconcat` — the N-deep closure tree that roadmap item 21
+    // (flat array-based folds) aims to flatten. This is the before-baseline.
     let combined = mconcat(Array(repeating: tickReducer, count: 64))
     Benchmark("Reducer.combine x64 — reduce") { benchmark in
-        var state = BenchState(payload: [])
+        var state = BenchState()
         for _ in benchmark.scaledIterations {
             combined.reduce(.tick).runEndoMut(&state)
             blackHole(state.counter)
         }
     }
 
-    // 3. EndoMut zero-copy guard: apply a scalar-field mutation to a state holding a large
-    //    array. EndoMut runs the mutation through `inout`, so `payload` must NOT be copied —
-    //    its wall clock should track the raw control below (#4), independent of array size.
-    //    A regression to whole-state copying would make this scale with `largePayloadSize`.
+    // EndoMut zero-copy guard: apply a scalar-field mutation to a state holding a large array.
+    // EndoMut runs the mutation through `inout`, so `payload` must NOT be copied — its wall
+    // clock should track the raw control below, independent of array size.
     Benchmark(
         "EndoMut zero-copy — large state",
         configuration: .init(metrics: [.wallClock, .throughput, .mallocCountTotal])
@@ -62,9 +48,8 @@ let benchmarks: @Sendable () -> Void = {
         }
     }
 
-    // 4. Raw in-place field mutation — the zero-copy reference for #3. Same state shape,
-    //    no EndoMut. #3 staying level with this confirms the EndoMut abstraction adds no
-    //    array-size-proportional cost.
+    // Raw in-place field mutation — the zero-copy reference for the benchmark above. #3 staying
+    // level with this confirms the EndoMut abstraction adds no array-size-proportional cost.
     Benchmark(
         "EndoMut zero-copy — raw control",
         configuration: .init(metrics: [.wallClock, .throughput, .mallocCountTotal])
@@ -73,6 +58,59 @@ let benchmarks: @Sendable () -> Void = {
         for _ in benchmark.scaledIterations {
             state.counter += 1
             blackHole(state.counter)
+        }
+    }
+}
+
+// MARK: - lift / liftEach / liftCollection (optic cost per dispatch)
+
+func liftBenchmarks() {
+    // Single-target lift through getter/setter closures (the Lens path). Measures the per-dispatch
+    // optic overhead vs the un-lifted `Reducer.reduce — single` baseline.
+    let lifted = tickReducer.lift(
+        actionGetter: { (g: GlobalAction) -> BenchAction? in
+            if case .local(let a) = g { a } else { nil }
+        },
+        stateGetter: { (g: GlobalState) in g.local },
+        stateSetter: { (g: inout GlobalState, s: BenchState) in g.local = s }
+    )
+    Benchmark("Reducer.lift — single target") { benchmark in
+        var state = GlobalState()
+        for _ in benchmark.scaledIterations {
+            lifted.reduce(.local(.tick)).runEndoMut(&state)
+            blackHole(state.local.counter)
+        }
+    }
+
+    // Broadcast to EVERY element of a 1,000-element collection — O(n) per dispatch.
+    let liftedEach = itemReducer.liftEach(
+        action: { (a: ListAction) -> ItemAction? in
+            if case .bumpAll = a { .bump } else { nil }
+        },
+        stateCollection: \ListState.items
+    )
+    Benchmark("Reducer.liftEach — broadcast \(collectionSize)") { benchmark in
+        var state = makeList(collectionSize)
+        for _ in benchmark.scaledIterations {
+            liftedEach.reduce(.bumpAll).runEndoMut(&state)
+            blackHole(state.items[0].n)
+        }
+    }
+
+    // Target ONE element by id in a 1,000-element collection — O(n) lookup per dispatch.
+    let liftedColl = itemReducer.liftCollection(
+        action: { (a: ListAction) -> ElementAction<Int, ItemAction>? in
+            if case .item(let ea) = a { ea } else { nil }
+        },
+        stateCollection: \ListState.items,
+        identifier: { (item: Item) in item.id }
+    )
+    let targetId = collectionSize - 1
+    Benchmark("Reducer.liftCollection — by id in \(collectionSize)") { benchmark in
+        var state = makeList(collectionSize)
+        for _ in benchmark.scaledIterations {
+            liftedColl.reduce(.item(ElementAction(targetId, action: .bump))).runEndoMut(&state)
+            blackHole(state.items[targetId].n)
         }
     }
 }

--- a/BenchmarkSuite/Benchmarks/SwiftRexBenchmarks/SwiftRexBenchmarks.swift
+++ b/BenchmarkSuite/Benchmarks/SwiftRexBenchmarks/SwiftRexBenchmarks.swift
@@ -1,0 +1,78 @@
+import Benchmark
+import CoreFP
+import SwiftRex
+
+// MARK: - Fixtures
+
+private struct BenchState: Sendable {
+    var counter: Int = 0
+    // A large copy-on-write array used to detect accidental whole-state copies.
+    var payload: [Int]
+}
+
+private enum BenchAction: Sendable {
+    case tick
+}
+
+// A trivial leaf reducer that mutates only the scalar field, leaving `payload` untouched.
+private let tickReducer = Reducer<BenchAction, BenchState>.reduce { _, state in
+    state.counter += 1
+}
+
+// 800 KB of Ints — large enough that a stray whole-array copy would dominate wall clock.
+private let largePayloadSize = 100_000
+
+// MARK: - Benchmarks
+
+let benchmarks: @Sendable () -> Void = {
+    // 1. Single-reducer dispatch throughput — the synchronous hot path
+    //    (`reduce(action).runEndoMut(&state)`) the Store runs in phase 2 of every dispatch.
+    Benchmark("Reducer.reduce — single") { benchmark in
+        var state = BenchState(payload: [])
+        for _ in benchmark.scaledIterations {
+            tickReducer.reduce(.tick).runEndoMut(&state)
+            blackHole(state.counter)
+        }
+    }
+
+    // 2. Composition of 64 reducers via `mconcat` — the N-deep closure tree that roadmap
+    //    item 21 (flat array-based folds) aims to flatten. This is the before-baseline.
+    let combined = mconcat(Array(repeating: tickReducer, count: 64))
+    Benchmark("Reducer.combine x64 — reduce") { benchmark in
+        var state = BenchState(payload: [])
+        for _ in benchmark.scaledIterations {
+            combined.reduce(.tick).runEndoMut(&state)
+            blackHole(state.counter)
+        }
+    }
+
+    // 3. EndoMut zero-copy guard: apply a scalar-field mutation to a state holding a large
+    //    array. EndoMut runs the mutation through `inout`, so `payload` must NOT be copied —
+    //    its wall clock should track the raw control below (#4), independent of array size.
+    //    A regression to whole-state copying would make this scale with `largePayloadSize`.
+    Benchmark(
+        "EndoMut zero-copy — large state",
+        configuration: .init(metrics: [.wallClock, .throughput, .mallocCountTotal])
+    ) { benchmark in
+        let mutate = tickReducer.reduce(.tick)
+        var state = BenchState(payload: Array(0..<largePayloadSize))
+        for _ in benchmark.scaledIterations {
+            mutate.runEndoMut(&state)
+            blackHole(state.counter)
+        }
+    }
+
+    // 4. Raw in-place field mutation — the zero-copy reference for #3. Same state shape,
+    //    no EndoMut. #3 staying level with this confirms the EndoMut abstraction adds no
+    //    array-size-proportional cost.
+    Benchmark(
+        "EndoMut zero-copy — raw control",
+        configuration: .init(metrics: [.wallClock, .throughput, .mallocCountTotal])
+    ) { benchmark in
+        var state = BenchState(payload: Array(0..<largePayloadSize))
+        for _ in benchmark.scaledIterations {
+            state.counter += 1
+            blackHole(state.counter)
+        }
+    }
+}

--- a/BenchmarkSuite/Package.resolved
+++ b/BenchmarkSuite/Package.resolved
@@ -1,0 +1,123 @@
+{
+  "originHash" : "10e8d9919bb2893c939deb6088349b8330f4b6b1e6d8b743cc3af547db849573",
+  "pins" : [
+    {
+      "identity" : "fp",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/luizmb/FP.git",
+      "state" : {
+        "revision" : "9141607df481b2ff4b65ca1f46a1a6e7395c5062",
+        "version" : "1.11.2"
+      }
+    },
+    {
+      "identity" : "hdrhistogram-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/HdrHistogram/hdrhistogram-swift.git",
+      "state" : {
+        "revision" : "c2e1210df04b4fff47e53f2f9dad9cc45ae15d63",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "hourglass",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/luizmb/Hourglass.git",
+      "state" : {
+        "revision" : "c75bc4aba0bc81f6203f9b5b266a1832759d654f",
+        "version" : "0.6.1"
+      }
+    },
+    {
+      "identity" : "package-benchmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/package-benchmark",
+      "state" : {
+        "revision" : "595d8db7d9d612ecf256ebf659c20aeec338c5ca",
+        "version" : "1.34.1"
+      }
+    },
+    {
+      "identity" : "package-jemalloc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/package-jemalloc.git",
+      "state" : {
+        "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+      "state" : {
+        "revision" : "a44317ce38b5bcce173b03f5d36cfdc939e1768b",
+        "version" : "7.2.1"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "132aea4f236ccadc51590b38af0357a331d51fa2",
+        "version" : "6.10.2"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
+      }
+    },
+    {
+      "identity" : "texttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/TextTable.git",
+      "state" : {
+        "revision" : "a27a07300cf4ae322e0079ca0a475c5583dd575f",
+        "version" : "0.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/BenchmarkSuite/Package.swift
+++ b/BenchmarkSuite/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+// Benchmarks live in a nested package so the published SwiftRex library never gains a
+// dependency on package-benchmark (or its jemalloc system requirement). It references the
+// root package by path and is built/run only by the dedicated, non-gating CI benchmark job.
+let package = Package(
+    name: "SwiftRexBenchmarks",
+    platforms: [.macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9)],
+    dependencies: [
+        .package(path: ".."),
+        .package(url: "https://github.com/luizmb/FP.git", from: "1.11.1"),
+        .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.4.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "SwiftRexBenchmarks",
+            dependencies: [
+                .product(name: "SwiftRex", package: "SwiftRex"),
+                .product(name: "CoreFP", package: "FP"),
+                .product(name: "Benchmark", package: "package-benchmark")
+            ],
+            path: "Benchmarks/SwiftRexBenchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            ]
+        )
+    ]
+)


### PR DESCRIPTION
## What
Adds a benchmark suite (roadmap item 22) covering SwiftRex's public hot paths, using `ordo-one/package-benchmark`.

## Why
There was no way to measure dispatch throughput or to catch silent regressions (e.g. `EndoMut` zero-copy, or the O(n) projection read). This adds that visibility and baselines for upcoming perf work (items 21 and 23).

## Design — nested package, isolated CI job
Benchmarks live in a nested `BenchmarkSuite/` SwiftPM package that references the root by path. This keeps `package-benchmark` (and its **jemalloc** system dependency) entirely out of the published `SwiftRex` graph — the root `build`/`test`/`lint`/`periphery` jobs and every downstream consumer are unchanged. A dedicated **non-gating** CI job (`continue-on-error: true`) installs jemalloc and runs the suite against the PR branch.

## Coverage
- **Reducer / EndoMut** — single `reduce`, `combine x64` (the N-deep `mconcat` tree; item-21 baseline), and the zero-copy guard vs a raw-mutation control.
- **lift / liftEach / liftCollection** — per-dispatch optic cost; `liftEach` is O(n) broadcast (~1 malloc/element over 1k), `liftCollection` O(n) lookup to hit one element.
- **Store.dispatch** — reducer-only vs reducer+middleware vs combined-behavior×8, exercising the full three-phase pipeline. (`Behavior`/`Middleware`/`Consequence` are exercised through the Store because `PreReducerContext`'s init is `package`-level and unreachable from a separate package.)
- **StoreProjection.state** by-id — the O(n)-per-read path; **item 23's baseline**.
- **StoreBuffer.dispatch** — the Equatable dedup/notification gating path.

## Changes
- `BenchmarkSuite/` — nested package: `Package.swift`/`Package.resolved`, `Fixtures.swift`, `SwiftRexBenchmarks.swift` (reduce + lift), `StoreBenchmarks.swift` (@MainActor store paths).
- `.github/workflows/ci.yml` — new non-gating `Benchmarks` job (macOS, installs jemalloc, runs the suite).
- `.swiftlint.yml` — exclude `BenchmarkSuite/.build`.

## Note for branch protection
Keep the **Benchmarks (non-gating)** check out of required status checks (it's also `continue-on-error`, so it won't report failure regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)