### PR TITLE
perf: flat unit-list Reducer/Behavior composition (item 21)

### DIFF
--- a/BenchmarkSuite/Benchmarks/SwiftRexBenchmarks/SwiftRexBenchmarks.swift
+++ b/BenchmarkSuite/Benchmarks/SwiftRexBenchmarks/SwiftRexBenchmarks.swift
@@ -33,6 +33,17 @@ func reduceBenchmarks() {
         }
     }
 
+    // Folding 64 identities — once identity is structurally empty (item 21) this should collapse
+    // to ~nothing (empty unit list → no work, no allocation). Today it builds a 64-deep tree.
+    let identities = mconcat(Array(repeating: Reducer<BenchAction, BenchState>.identity, count: 64))
+    Benchmark("Reducer.mconcat identity x64 — reduce") { benchmark in
+        var state = BenchState()
+        for _ in benchmark.scaledIterations {
+            identities.reduce(.tick).runEndoMut(&state)
+            blackHole(state.counter)
+        }
+    }
+
     // EndoMut zero-copy guard: apply a scalar-field mutation to a state holding a large array.
     // EndoMut runs the mutation through `inout`, so `payload` must NOT be copied — its wall
     // clock should track the raw control below, independent of array size.

--- a/BenchmarkSuite/Package.resolved
+++ b/BenchmarkSuite/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "10e8d9919bb2893c939deb6088349b8330f4b6b1e6d8b743cc3af547db849573",
+  "originHash" : "bdb49ea7182167f999da5d34f72209d898484d0ad532aeaea6a7ec3552ed35f2",
   "pins" : [
     {
       "identity" : "fp",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/FP.git",
       "state" : {
-        "revision" : "9141607df481b2ff4b65ca1f46a1a6e7395c5062",
-        "version" : "1.11.2"
+        "revision" : "1b93d54ee5d35a9696c038b323563d2f22f60a2c",
+        "version" : "1.12.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/Hourglass.git",
       "state" : {
-        "revision" : "c75bc4aba0bc81f6203f9b5b266a1832759d654f",
-        "version" : "0.6.1"
+        "revision" : "ec2ff5aac99e59d2ea208e4d391fe54da8961608",
+        "version" : "0.6.2"
       }
     },
     {

--- a/BenchmarkSuite/Package.swift
+++ b/BenchmarkSuite/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     platforms: [.macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9)],
     dependencies: [
         .package(path: ".."),
-        .package(url: "https://github.com/luizmb/FP.git", from: "1.11.1"),
+        .package(url: "https://github.com/luizmb/FP.git", from: "1.12.0"),
         .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.4.0")
     ],
     targets: [

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "9249e3631fa1816298ebc84d8cee92c8654069a5fdb698b25874525a22718816",
+  "originHash" : "40927dcc37a86536ac1f2ea5cfe66890947ad9f92570007ef4f3d757a5198f9a",
   "pins" : [
     {
       "identity" : "fp",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/FP.git",
       "state" : {
-        "revision" : "7d94724b29c47cc60695fe6c4d6cb813f25341aa",
-        "version" : "1.11.1"
+        "revision" : "1b93d54ee5d35a9696c038b323563d2f22f60a2c",
+        "version" : "1.12.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/Hourglass.git",
       "state" : {
-        "revision" : "6d35df23dcce1477bb244d51eb045707eec5506c",
-        "version" : "0.5.0"
+        "revision" : "ec2ff5aac99e59d2ea208e4d391fe54da8961608",
+        "version" : "0.6.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
         .library(name: "SwiftRex.Testing", targets: ["SwiftRexTesting"])
     ],
     dependencies: [
-        .package(url: "https://github.com/luizmb/FP.git", from: "1.11.1"),
-        .package(url: "https://github.com/luizmb/Hourglass.git", from: "0.5.0"),
+        .package(url: "https://github.com/luizmb/FP.git", from: "1.12.0"),
+        .package(url: "https://github.com/luizmb/Hourglass.git", from: "0.6.2"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.2.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.1"),

--- a/Sources/SwiftRex/Behavior/Behavior.swift
+++ b/Sources/SwiftRex/Behavior/Behavior.swift
@@ -88,6 +88,43 @@ public struct Behavior<Action: Sendable, State: Sendable, Environment: Sendable>
         _ context: PreReducerContext<State>
     ) -> Consequence<State, Environment, Action>
 
+    /// The per-feature units, in composition order. ``identity`` is the empty list, ``combine(_:_:)``
+    /// concatenates, and ``handle`` is a single flat pass over them — no nested closure tree.
+    let units: [@MainActor @Sendable (
+        _ action: Action,
+        _ context: PreReducerContext<State>
+    ) -> Consequence<State, Environment, Action>]
+
+    init(
+        units: [@MainActor @Sendable (
+            _ action: Action,
+            _ context: PreReducerContext<State>
+        ) -> Consequence<State, Environment, Action>]
+    ) {
+        self.units = units
+        if units.isEmpty {
+            self.handle = { _, _ in .doNothing }
+        } else if units.count == 1 {
+            self.handle = units[0]
+        } else {
+            self.handle = { @MainActor action, context in
+                // Run each unit once (all see the same pre-mutation state), then fold flatly.
+                // ReducerOutcome.combine absorbs `.unchanged`, so an all-no-op composition stays
+                // `.unchanged` and the Store skips notifications. Effects merge in phase 3.
+                let consequences = units.map { $0(action, context) }
+                let mutation = consequences.reduce(ReducerOutcome<State>.unchanged) {
+                    .combine($0, $1.mutation)
+                }
+                let effect = Reader<PostReducerContext<State, Environment>, Effect<Action>> { postContext in
+                    consequences.reduce(Effect<Action>.empty) {
+                        .combine($0, $1.effect.runReader(postContext))
+                    }
+                }
+                return Consequence(mutation: mutation, effect: effect)
+            }
+        }
+    }
+
     /// Creates a `Behavior` from a `handle` closure.
     ///
     /// - Parameter handle: The closure that maps `(Action, PreReducerContext<State>)` to
@@ -98,7 +135,7 @@ public struct Behavior<Action: Sendable, State: Sendable, Environment: Sendable>
             _ context: PreReducerContext<State>
         ) -> Consequence<State, Environment, Action>
     ) {
-        self.handle = handle
+        self.init(units: [handle])
     }
 }
 
@@ -152,12 +189,14 @@ extension Behavior {
         reducer: Reducer<Action, State>,
         middleware: Middleware<Action, State, Environment>
     ) {
-        self.handle = { action, context in
-            Consequence(
-                mutation: .mutation(reducer.reduce(action)),
-                effect: middleware.handle(action, context)
-            )
-        }
+        self.init(units: [
+            { action, context in
+                Consequence(
+                    mutation: .mutation(reducer.reduce(action)),
+                    effect: middleware.handle(action, context)
+                )
+            }
+        ])
     }
 }
 
@@ -185,9 +224,12 @@ extension Behavior: Semigroup {
     ///   - rhs: The second behavior; its mutation sees lhs's mutations.
     /// - Returns: A combined behavior that runs both handle closures and merges their consequences.
     public static func combine(_ lhs: Behavior, _ rhs: Behavior) -> Behavior {
-        Behavior { action, context in
-            .combine(lhs.handle(action, context), rhs.handle(action, context))
-        }
+        Behavior(units: lhs.units + rhs.units)
+    }
+
+    /// Flattens a non-empty run of behaviors in a single pass — O(total units), no nesting.
+    public static func sconcat(_ first: Behavior, _ rest: [Behavior]) -> Behavior {
+        Behavior(units: rest.reduce(into: first.units) { $0 += $1.units })
     }
 }
 
@@ -197,6 +239,12 @@ extension Behavior: Monoid {
     /// Acts as the identity element for ``combine(_:_:)``:
     /// `combine(b, identity) == combine(identity, b) == b` for any behavior `b`.
     public static var identity: Behavior {
-        Behavior { _, _ in .doNothing }
+        Behavior(units: [])
+    }
+
+    /// Flattens any (possibly empty) array of behaviors in a single pass — O(total units).
+    /// Identities contribute empty lists and vanish.
+    public static func mconcat(_ values: [Behavior]) -> Behavior {
+        Behavior(units: values.flatMap(\.units))
     }
 }

--- a/Sources/SwiftRex/Reducer/Reducer.swift
+++ b/Sources/SwiftRex/Reducer/Reducer.swift
@@ -68,15 +68,31 @@ import CoreFP
 ///   constraints on ``Behavior`` and ``Middleware``. The stored `reduce` closure is `@Sendable`
 ///   so `Reducer` itself satisfies `Sendable` without `@unchecked`.
 public struct Reducer<ActionType: Sendable, StateType: Sendable>: Sendable {
+    /// The in-place mutation units, in composition order.
+    ///
+    /// ``identity`` is the **empty** list, so composing with it adds nothing structurally;
+    /// ``combine(_:_:)`` concatenates. Keeping the units flat (rather than a nested closure
+    /// tree) means folding N reducers is an O(N) single pass, and identities simply vanish.
+    let units: [@Sendable (ActionType, inout StateType) -> Void]
+
     /// Given an action, produces an in-place endomorphism on `StateType`.
     ///
     /// The ``Store`` uses this as `reduce(action).runEndoMut(&_state)` in phase 2 of
-    /// dispatch. The resulting `EndoMut` captures the action and modifies the state
-    /// in-place when run.
+    /// dispatch. Built once from ``units``: a single `EndoMut` that runs every unit in order,
+    /// so even a composition of many reducers allocates just one wrapper per call.
     public let reduce: @Sendable (ActionType) -> EndoMut<StateType>
 
-    private init(_ reduce: @escaping @Sendable (ActionType) -> EndoMut<StateType>) {
-        self.reduce = reduce
+    init(units: [@Sendable (ActionType, inout StateType) -> Void]) {
+        self.units = units
+        if units.isEmpty {
+            self.reduce = { _ in .identity }
+        } else {
+            self.reduce = { @Sendable action in
+                EndoMut { state in
+                    for unit in units { unit(action, &state) }
+                }
+            }
+        }
     }
 }
 
@@ -101,7 +117,7 @@ extension Reducer {
     /// - Parameter f: A `@Sendable` function from action to `EndoMut<State>`.
     /// - Returns: A `Reducer` that applies the returned `EndoMut` for each action.
     public static func reduce(_ f: @escaping @Sendable (ActionType) -> EndoMut<StateType>) -> Reducer {
-        Reducer(f)
+        Reducer(units: [{ action, state in f(action).runEndoMut(&state) }])
     }
 
     /// Creates a `Reducer` from `@Sendable (Action) -> Endo<State>`. Bridges via `.toEndoMut()`.
@@ -112,7 +128,7 @@ extension Reducer {
     /// - Parameter f: A `@Sendable` function from action to `Endo<State>` (a `State -> State` function).
     /// - Returns: A `Reducer` that converts each `Endo` to an `EndoMut` via `.toEndoMut()`.
     public static func reduce(_ f: @escaping @Sendable (ActionType) -> Endo<StateType>) -> Reducer {
-        Reducer { action in f(action).toEndoMut() }
+        Reducer(units: [{ action, state in state = f(action)(state) }])
     }
 
     /// Creates a `Reducer` from an `inout` mutation function — the idiomatic Swift form.
@@ -134,7 +150,7 @@ extension Reducer {
     /// - Parameter f: A `@Sendable` closure that receives the action and mutates `state` in place.
     /// - Returns: A `Reducer` that wraps each `inout` mutation in an `EndoMut`.
     public static func reduce(_ f: @escaping @Sendable (ActionType, inout StateType) -> Void) -> Reducer {
-        Reducer { action in EndoMut { state in f(action, &state) } }
+        Reducer(units: [f])
     }
 
     /// Creates a `Reducer` from a pure `@Sendable (Action, State) -> State` function.
@@ -158,7 +174,7 @@ extension Reducer {
     /// - Parameter f: A `@Sendable` pure function from `(ActionType, StateType)` to a new `StateType`.
     /// - Returns: A `Reducer` that bridges each invocation through `Endo.toEndoMut()`.
     public static func reduce(_ f: @escaping @Sendable (ActionType, StateType) -> StateType) -> Reducer {
-        Reducer { action in Endo { state in f(action, state) }.toEndoMut() }
+        Reducer(units: [{ action, state in state = f(action, state) }])
     }
 }
 
@@ -177,7 +193,15 @@ extension Reducer: Semigroup {
     ///   - rhs: The second reducer; its mutation sees lhs's changes.
     /// - Returns: A reducer whose `EndoMut` is the sequential composition of both.
     public static func combine(_ lhs: Reducer, _ rhs: Reducer) -> Reducer {
-        Reducer { action in .combine(lhs.reduce(action), rhs.reduce(action)) }
+        Reducer(units: lhs.units + rhs.units)
+    }
+
+    /// Flattens a non-empty run of reducers in a single pass — O(total units), no nesting.
+    ///
+    /// Overrides the default `Semigroup` fold so `@ReducerBuilder` and the free `sconcat`/`compose`
+    /// build one flat unit list instead of `combine`-ing pairwise (which would be O(n²)).
+    public static func sconcat(_ first: Reducer, _ rest: [Reducer]) -> Reducer {
+        Reducer(units: rest.reduce(into: first.units) { $0 += $1.units })
     }
 }
 
@@ -187,7 +211,15 @@ extension Reducer: Monoid {
     /// Composing with `identity` leaves the other reducer unchanged.
     /// An empty ``compose(content:)`` block also produces this.
     public static var identity: Reducer {
-        .reduce { _ in EndoMut<StateType>.identity }
+        Reducer(units: [])
+    }
+
+    /// Flattens any (possibly empty) array of reducers in a single pass — O(total units).
+    ///
+    /// Overrides the default `Monoid` fold so `mconcat` (and the `@ReducerBuilder` block that
+    /// delegates to it) builds one flat unit list. Identities contribute empty lists and vanish.
+    public static func mconcat(_ values: [Reducer]) -> Reducer {
+        Reducer(units: values.flatMap(\.units))
     }
 }
 

--- a/Tests/SwiftRexTests/StoreTests/StoreTests.swift
+++ b/Tests/SwiftRexTests/StoreTests/StoreTests.swift
@@ -97,6 +97,39 @@ struct StoreObserveTests {
         #expect(count.value == 2)
     }
 
+    @Test func composedNoOpBehaviorsSkipNotifications() {
+        // Item-21 guard: a composition of many no-op behaviors must still fold to `.unchanged`,
+        // so the Store fires NEITHER willChange NOR didChange. If the flat fold ever collapsed
+        // them into a non-`.unchanged` mutation, every routing/effect-only action would re-render.
+        let noop = Behavior<Int, Int, Void>.identity
+        let doNothing = Behavior<Int, Int, Void>.handle { _, _ in .doNothing }
+        let composed = mconcat(Array(repeating: noop, count: 8) + Array(repeating: doNothing, count: 8))
+        let store = Store(initial: 0, behavior: composed)
+        let count = LockProtected(0)
+        _ = store.observe(
+            willChange: { count.mutate { $0 += 1 } },
+            didChange: { count.mutate { $0 += 1 } }
+        )
+        store.dispatch(1)
+        #expect(count.value == 0) // folded mutation is `.unchanged` → no notifications
+        #expect(store.state == 0)
+    }
+
+    @Test func composedWithOneMutatorStillNotifies() {
+        // Sanity counterpart: one real mutation among many no-ops must survive the fold and notify.
+        let noop = Behavior<Int, Int, Void>.identity
+        let mutator: Behavior<Int, Int, Void> = Reducer<Int, Int>.reduce { action, state in
+            state += action
+        }.asBehavior()
+        let composed = mconcat([noop, noop, mutator, noop])
+        let store = Store(initial: 0, behavior: composed)
+        let count = LockProtected(0)
+        _ = store.observe(willChange: {}, didChange: { count.mutate { $0 += 1 } })
+        store.dispatch(5)
+        #expect(count.value == 1)
+        #expect(store.state == 5)
+    }
+
     @Test func cancellingTokenRemovesObserver() async {
         let store = makeStore()
         let count = LockProtected(0)


### PR DESCRIPTION
## What
Item 21 — replace the N-deep closure tree in `Reducer`/`Behavior` composition with a flat unit list. Public API is unchanged; this is an internal-representation perf change. Bumps FP → 1.12.0, Hourglass → 0.6.2.

## Why
`combine`/`mconcat` built a nested binary closure tree, so folding N units was an N-deep call (and allocated per level) on every dispatch, and identities still did full work. The benchmark showed `Reducer.combine x64` = **127 mallocs**.

## How
- **Flat representation**: `Reducer`/`Behavior` store a flat `units` list. `identity` = **empty list** (so identities vanish structurally), `combine` concatenates, `reduce`/`handle` are one flat pass over the units. `reduce`/`handle` stay stored (built once) so call sites — including the generated lift code — pay nothing extra.
- **Reducer**: the unit is the in-place mutation `(Action, inout State) -> Void`, so composing N reducers runs them inside a **single** `EndoMut`.
- **Behavior**: folds its units in one pass — `ReducerOutcome.combine` absorbs `.unchanged`, so an all-no-op composition stays `.unchanged` and the Store still skips `willChange`/`didChange`.
- **O(n) construction**: both override FP 1.12.0's `mconcat`/`sconcat` customization points to flatten in a single pass, so `@ReducerBuilder` / `compose` are O(n), not O(n²).

## Results (committed benchmark, before → after)
| Benchmark | before | after |
|---|---|---|
| `Reducer.combine x64 — reduce` | **127 mallocs**, ~75 K/s | **1 malloc**, ~264 K/s |
| `Reducer.mconcat identity x64` | **127 mallocs** | **1 malloc** |
| `Reducer.reduce — single` | 1 malloc | 1 malloc |

Behavior dispatch is within `@MainActor` measurement noise (the win there is structural: identities vanish, O(n) construction, no recursion); Reducer is the measured win.

## Tests
New `StoreObserve` guards: a composition of many no-op behaviors fires **no** notifications (mutation folds to `.unchanged`), and one real mutator among no-ops **still** notifies. 405 tests pass; `swiftlint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
