### PR TITLE
Package traits for reactive bridges + ReactiveConcurrency bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,17 @@ jobs:
           swift run GenerateLifts Sources/SwiftRex
           git diff --exit-code Sources/SwiftRex/__Generated__
 
+      # --enable-all-traits builds every reactive bridge (RxSwift, ReactiveSwift,
+      # ReactiveConcurrency). Without it only the core + always-on bridges compile.
       - name: Build
-        run: swift build 2>&1
+        run: swift build --enable-all-traits 2>&1
 
       - name: Test
-        run: swift test 2>&1
+        run: swift test --enable-all-traits 2>&1
 
+      # Periphery runs on the default-trait build; the trait-gated bridge targets are
+      # pruned here and therefore skipped (they are all-public API anyway, retained via
+      # retain_public).
       - name: Periphery
         run: mint run periphery scan
 
@@ -63,10 +68,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build
-        run: swift build 2>&1
+        run: swift build --enable-all-traits 2>&1
 
       - name: Test
-        run: swift test 2>&1
+        run: swift test --enable-all-traits 2>&1
 
   # Non-gating: builds and runs the nested BenchmarkSuite package (which pulls in
   # package-benchmark + jemalloc — kept out of the main package). `continue-on-error`

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,14 +30,17 @@ jobs:
         run: |
           swift package \
             --allow-writing-to-directory .docs \
+            --enable-all-traits \
             generate-documentation \
             --target SwiftRex \
             --target SwiftRexOperators \
-            --target SwiftRexConcurrency \
+            --target SwiftRexSwiftConcurrency \
             --target SwiftRexCombine \
             --target SwiftRexRxSwift \
             --target SwiftRexReactiveSwift \
+            --target SwiftRexReactiveConcurrency \
             --target SwiftRexSwiftUI \
+            --target SwiftRexArchitecture \
             --enable-experimental-combined-documentation \
             --output-path .docs \
             --transform-for-static-hosting \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,10 @@ jobs:
         run: mint run swiftlint lint --strict
 
       - name: Build
-        run: swift build --build-tests
+        run: swift build --build-tests --enable-all-traits
 
       - name: Test
-        run: swift test
+        run: swift test --enable-all-traits
 
       - name: Periphery
         run: mint run periphery scan
@@ -69,10 +69,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build
-        run: swift build 2>&1
+        run: swift build --enable-all-traits 2>&1
 
       - name: Test
-        run: swift test 2>&1
+        run: swift test --enable-all-traits 2>&1
 
   rc-build-xcframework:
     name: RC - Build XCFramework
@@ -81,7 +81,7 @@ jobs:
     needs: rc-test
     strategy:
       matrix:
-        framework: [SwiftRex, SwiftRexOperators, SwiftRexConcurrency, SwiftRexCombine, SwiftRexSwiftUI]
+        framework: [SwiftRex, SwiftRexOperators, SwiftRexSwiftConcurrency, SwiftRexCombine, SwiftRexSwiftUI]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -96,7 +96,7 @@ jobs:
       - name: Build Library in Release Configuration
         run: |
           set -x
-          swift build -c release --product ${{ matrix.framework }} -v
+          swift build -c release --target ${{ matrix.framework }} -v
           echo "✓ Build succeeded"
 
       - name: Create XCFramework Structure
@@ -257,9 +257,9 @@ jobs:
 
           ### XCFrameworks
           See the attached \`.xcframework.zip\` files for pre-built binaries of the
-          dependency-free products (SwiftRex, SwiftRexOperators, SwiftRexConcurrency,
-          SwiftRexCombine, SwiftRexSwiftUI). The RxSwift and ReactiveSwift bridges
-          are available via SPM only."
+          dependency-free products (SwiftRex, SwiftRexOperators, SwiftRexSwiftConcurrency,
+          SwiftRexCombine, SwiftRexSwiftUI). The RxSwift, ReactiveSwift, and
+          ReactiveConcurrency bridges are available via SPM only."
           fi
 
           echo "body<<EOF" >> $GITHUB_OUTPUT

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -6,15 +6,18 @@ retain_files:
 targets:
   - SwiftRex
   - SwiftRexOperators
-  - SwiftRexConcurrency
+  - SwiftRexSwiftConcurrency
   - SwiftRexCombine
   - SwiftRexRxSwift
   - SwiftRexReactiveSwift
+  - SwiftRexReactiveConcurrency
   - SwiftRexSwiftUI
+  - SwiftRexArchitecture
   - SwiftRexTesting
   - SwiftRexTests
-  - SwiftRexConcurrencyTests
+  - SwiftRexSwiftConcurrencyTests
   - SwiftRexCombineTests
   - SwiftRexRxSwiftTests
   - SwiftRexReactiveSwiftTests
-  - SwiftRexTestingTests
+  - SwiftRexReactiveConcurrencyTests
+  - SwiftRexArchitectureTests

--- a/.spi.yml
+++ b/.spi.yml
@@ -5,11 +5,13 @@ builder:
       documentation_targets:
         - SwiftRex
         - SwiftRexOperators
-        - SwiftRexConcurrency
+        - SwiftRexSwiftConcurrency
         - SwiftRexCombine
         - SwiftRexRxSwift
         - SwiftRexReactiveSwift
+        - SwiftRexReactiveConcurrency
         - SwiftRexSwiftUI
+        - SwiftRexArchitecture
         - SwiftRexTesting
     - platform: ios
     - platform: tvos

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,9 +50,9 @@ SwiftRex (Package.swift)
 ├── Products
 │   ├── SwiftRex            — core; imports FP[CoreFP, DataStructure]
 │   ├── SwiftRexOperators   — operator sugar; imports FP[CoreFPOperators, DataStructureOperators]
-│   ├── CombineRex          — Combine bridges
-│   ├── RxSwiftRex          — RxSwift bridges
-│   └── ReactiveSwiftRex    — ReactiveSwift bridges
+│   ├── SwiftRexCombine          — Combine bridges
+│   ├── SwiftRexRxSwift          — RxSwift bridges
+│   └── SwiftRexReactiveSwift    — ReactiveSwift bridges
 │
 └── Targets
     ├── SwiftRex/
@@ -79,18 +79,18 @@ SwiftRex (Package.swift)
     │   ├── Middleware+Operators.swift
     │   └── Lift+Operators.swift
     │
-    ├── CombineRex/
+    ├── SwiftRexCombine/
     │   ├── Effect+Publisher.swift
     │   ├── Store+Publisher.swift
     │   └── SwiftUI/
     │       ├── ObservableViewModel.swift      — ObservableObject (iOS 13+)
     │       └── ObservableStore.swift          — @Observable (iOS 17+)
     │
-    ├── RxSwiftRex/
+    ├── SwiftRexRxSwift/
     │   ├── Effect+Observable.swift
     │   └── Store+Observable.swift
     │
-    └── ReactiveSwiftRex/
+    └── SwiftRexReactiveSwift/
         ├── Effect+SignalProducer.swift
         └── Store+SignalProducer.swift
 ```
@@ -116,8 +116,8 @@ public struct Cancellation {
 
 Bridge packages wrap their framework's token:
 ```swift
-Cancellation { combineCancellable.cancel() }  // CombineRex
-Cancellation { disposable.dispose() }          // RxSwiftRex
+Cancellation { combineCancellable.cancel() }  // SwiftRexCombine
+Cancellation { disposable.dispose() }          // SwiftRexRxSwift
 Cancellation { task.cancel() }                // async/await
 ```
 
@@ -314,21 +314,21 @@ extension Effect {
 
 **Bridge factories (in their respective targets):**
 ```swift
-// CombineRex
+// SwiftRexCombine
 extension Effect {
     public static func publisher<P: Publisher>(
         _ p: P, file: String = #file, function: String = #function
     ) -> Self where P.Output == Action, P.Failure == Never
 }
 
-// RxSwiftRex
+// SwiftRexRxSwift
 extension Effect {
     public static func observable<O: ObservableType>(
         _ o: O, file: String = #file, function: String = #function
     ) -> Self where O.Element == Action
 }
 
-// ReactiveSwiftRex
+// SwiftRexReactiveSwift
 extension Effect {
     public static func signalProducer<SP: SignalProducerConvertible>(
         _ sp: SP, file: String = #file, function: String = #function
@@ -702,21 +702,21 @@ The Store always notifies after a dispatch — fine-grained diffing is left to S
 
 **State observation bridges (in respective targets):**
 ```swift
-// CombineRex
+// SwiftRexCombine
 extension Store {
     public var statePublisher: AnyPublisher<State, Never> { … }
 }
 
-// CombineRex + SwiftUI
+// SwiftRexCombine + SwiftUI
 // iOS 13+: ObservableObject wrapper
 // iOS 17+: @Observable wrapper
 
-// RxSwiftRex
+// SwiftRexRxSwift
 extension Store {
     public var stateObservable: Observable<State> { … }
 }
 
-// ReactiveSwiftRex
+// SwiftRexReactiveSwift
 extension Store {
     public var stateSignalProducer: SignalProducer<State, Never> { … }
 }
@@ -872,9 +872,9 @@ extension Store {
 6. `ActionHandler` — bundles Reducer + Middleware; `asActionHandler` bridges; Monoid; `lift`/`liftCollection`
 7. `Store` — `@MainActor actor`, ActionHandler-based dispatch flow, effect scheduling, push-based `observe`
 8. `StoreProjection` — class, `State → LocalState` mapping, `Equatable` deduplication, `@Observable` (iOS 17+) and `ObservableObject` (iOS 13+) variants; this is where SwiftUI observation lives, not on `Store`
-9. `CombineRex` bridges — `Effect+Publisher`, `Store+Publisher`
-10. `RxSwiftRex` bridges
-11. `ReactiveSwiftRex` bridges
+9. `SwiftRexCombine` bridges — `Effect+Publisher`, `Store+Publisher`
+10. `SwiftRexRxSwift` bridges
+11. `SwiftRexReactiveSwift` bridges
 12. `SwiftRexOperators` — `<>` and other symbolic operators via FP operator modules
 13. Swift Macro for `lift` overload generation
 14. Tests for each layer

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "40927dcc37a86536ac1f2ea5cfe66890947ad9f92570007ef4f3d757a5198f9a",
+  "originHash" : "cb602f11d129e729632bbff022c4a840200b18718c7785fb8275e7ae740c59d4",
   "pins" : [
     {
       "identity" : "fp",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "ec2ff5aac99e59d2ea208e4d391fe54da8961608",
         "version" : "0.6.2"
+      }
+    },
+    {
+      "identity" : "reactiveconcurrency",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/luizmb/ReactiveConcurrency.git",
+      "state" : {
+        "revision" : "e7c8f6dcf6ffa3d2a148f92081f7fbcc935077a1",
+        "version" : "0.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,15 +17,29 @@ let package = Package(
         .library(name: "SwiftRex.Combine", targets: ["SwiftRexCombine"]),
         .library(name: "SwiftRex.RxSwift", targets: ["SwiftRexRxSwift"]),
         .library(name: "SwiftRex.ReactiveSwift", targets: ["SwiftRexReactiveSwift"]),
+        .library(name: "SwiftRex.ReactiveConcurrency", targets: ["SwiftRexReactiveConcurrency"]),
         .library(name: "SwiftRex.SwiftUI", targets: ["SwiftRexSwiftUI"]),
         .library(name: "SwiftRex.Architecture", targets: ["SwiftRexArchitecture"]),
         .library(name: "SwiftRex.Testing", targets: ["SwiftRexTesting"])
+    ],
+    // Each third-party reactive bridge is behind an opt-in trait. A consumer who only
+    // wants one (e.g. RxSwift) enables that trait and SwiftPM resolves/clones ONLY that
+    // package — the others are never fetched and never appear in their acknowledgements.
+    // Default is none: pick your champion explicitly. Combine (system) and
+    // SwiftConcurrency (no external dependency) need no trait. CI runs with
+    // `--enable-all-traits` so every bridge is built and tested.
+    traits: [
+        .trait(name: "RxSwift"),
+        .trait(name: "ReactiveSwift"),
+        .trait(name: "ReactiveConcurrency"),
+        .default(enabledTraits: [])
     ],
     dependencies: [
         .package(url: "https://github.com/luizmb/FP.git", from: "1.12.0"),
         .package(url: "https://github.com/luizmb/Hourglass.git", from: "0.6.2"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.2.0"),
+        .package(url: "https://github.com/luizmb/ReactiveConcurrency.git", from: "0.1.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.0")
     ],
@@ -75,7 +89,7 @@ let package = Package(
             name: "SwiftRexRxSwift",
             dependencies: [
                 "SwiftRex",
-                .product(name: "RxSwift", package: "RxSwift")
+                .product(name: "RxSwift", package: "RxSwift", condition: .when(traits: ["RxSwift"]))
             ],
             path: "Sources/SwiftRexRxSwift"
         ),
@@ -83,9 +97,21 @@ let package = Package(
             name: "SwiftRexReactiveSwift",
             dependencies: [
                 "SwiftRex",
-                .product(name: "ReactiveSwift", package: "ReactiveSwift")
+                .product(name: "ReactiveSwift", package: "ReactiveSwift", condition: .when(traits: ["ReactiveSwift"]))
             ],
             path: "Sources/SwiftRexReactiveSwift"
+        ),
+        .target(
+            name: "SwiftRexReactiveConcurrency",
+            dependencies: [
+                "SwiftRex",
+                .product(
+                    name: "ReactiveConcurrency",
+                    package: "ReactiveConcurrency",
+                    condition: .when(traits: ["ReactiveConcurrency"])
+                )
+            ],
+            path: "Sources/SwiftRexReactiveConcurrency"
         ),
 
         // MARK: - Macros (implementation — build-time only)
@@ -177,6 +203,11 @@ let package = Package(
             name: "SwiftRexReactiveSwiftTests",
             dependencies: ["SwiftRexReactiveSwift"],
             path: "Tests/SwiftRexReactiveSwiftTests"
+        ),
+        .testTarget(
+            name: "SwiftRexReactiveConcurrencyTests",
+            dependencies: ["SwiftRexReactiveConcurrency"],
+            path: "Tests/SwiftRexReactiveConcurrencyTests"
         ),
         .testTarget(
             name: "SwiftRexArchitectureTests",

--- a/README.md
+++ b/README.md
@@ -98,27 +98,30 @@ I'm not gonna lie, it's a completely different way of writing apps, as most reac
 
 SwiftRex supports multiple concurrency styles. The core package is self-contained and sufficient on its own; the reactive, concurrency, and testing bridges are optional add-ons:
 
-| Product | When to use |
-|---|---|
-| `SwiftRex` | Always — the core store, reducers, behaviors, effects |
-| `SwiftRex.Concurrency` | async/await — Effect bridges for `Task`, `AsyncSequence`, `DeferredStream` |
-| `SwiftRex.Combine` | Apple Combine integration — `asEffect()` on `Publisher`, `store.publisher`, `ctx.readStateAfter() -> AnyPublisher` |
-| `SwiftRex.RxSwift` | RxSwift integration — `asEffect()` on `Observable`, `store.observable`, `ctx.readStateAfter() -> Observable` |
-| `SwiftRex.ReactiveSwift` | ReactiveSwift integration — `asEffect()` on `SignalProducer`/`Signal`, `store.signal`, `ctx.readStateAfter() -> SignalProducer` |
-| `SwiftRex.SwiftUI` | SwiftUI helpers — `asObservableObject()`, `@ViewModel` macro, `HasViewModel` |
-| `SwiftRex.Architecture` | Opinionated module pattern — `Feature`, `FeatureHost` (iOS 17+) |
-| `SwiftRex.Testing` | Test target only — `TestStore` for deterministic unit tests |
+| Product | Trait | When to use |
+|---|---|---|
+| `SwiftRex` | — | Always — the core store, reducers, behaviors, effects |
+| `SwiftRex.SwiftConcurrency` | — | async/await — Effect bridges for `Task`, `AsyncSequence`; `store.stream` |
+| `SwiftRex.Combine` | — | Apple Combine integration — `asEffect()` on `Publisher`, `store.publisher`, `ctx.readLiveState() -> AnyPublisher` |
+| `SwiftRex.RxSwift` | `RxSwift` | RxSwift integration — `asEffect()` on `Observable`, `store.observable`, `ctx.readLiveState() -> Observable` |
+| `SwiftRex.ReactiveSwift` | `ReactiveSwift` | ReactiveSwift integration — `asEffect()` on `SignalProducer`/`Signal`, `store.signal`, `ctx.readLiveState() -> SignalProducer` |
+| `SwiftRex.ReactiveConcurrency` | `ReactiveConcurrency` | [ReactiveConcurrency](https://github.com/luizmb/ReactiveConcurrency) integration — `asEffect()` on its async/await-native `Publisher`, `store.publisher`, `ctx.readLiveState() -> Publisher` |
+| `SwiftRex.SwiftUI` | — | SwiftUI helpers — `asObservableObject()`, `@ViewModel` macro, `HasViewModel` |
+| `SwiftRex.Architecture` | — | Opinionated module pattern — `Feature`, `FeatureHost` (iOS 17+) |
+| `SwiftRex.Testing` | — | Test target only — `TestStore` for deterministic unit tests |
 
-Pick the module(s) that match your project's reactive strategy. For a pure Swift Concurrency setup with no third-party dependencies, `SwiftRex` + `SwiftRex.Concurrency` is sufficient.
+Pick the module(s) that match your project's reactive strategy. For a pure Swift Concurrency setup with no third-party dependencies, `SwiftRex` + `SwiftRex.SwiftConcurrency` is sufficient.
+
+> **Opt-in bridges via package traits.** The three third-party reactive bridges — `SwiftRex.RxSwift`, `SwiftRex.ReactiveSwift`, and `SwiftRex.ReactiveConcurrency` — are each gated behind a [Swift Package Manager **trait**](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0450-swiftpm-package-traits.md) of the same name. **All traits are off by default**, so a consumer who picks one bridge never downloads — nor sees in their acknowledgements — the other two third-party packages. `SwiftRex.Combine` (system framework) and `SwiftRex.SwiftConcurrency` (no third-party dependency) need no trait. Requires a Swift 6.1+ toolchain. See [Installation](#installation) for how to enable a trait.
 
 ## Swift Concurrency
 
-`SwiftRex.Concurrency` bridges the Effect system to Swift's async/await world:
+`SwiftRex.SwiftConcurrency` bridges the Effect system to Swift's async/await world:
 
 - `Effect.task { await myAsyncFunc() }` — wraps a single async computation
 - `Effect.throwingTask(MyAction.result) { try await api.fetch() }` — throwing async work with automatic `Result` mapping
 - `Effect.asyncSequence(myAsyncStream, MyAction.received)` — bridges any `AsyncSequence` into a stream of dispatched actions
-- `store.stream` — a `DeferredStream<State>` for iterating over state changes with `for await state in store.stream { ... }`
+- `store.stream` — a `@Sendable () -> AsyncStream<State>` factory; each call starts a fresh observation: `for await state in store.stream() { ... }`
 
 ```swift
 let fetchMiddleware = Middleware<AppAction, AppState, API>.handle { action, _ in
@@ -130,6 +133,30 @@ let fetchMiddleware = Middleware<AppAction, AppState, API>.handle { action, _ in
     }
 }
 ```
+
+`SwiftRex.SwiftConcurrency` uses Swift's native, *eager* `Task`/`AsyncStream` directly. If you want the lazy, referentially-transparent equivalents (`DeferredTask`, `DeferredStream`) plus a cold, composable `Publisher`, reach for `SwiftRex.ReactiveConcurrency` instead.
+
+## ReactiveConcurrency
+
+`SwiftRex.ReactiveConcurrency` bridges the Effect system to [ReactiveConcurrency](https://github.com/luizmb/ReactiveConcurrency)'s cold, async/await-native `Publisher` — a `Sendable`, Combine-shaped stream backed by `DeferredStream`:
+
+- `publisher.asEffect()` / `.asEffect(AppAction.didReceive)` — map each element to an action (the call-site is captured as the `ActionSource`)
+- `publisher.asEffect(AppAction.didFetch)` on a failing `Publisher<_, Failure>` — delivers `Result<Output, Failure>`
+- `Effect.fireAndForget(publisher)` — run a pipeline for its side effects only
+- `store.publisher` — a cold `Publisher<State, Never>` emitting state after every mutation
+- `ctx.readLiveState()` — a single-element `Publisher<State, Never>` for reading post-mutation state inside a `produce` closure
+
+```swift
+let searchMiddleware = Middleware<AppAction, AppState, API>.handle { action, _ in
+    guard case .search(let query) = action else { return .doNothing }
+    return Reader { ctx in
+        ctx.environment.search(query)        // a ReactiveConcurrency Publisher<[Result], APIError>
+            .asEffect(AppAction.didSearch)   // Publisher → Effect, errors flow as Result
+    }
+}
+```
+
+> Enable the `ReactiveConcurrency` trait to use this product — see [Installation](#installation).
 
 # Parts
 
@@ -540,31 +567,38 @@ Middleware is generic over 3 type parameters:
 It returns `Reader<PostReducerContext<State, Environment>, Effect<Action>>`. The `Reader` closure runs in phase 3, after mutations, and receives a `PostReducerContext<State, Environment>` with:
 
 - `ctx.environment: Environment` — dependencies injected at that point.
-- `ctx.stateAfter: State?` — post-mutation state; requires `@MainActor`. From a non-`@MainActor` context use `await MainActor.run { ctx.stateAfter }`, or the `readStateAfter()` helper described below.
+- `ctx.liveState: State?` — post-mutation state; requires `@MainActor`. From a non-`@MainActor` context use `await MainActor.run { ctx.liveState }`, or the `readLiveState()` helper described below.
 
 `PreReducerContext` is **non-Sendable by design** — the compiler prevents you from capturing it into the `@Sendable` phase-3 closure. If you need to compare before/after, capture `context.stateBefore` into a local `let` first.
 
-**Reading post-mutation state from a reactive pipeline** — `SwiftRex.Combine`, `SwiftRex.RxSwift`, and `SwiftRex.ReactiveSwift` each add a `readStateAfter()` extension on `PostReducerContext` that returns a single-element stream and hops to `@MainActor` automatically:
+**Reading post-mutation state from a reactive pipeline** — `SwiftRex.Combine`, `SwiftRex.RxSwift`, `SwiftRex.ReactiveSwift`, and `SwiftRex.ReactiveConcurrency` each add a `readLiveState()` extension on `PostReducerContext` that returns a single-element stream and hops to `@MainActor` automatically:
 
 ```swift
 // Combine (AnyPublisher)
 return .produce { ctx in
-    ctx.readStateAfter()                                    // AnyPublisher<State, Never>
+    ctx.readLiveState()                                     // AnyPublisher<State, Never>
         .flatMap { state in ctx.environment.api.save(state.draft) }
         .asEffect()
 }
 
 // RxSwift (Observable)
 return .produce { ctx in
-    ctx.readStateAfter()                                    // Observable<State>
+    ctx.readLiveState()                                     // Observable<State>
         .flatMap { state in ctx.environment.api.save(state.draft) }
         .asEffect()
 }
 
 // ReactiveSwift (SignalProducer)
 return .produce { ctx in
-    ctx.readStateAfter()                                    // SignalProducer<State, Never>
+    ctx.readLiveState()                                     // SignalProducer<State, Never>
         .flatMap(.latest) { state in ctx.environment.api.save(state.draft) }
+        .asEffect()
+}
+
+// ReactiveConcurrency (Publisher)
+return .produce { ctx in
+    ctx.readLiveState()                                     // Publisher<State, Never>
+        .flatMap { state in ctx.environment.api.save(state.draft) }
         .asEffect()
 }
 ```
@@ -605,8 +639,8 @@ let loggerMiddleware = Middleware<AppAction, AppState, Logger>.handle { action, 
     let stateBefore = context.stateBefore          // phase 1 — pre-mutation state
     let source = "\(context.source.file):\(context.source.line)"
     return Reader { ctx in
-        let stateAfter = ctx.stateAfter            // phase 3 — post-mutation state
-        ctx.environment.log(action: action, from: source, before: stateBefore, after: stateAfter)
+        let liveState = ctx.liveState              // phase 3 — post-mutation state
+        ctx.environment.log(action: action, from: source, before: stateBefore, after: liveState)
         return .empty
     }
 }
@@ -1833,45 +1867,53 @@ enum AppAction: Sendable {
 SwiftRex is distributed exclusively via Swift Package Manager. Add it to your `Package.swift`:
 
 ```swift
-// swift-tools-version:5.9
+// swift-tools-version:6.1   // traits require Swift 6.1+
 
 import PackageDescription
 
 let package = Package(
     name: "MyApp",
-    platforms: [.macOS(.v12), .iOS(.v15), .tvOS(.v15), .watchOS(.v8), .visionOS(.v1)],
+    platforms: [.macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9), .visionOS(.v1)],
     products: [
         .executable(name: "MyApp", targets: ["MyApp"])
     ],
     dependencies: [
-        .package(url: "https://github.com/SwiftRex/SwiftRex.git", from: "1.0.0")
+        // Enable the trait(s) for the third-party bridge(s) you want. Omit `traits:`
+        // entirely if you only use the core, Combine, or SwiftConcurrency products —
+        // then RxSwift/ReactiveSwift/ReactiveConcurrency are never even downloaded.
+        .package(
+            url: "https://github.com/SwiftRex/SwiftRex.git",
+            from: "1.0.0",
+            traits: ["RxSwift"]   // e.g. ["RxSwift", "ReactiveConcurrency"]
+        )
     ],
     targets: [
         .target(
             name: "MyApp",
             dependencies: [
-                // Pick one or more:
-                .product(name: "SwiftRex", package: "SwiftRex"),               // Core only
-                .product(name: "SwiftRex.Concurrency", package: "SwiftRex"),   // async/await bridges
-                .product(name: "SwiftRex.Combine", package: "SwiftRex"),       // Combine
-                .product(name: "SwiftRex.RxSwift", package: "SwiftRex"),       // RxSwift
-                .product(name: "SwiftRex.ReactiveSwift", package: "SwiftRex"), // ReactiveSwift
+                // Pick one or more (a gated bridge also needs its trait above):
+                .product(name: "SwiftRex", package: "SwiftRex"),                    // Core only — no trait
+                .product(name: "SwiftRex.SwiftConcurrency", package: "SwiftRex"),   // async/await — no trait
+                .product(name: "SwiftRex.Combine", package: "SwiftRex"),            // Combine — no trait
+                .product(name: "SwiftRex.RxSwift", package: "SwiftRex"),            // needs trait "RxSwift"
+                // .product(name: "SwiftRex.ReactiveSwift", package: "SwiftRex"),        // needs trait "ReactiveSwift"
+                // .product(name: "SwiftRex.ReactiveConcurrency", package: "SwiftRex"),  // needs trait "ReactiveConcurrency"
             ]
         ),
         .testTarget(
             name: "MyAppTests",
             dependencies: [
                 "MyApp",
-                .product(name: "SwiftRex.Testing", package: "SwiftRex"),       // TestStore
+                .product(name: "SwiftRex.Testing", package: "SwiftRex"),            // TestStore
             ]
         )
     ]
 )
 ```
 
-Supported platforms: macOS 12+, iOS 15+, tvOS 15+, watchOS 8+, visionOS 1+, Linux (Swift 6+).
+Supported platforms: macOS 13+, iOS 16+, tvOS 16+, watchOS 9+, visionOS 1+, Linux (Swift 6.1+).
 
-`SwiftRex.Concurrency`, `SwiftRex`, and `SwiftRex.Testing` are fully cross-platform including Linux. `SwiftRex.Combine` and `SwiftRex.SwiftUI` require Apple platforms. `SwiftRex.RxSwift` and `SwiftRex.ReactiveSwift` require Apple platforms unless the respective frameworks add Linux support.
+`SwiftRex`, `SwiftRex.SwiftConcurrency`, and `SwiftRex.Testing` are fully cross-platform including Linux. `SwiftRex.Combine` and `SwiftRex.SwiftUI` require Apple platforms. `SwiftRex.RxSwift`, `SwiftRex.ReactiveSwift`, and `SwiftRex.ReactiveConcurrency` require their respective traits enabled (above), and the first two require Apple platforms unless those frameworks add Linux support.
 
 You can also add SwiftRex directly in Xcode via **File > Add Package Dependencies** and entering the repository URL `https://github.com/SwiftRex/SwiftRex.git`.
 
@@ -1883,10 +1925,10 @@ Pre-built XCFrameworks for the dependency-free products are attached to each [Gi
 |---|---|
 | `SwiftRex.xcframework.zip` | Core store, reducers, behaviors, effects |
 | `SwiftRex.Operators.xcframework.zip` | Symbolic operators (`<>`, `\|>`, `>>>`, …) |
-| `SwiftRex.Concurrency.xcframework.zip` | async/await Effect bridges |
+| `SwiftRex.SwiftConcurrency.xcframework.zip` | async/await Effect bridges |
 | `SwiftRex.Combine.xcframework.zip` | Combine publisher bridge |
 | `SwiftRex.SwiftUI.xcframework.zip` | SwiftUI integration (`asObservableObject`, `@ViewModel`, `HasViewModel`) |
 
-The reactive bridges (`SwiftRex.RxSwift`, `SwiftRex.ReactiveSwift`) depend on third-party frameworks that ship their own XCFrameworks; use SPM for those products.
+The third-party reactive bridges (`SwiftRex.RxSwift`, `SwiftRex.ReactiveSwift`, `SwiftRex.ReactiveConcurrency`) are trait-gated and depend on third-party frameworks; use SPM for those products.
 
 To integrate an XCFramework manually: download the `.zip` from the release, unzip it, and drag the `.xcframework` bundle into your Xcode project's **Frameworks, Libraries, and Embedded Content** section.

--- a/Sources/SwiftRex/Effect/Effect.swift
+++ b/Sources/SwiftRex/Effect/Effect.swift
@@ -17,8 +17,9 @@ import CoreFP
 ///   subscription getting its own independent stream of values.
 /// - **Cross-platform**: the model works on Linux, Windows, and WASM where Swift Concurrency
 ///   may be unavailable or constrained.
-/// - **Framework-agnostic**: bridge targets (CombineRex, RxSwiftRex, ReactiveSwiftRex) wrap
-///   their respective publisher/observable/signal types into this single representation.
+/// - **Framework-agnostic**: bridge targets (`SwiftRexCombine`, `SwiftRexRxSwift`,
+///   `SwiftRexReactiveSwift`, `SwiftRexReactiveConcurrency`) wrap their respective
+///   publisher/observable/signal types into this single representation.
 ///
 /// ## The subscribe closure
 ///
@@ -112,7 +113,7 @@ public struct Effect<Action: Sendable>: Sendable {
 extension Effect {
     /// Creates a single-component `Effect` from a subscribe closure and an optional scheduling policy.
     ///
-    /// This SPI initialiser is intended for bridge targets (CombineRex, RxSwiftRex, etc.) and
+    /// This SPI initialiser is intended for bridge targets (`SwiftRexCombine`, `SwiftRexRxSwift`, etc.) and
     /// extension packages that need to wrap a framework-specific publisher into an `Effect`
     /// without access to the internal `Component` type. Application code should prefer the
     /// typed factories: ``just(_:scheduling:file:function:line:)-5i6kl``,

--- a/Sources/SwiftRex/Foundation/SubscriptionToken.swift
+++ b/Sources/SwiftRex/Foundation/SubscriptionToken.swift
@@ -11,13 +11,13 @@
 /// wrap their framework-specific cancellation handles into this single, framework-agnostic type:
 ///
 /// ```swift
-/// // CombineRex — wraps an AnyCancellable
+/// // SwiftRexCombine — wraps an AnyCancellable
 /// SubscriptionToken { anyCancellable.cancel() }
 ///
-/// // RxSwiftRex — wraps a Disposable
+/// // SwiftRexRxSwift — wraps a Disposable
 /// SubscriptionToken { disposable.dispose() }
 ///
-/// // Swift concurrency — wraps a Task
+/// // SwiftRexSwiftConcurrency — wraps a Task
 /// SubscriptionToken { task.cancel() }
 ///
 /// // A no-op token (e.g., for effects that can't be cancelled)

--- a/Sources/SwiftRexReactiveConcurrency/Effect+ReactiveConcurrency.swift
+++ b/Sources/SwiftRexReactiveConcurrency/Effect+ReactiveConcurrency.swift
@@ -1,0 +1,229 @@
+#if ReactiveConcurrency
+import ReactiveConcurrency
+import SwiftRex
+
+// MARK: - ReactiveConcurrency.Publisher → Effect bridges
+//
+// `ReactiveConcurrency.Publisher` is a cold, lazy, natively-Sendable stream — the
+// async/await-native counterpart to Combine's `Publisher`. The four overloads mirror the
+// Combine bridge exactly:
+//
+//   Case A   Publisher<Action, Never>               .asEffect(scheduling:)
+//            Output is already the Action — new ActionSource from call site.
+//
+//   Case A2  Publisher<DispatchedAction<A>, Never>  .asEffect(scheduling:)
+//            Output is pre-sourced — dispatcher forwarded unchanged, no new ActionSource.
+//
+//   Case B   Publisher<Output, Never>               .asEffect(_ transform:scheduling:)
+//            Infallible; user maps Output → Action.
+//
+//   Case C   Publisher<Output, Failure: Error>      .asEffect(_ transform:scheduling:)
+//            Failable; user maps Result<Output, Failure> → Action.
+//
+// Lazy subscription model:
+//   The Publisher is cold — nothing runs until the Store calls the Effect's `subscribe`
+//   closure, which attaches a `sink`. Each subscription creates a new `AnyCancellable`;
+//   cancelling the returned `SubscriptionToken` calls `cancel()` on it. Unlike the Combine
+//   bridge, no `@unchecked Sendable` wrapper is needed — `Publisher` is `Sendable`.
+//
+// Completion: `complete()` fires on `.finished` or after the error action (Case C).
+// Cancellation suppresses all further callbacks including completion.
+
+extension Publisher where Failure == Never {
+    /// Bridges a `Publisher<Action, Never>` to `Effect<Action>`.
+    ///
+    /// The call-site (`#file`, `#function`, `#line`) is captured as the ``ActionSource`` for
+    /// every element the publisher emits. Subscription is lazy — the publisher's `sink` is
+    /// only attached when the Store runs the effect.
+    ///
+    /// Use this overload when the publisher's `Output` is already the action type:
+    ///
+    /// ```swift
+    /// let publisher: Publisher<AppAction, Never> = …
+    /// let effect: Effect<AppAction> = publisher.asEffect()
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - scheduling: The ``EffectScheduling`` policy. Defaults to
+    ///     ``EffectScheduling/immediately``.
+    ///   - file: Source file; captured automatically.
+    ///   - function: Source function; captured automatically.
+    ///   - line: Source line; captured automatically.
+    /// - Returns: An `Effect<Action>` backed by this publisher.
+    public func asEffect(
+        scheduling: EffectScheduling = .immediately,
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Effect<Output> {
+        let source = ActionSource(file: file, function: function, line: line)
+        return Effect(components: [
+            Effect<Output>.Component(subscribe: { send, complete in
+                let c = self.sink(
+                    receiveCompletion: { _ in complete() },
+                    receiveValue: { send(DispatchedAction($0, dispatcher: source)) }
+                )
+                return SubscriptionToken { c.cancel() }
+            }, scheduling: scheduling)
+        ])
+    }
+
+    /// Bridges a `Publisher<DispatchedAction<Action>, Never>` to `Effect<Action>`.
+    ///
+    /// The existing ``ActionSource`` inside each ``DispatchedAction`` is forwarded unchanged —
+    /// no new ``ActionSource`` is created at the call site. Use this when the publisher already
+    /// carries pre-sourced dispatched actions (e.g. from another middleware stage).
+    ///
+    /// ```swift
+    /// let publisher: Publisher<DispatchedAction<AppAction>, Never> = …
+    /// let effect: Effect<AppAction> = publisher.asEffect()
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - scheduling: The ``EffectScheduling`` policy. Defaults to
+    ///     ``EffectScheduling/immediately``.
+    /// - Returns: An `Effect<Action>` that forwards each ``DispatchedAction`` as-is.
+    public func asEffect<Action: Sendable>(
+        scheduling: EffectScheduling = .immediately
+    ) -> Effect<Action> where Output == DispatchedAction<Action> {
+        Effect(components: [
+            Effect<Action>.Component(subscribe: { send, complete in
+                let c = self.sink(
+                    receiveCompletion: { _ in complete() },
+                    receiveValue: { send($0) }
+                )
+                return SubscriptionToken { c.cancel() }
+            }, scheduling: scheduling)
+        ])
+    }
+
+    /// Bridges a `Publisher<Output, Never>` to `Effect<Action>` by mapping each value.
+    ///
+    /// Use this overload when the publisher's `Output` differs from the action type and you
+    /// need a transform function. The call-site is captured as the ``ActionSource``.
+    ///
+    /// ```swift
+    /// enum AppAction { case didFetch(MyModel) }
+    ///
+    /// let publisher: Publisher<MyModel, Never> = …
+    /// let effect: Effect<AppAction> = publisher.asEffect(AppAction.didFetch)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - transform: Maps each `Output` value to an `Action`.
+    ///   - scheduling: The ``EffectScheduling`` policy. Defaults to
+    ///     ``EffectScheduling/immediately``.
+    ///   - file: Source file; captured automatically.
+    ///   - function: Source function; captured automatically.
+    ///   - line: Source line; captured automatically.
+    /// - Returns: An `Effect<Action>` backed by the transformed publisher.
+    public func asEffect<Action: Sendable>(
+        _ transform: @escaping @Sendable (Output) -> Action,
+        scheduling: EffectScheduling = .immediately,
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Effect<Action> {
+        let source = ActionSource(file: file, function: function, line: line)
+        return Effect(components: [
+            Effect<Action>.Component(subscribe: { send, complete in
+                let c = self.sink(
+                    receiveCompletion: { _ in complete() },
+                    receiveValue: { send(DispatchedAction(transform($0), dispatcher: source)) }
+                )
+                return SubscriptionToken { c.cancel() }
+            }, scheduling: scheduling)
+        ])
+    }
+}
+
+extension Publisher where Failure: Error {
+    /// Bridges a failable `Publisher<Output, Failure>` to `Effect<Action>` via a `Result` transform.
+    ///
+    /// This is the idiomatic ReactiveConcurrency bridge for publishers that can fail. Each
+    /// successfully emitted value is delivered as `.success`; the publisher's terminating error
+    /// (if any) is delivered as `.failure` and then `complete` fires.
+    ///
+    /// Subscription is lazy — the `sink` is only attached when the Store runs the effect.
+    /// Cancellation calls `AnyCancellable.cancel()` and suppresses all further callbacks.
+    ///
+    /// ```swift
+    /// enum AppAction {
+    ///     case didFetch(Result<MyModel, APIError>)
+    /// }
+    ///
+    /// // Publisher<MyModel, APIError> bridges directly using the enum case as transform
+    /// apiPublisher.asEffect(AppAction.didFetch)
+    /// // Each model → .didFetch(.success(model))
+    /// // API error  → .didFetch(.failure(error)) then complete
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - transform: Maps each `Result<Output, Failure>` to an `Action`.
+    ///   - scheduling: The ``EffectScheduling`` policy. Defaults to
+    ///     ``EffectScheduling/immediately``.
+    ///   - file: Source file; captured automatically.
+    ///   - function: Source function; captured automatically.
+    ///   - line: Source line; captured automatically.
+    /// - Returns: An `Effect<Action>` that handles both values and publisher failures.
+    public func asEffect<Action: Sendable>(
+        _ transform: @escaping @Sendable (Result<Output, Failure>) -> Action,
+        scheduling: EffectScheduling = .immediately,
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Effect<Action> {
+        let source = ActionSource(file: file, function: function, line: line)
+        return Effect(components: [
+            Effect<Action>.Component(subscribe: { send, complete in
+                let c = self.sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            send(DispatchedAction(transform(.failure(error)), dispatcher: source))
+                        }
+                        complete()
+                    },
+                    receiveValue: { send(DispatchedAction(transform(.success($0)), dispatcher: source)) }
+                )
+                return SubscriptionToken { c.cancel() }
+            }, scheduling: scheduling)
+        ])
+    }
+}
+
+// MARK: - Fire and forget (Publisher)
+
+extension Effect {
+    /// Creates an ``Effect`` that subscribes to a `Publisher`, ignoring all values and errors.
+    ///
+    /// Use when a ReactiveConcurrency pipeline runs for its side effects alone, with no resulting
+    /// action. The publisher is subscribed lazily when the Store runs the effect; `complete`
+    /// fires when the publisher finishes (either `.finished` or `.failure`).
+    ///
+    /// Works naturally in point-free pipelines using `|>`:
+    ///
+    /// ```swift
+    /// // Run an analytics publisher and discard the output
+    /// myPublisher |> Effect.fireAndForget
+    ///
+    /// // Or call directly
+    /// Effect<AppAction>.fireAndForget(cachePublisher)
+    /// ```
+    ///
+    /// - Parameter p: Any `Publisher` to subscribe to for its side effects.
+    /// - Returns: An `Effect<Action>` that never dispatches an action.
+    public static func fireAndForget<Output: Sendable, Failure: Error>(
+        _ p: Publisher<Output, Failure>
+    ) -> Self {
+        Effect(components: [
+            Component(subscribe: { _, complete in
+                let c = p.sink(
+                    receiveCompletion: { _ in complete() },
+                    receiveValue: { _ in }
+                )
+                return SubscriptionToken { c.cancel() }
+            }, scheduling: .immediately)
+        ])
+    }
+}
+#endif

--- a/Sources/SwiftRexReactiveConcurrency/PostReducerContext+ReactiveConcurrency.swift
+++ b/Sources/SwiftRexReactiveConcurrency/PostReducerContext+ReactiveConcurrency.swift
@@ -1,0 +1,35 @@
+#if ReactiveConcurrency
+import ReactiveConcurrency
+import SwiftRex
+
+extension PostReducerContext {
+    /// Returns a single-element publisher that reads the Store's current state on the main actor.
+    ///
+    /// The state is read lazily — only when a subscriber attaches, not when the publisher is
+    /// constructed. The emitted value reflects the Store's state at the moment of subscription;
+    /// subscribing synchronously inside a `produce` closure yields this cycle's post-mutation
+    /// state, while a later subscription yields whatever the Store holds then.
+    ///
+    /// ```swift
+    /// Behavior<MyAction, MyState, API>.handle { action, _ in
+    ///     guard case .save(let data) = action else { return .doNothing }
+    ///     return .produce { ctx in
+    ///         ctx.readLiveState()
+    ///             .flatMap { state in ctx.environment.api.save(data, revision: state.revision) }
+    ///             .asEffect()
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Returns: A `Publisher<State, Never>` that emits the current state once and completes.
+    ///   Emits nothing if the Store has been deallocated.
+    public func readLiveState() -> Publisher<State, Never> {
+        Publisher { continuation in
+            if let state = await MainActor.run(body: { self.liveState }) {
+                continuation.yield(state)
+            }
+            continuation.finish()
+        }
+    }
+}
+#endif

--- a/Sources/SwiftRexReactiveConcurrency/StoreType+ReactiveConcurrency.swift
+++ b/Sources/SwiftRexReactiveConcurrency/StoreType+ReactiveConcurrency.swift
@@ -1,0 +1,42 @@
+#if ReactiveConcurrency
+import ReactiveConcurrency
+import SwiftRex
+
+// MARK: - Store observation as Publisher
+
+extension StoreType {
+    /// A cold `Publisher<State, Never>` that emits the current state after every mutation.
+    ///
+    /// Subscribes lazily — ``StoreType/observe(willChange:didChange:)`` is only called when a
+    /// subscriber attaches (the publisher is backed by `ReactiveConcurrency`'s cold
+    /// `DeferredStream`). Each subscription registers its own observer on the `@MainActor` and
+    /// receives an independent `AnyCancellable`; cancelling it removes the observer from the
+    /// store immediately.
+    ///
+    /// Each emission reads ``StoreType/state`` once on the `@MainActor` right after the mutation.
+    /// Use `ReactiveConcurrency` operators (`map`, `removeDuplicates`, `receive(on:)`, …) to shape
+    /// the stream:
+    ///
+    /// ```swift
+    /// store.publisher
+    ///     .map(\.username)
+    ///     .removeDuplicates()
+    ///     .sink { name in print(name) }
+    ///     .store(in: &cancellables)
+    /// ```
+    ///
+    /// To create an ``Effect`` from this publisher, use one of the
+    /// ``ReactiveConcurrency/Publisher/asEffect`` overloads provided by `SwiftRexReactiveConcurrency`.
+    public var publisher: Publisher<State, Never> {
+        Publisher { continuation in
+            // The Publisher body runs off the main actor; hop on to register the observer and
+            // capture the token, then park until the subscription is cancelled and tear down.
+            let token = await MainActor.run {
+                self.observe(didChange: { continuation.yield(self.state) })
+            }
+            await continuation.suspendUntilCancelled()
+            token.cancel()
+        }
+    }
+}
+#endif

--- a/Sources/SwiftRexReactiveSwift/Effect+ReactiveSwift.swift
+++ b/Sources/SwiftRexReactiveSwift/Effect+ReactiveSwift.swift
@@ -1,3 +1,4 @@
+#if ReactiveSwift
 @preconcurrency import ReactiveSwift
 import SwiftRex
 
@@ -334,3 +335,4 @@ extension Effect {
         fireAndForget(SignalProducer(signal))
     }
 }
+#endif

--- a/Sources/SwiftRexReactiveSwift/PostReducerContext+ReactiveSwift.swift
+++ b/Sources/SwiftRexReactiveSwift/PostReducerContext+ReactiveSwift.swift
@@ -1,3 +1,4 @@
+#if ReactiveSwift
 @preconcurrency import ReactiveSwift
 import SwiftRex
 
@@ -34,3 +35,4 @@ extension PostReducerContext {
         }
     }
 }
+#endif

--- a/Sources/SwiftRexReactiveSwift/StoreType+ReactiveSwift.swift
+++ b/Sources/SwiftRexReactiveSwift/StoreType+ReactiveSwift.swift
@@ -1,3 +1,4 @@
+#if ReactiveSwift
 @preconcurrency import ReactiveSwift
 import SwiftRex
 
@@ -38,3 +39,4 @@ extension StoreType {
         }
     }
 }
+#endif

--- a/Sources/SwiftRexRxSwift/Effect+RxSwift.swift
+++ b/Sources/SwiftRexRxSwift/Effect+RxSwift.swift
@@ -1,3 +1,4 @@
+#if RxSwift
 @preconcurrency import RxSwift
 import SwiftRex
 
@@ -366,3 +367,4 @@ extension Effect {
         ])
     }
 }
+#endif

--- a/Sources/SwiftRexRxSwift/PostReducerContext+RxSwift.swift
+++ b/Sources/SwiftRexRxSwift/PostReducerContext+RxSwift.swift
@@ -1,3 +1,4 @@
+#if RxSwift
 @preconcurrency import RxSwift
 import SwiftRex
 
@@ -36,3 +37,4 @@ extension PostReducerContext {
         }
     }
 }
+#endif

--- a/Sources/SwiftRexRxSwift/StoreType+RxSwift.swift
+++ b/Sources/SwiftRexRxSwift/StoreType+RxSwift.swift
@@ -1,3 +1,4 @@
+#if RxSwift
 @preconcurrency import RxSwift
 import SwiftRex
 
@@ -34,3 +35,4 @@ extension StoreType {
         }
     }
 }
+#endif

--- a/Sources/SwiftRexSwiftConcurrency/FutureContinuationBox.swift
+++ b/Sources/SwiftRexSwiftConcurrency/FutureContinuationBox.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Thread-safe continuation box used internally by ``Effect/future(_:scheduling:file:function:line:)``.
 ///
-/// This type is an implementation detail of the `SwiftRexConcurrency` module. It has no public
+/// This type is an implementation detail of the `SwiftRexSwiftConcurrency` module. It has no public
 /// surface and is not part of SwiftRex's public API.
 ///
 /// ### Responsibility

--- a/Tests/SwiftRexReactiveConcurrencyTests/EffectReactiveConcurrencyTests.swift
+++ b/Tests/SwiftRexReactiveConcurrencyTests/EffectReactiveConcurrencyTests.swift
@@ -1,0 +1,197 @@
+#if ReactiveConcurrency
+import ReactiveConcurrency
+import SwiftRex
+@testable import SwiftRexReactiveConcurrency
+import Testing
+
+// MARK: - Helpers
+
+private func collect<A: Sendable>(
+    _ effect: Effect<A>,
+    timeout: Duration = .milliseconds(500)
+) async -> [A] {
+    await withCheckedContinuation { continuation in
+        let received = LockProtected([A]())
+        let tokens = LockProtected([SubscriptionToken]())
+        let t = subscribeAll(effect, send: { d in received.mutate { $0.append(d.action) } }, onComplete: {
+            continuation.resume(returning: received.value)
+        })
+        tokens.mutate { $0 = t }
+    }
+}
+
+// MARK: - Publisher<Action, Never>.asEffect
+
+@Suite("Effect+ReactiveConcurrency: Publisher<Action, Never>")
+struct PublisherActionEffectTests {
+    @Test func dispatchesAllValues() async {
+        let effect = Publisher<Int, Never>.sequence([1, 2, 3]).asEffect()
+        let received = await collect(effect)
+        #expect(received == [1, 2, 3])
+    }
+
+    @Test func callsCompleteOnFinished() async {
+        let completed = LockProtected(false)
+        _ = subscribeAll(
+            Publisher<Int, Never>.just(1).asEffect(),
+            send: { _ in },
+            onComplete: { completed.set(true) }
+        )
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(completed.value)
+    }
+
+    @Test func capturesCallSiteAsDispatcher() async {
+        let line: UInt = #line; let effect = Publisher<Int, Never>.just(42).asEffect(line: line)
+        let received = LockProtected([DispatchedAction<Int>]())
+        _ = subscribeAll(effect, send: { d in received.mutate { $0.append(d) } })
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(received.value.first?.dispatcher.line == line)
+    }
+
+    @Test func tokenCancellationStopsDelivery() async {
+        let subject = PassthroughSubject<Int, Never>()
+        let received = LockProtected([Int]())
+        let token = subscribeAll(
+            subject.eraseToPublisher().asEffect(),
+            send: { d in received.mutate { $0.append(d.action) } }
+        )[0]
+        try? await Task.sleep(for: .milliseconds(50))
+        subject.send(1)
+        try? await Task.sleep(for: .milliseconds(50))
+        token.cancel()
+        subject.send(2)
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(received.value == [1])
+    }
+}
+
+// MARK: - Publisher<DispatchedAction<A>, Never>.asEffect (forwarding)
+
+@Suite("Effect+ReactiveConcurrency: Publisher<DispatchedAction<A>, Never> forwarding")
+struct PublisherForwardingEffectTests {
+    @Test func preservesExistingDispatcher() async {
+        let source = ActionSource(file: "original.swift", function: "fn()", line: 99)
+        let dispatched = DispatchedAction(42, dispatcher: source)
+        let effect: Effect<Int> = Publisher<DispatchedAction<Int>, Never>.sequence([dispatched]).asEffect()
+        let received = LockProtected([DispatchedAction<Int>]())
+        _ = subscribeAll(effect, send: { d in received.mutate { $0.append(d) } })
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(received.value.first?.dispatcher.file == "original.swift")
+        #expect(received.value.first?.action == 42)
+    }
+}
+
+// MARK: - Publisher<Output, Never>.asEffect(_ transform:)
+
+@Suite("Effect+ReactiveConcurrency: Publisher<Output, Never> with transform")
+struct PublisherTransformEffectTests {
+    @Test func appliesTransform() async {
+        let effect = Publisher<Int, Never>.sequence([5]).asEffect { "val:\($0)" }
+        let received = await collect(effect)
+        #expect(received == ["val:5"])
+    }
+}
+
+// MARK: - Publisher<Output, Error>.asEffect(_ transform:) — Result
+
+@Suite("Effect+ReactiveConcurrency: Publisher<Output, Error> with Result transform")
+struct PublisherResultEffectTests {
+    @Test func wrapsSuccessInResult() async {
+        struct TestError: Error {}
+        let effect = Publisher<Int, TestError>.just(10)
+            .asEffect { (r: Result<Int, TestError>) in (try? r.get()).map { $0 * 2 } ?? -1 }
+        let received = await collect(effect)
+        #expect(received == [20])
+    }
+
+    @Test func wrapsFailureInResult() async {
+        struct E: Error {}
+        let effect = Publisher<Int, E>.fail(E())
+            .asEffect { (r: Result<Int, E>) in
+                switch r {
+                case .failure: -1
+                case .success: 0
+                }
+            }
+        let received = await collect(effect)
+        #expect(received == [-1])
+    }
+}
+
+// MARK: - Effect.fireAndForget (ReactiveConcurrency)
+
+@Suite("Effect+ReactiveConcurrency: fireAndForget")
+struct ReactiveConcurrencyFireAndForgetTests {
+    @Test func dispatchesNoActions() async {
+        let received = LockProtected([Int]())
+        _ = subscribeAll(
+            Effect<Int>.fireAndForget(Publisher<Int, Never>.sequence([1, 2])),
+            send: { d in received.mutate { $0.append(d.action) } }
+        )
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(received.value.isEmpty)
+    }
+
+    @Test func callsCompleteWhenPublisherFinishes() async {
+        let completed = LockProtected(false)
+        _ = subscribeAll(
+            Effect<Int>.fireAndForget(Publisher<Int, Never>.just(1)),
+            send: { _ in },
+            onComplete: { completed.set(true) }
+        )
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(completed.value)
+    }
+}
+
+// MARK: - StoreType+ReactiveConcurrency: .publisher
+//
+// RC's `store.publisher` is a cold publisher consumed by a Task, so delivery is asynchronous
+// (unlike Combine's synchronous observer). Tests await propagation and read through a lock.
+
+@Suite("StoreType+ReactiveConcurrency: publisher")
+@MainActor
+struct StorePublisherTests {
+    @Test func publisherIsLazyDoesNotSubscribeUntilStarted() async {
+        let store = Store(initial: 0, reducer: Reducer<Int, Int>.reduce { a, s in s += a })
+        let received = LockProtected([Int]())
+        let pub = store.publisher
+        store.dispatch(10)
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(received.value.isEmpty)
+        let token = pub.sink { value in received.mutate { $0.append(value) } }
+        try? await Task.sleep(for: .milliseconds(50)) // let the observer register on @MainActor
+        store.dispatch(5)  // state: 10+5=15
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(received.value == [15])
+        token.cancel()
+    }
+
+    @Test func publisherDeliversStateAfterEachDispatch() async {
+        let store = Store(initial: 0, reducer: Reducer<Int, Int>.reduce { a, s in s += a })
+        let received = LockProtected([Int]())
+        let token = store.publisher.sink { value in received.mutate { $0.append(value) } }
+        try? await Task.sleep(for: .milliseconds(50))
+        store.dispatch(3)  // state: 3
+        store.dispatch(4)  // state: 7
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(received.value == [3, 7])
+        token.cancel()
+    }
+
+    @Test func cancellingSubscriptionStopsDelivery() async {
+        let store = Store(initial: 0, reducer: Reducer<Int, Int>.reduce { a, s in s += a })
+        let received = LockProtected([Int]())
+        var token: AnyCancellable? = store.publisher.sink { value in received.mutate { $0.append(value) } }
+        try? await Task.sleep(for: .milliseconds(50))
+        store.dispatch(1)  // state: 1
+        try? await Task.sleep(for: .milliseconds(50))
+        token = nil
+        store.dispatch(2)  // state: 3, not subscribed
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(received.value == [1])
+        _ = token
+    }
+}
+#endif

--- a/Tests/SwiftRexReactiveConcurrencyTests/TestHelpers.swift
+++ b/Tests/SwiftRexReactiveConcurrencyTests/TestHelpers.swift
@@ -1,4 +1,4 @@
-#if RxSwift
+#if ReactiveConcurrency
 import Foundation
 import SwiftRex
 

--- a/Tests/SwiftRexReactiveSwiftTests/EffectReactiveSwiftTests.swift
+++ b/Tests/SwiftRexReactiveSwiftTests/EffectReactiveSwiftTests.swift
@@ -1,3 +1,4 @@
+#if ReactiveSwift
 import ReactiveSwift
 import SwiftRex
 @testable import SwiftRexReactiveSwift
@@ -174,3 +175,4 @@ struct StoreSignalTests {
         token.dispose()
     }
 }
+#endif

--- a/Tests/SwiftRexReactiveSwiftTests/TestHelpers.swift
+++ b/Tests/SwiftRexReactiveSwiftTests/TestHelpers.swift
@@ -1,3 +1,4 @@
+#if ReactiveSwift
 import Foundation
 import SwiftRex
 
@@ -25,3 +26,4 @@ func subscribeAll<A: Sendable>(
     _effectSubscriptionSink.mutate { $0.append(contentsOf: tokens) }
     return tokens
 }
+#endif

--- a/Tests/SwiftRexRxSwiftTests/EffectRxSwiftTests.swift
+++ b/Tests/SwiftRexRxSwiftTests/EffectRxSwiftTests.swift
@@ -1,3 +1,4 @@
+#if RxSwift
 import RxSwift
 import SwiftRex
 @testable import SwiftRexRxSwift
@@ -181,3 +182,4 @@ struct StoreObservableTests {
         #expect(received == [3, 7])
     }
 }
+#endif


### PR DESCRIPTION
## What
Gate the three third-party reactive bridges behind opt-in SwiftPM **package traits**, add a new `SwiftRex.ReactiveConcurrency` bridge, and clean up stale target/product names left over from the old SwiftRex.

## Why
With every reactive bridge declared as an unconditional dependency, a consumer who picks just one (say RxSwift) was forced to clone RxSwift **and** ReactiveSwift **and** ReactiveConcurrency, with all of them showing up in their acknowledgements. SPM now supports per-trait dependency pruning (Swift 6.1+), so we can keep the monorepo and still ship granular, pay-for-what-you-use bridges.

Verified on Swift 6.3.2: a consumer enabling only the `RxSwift` trait clones **only** RxSwift — ReactiveSwift and ReactiveConcurrency are neither fetched nor present in the build graph.

## Changes
- **Package traits** (`Package.swift`): declare `RxSwift`, `ReactiveSwift`, `ReactiveConcurrency` traits (default none); gate each third-party `.product(...)` with `condition: .when(traits:)`. Combine (system) and SwiftConcurrency (no third-party dep) stay always-on.
- **Source gating**: wrap the RxSwift & ReactiveSwift bridge + test files in `#if RxSwift` / `#if ReactiveSwift` (an enabled trait becomes a compilation condition), mirroring how the Combine bridge uses `#if canImport(Combine)`.
- **New `SwiftRex.ReactiveConcurrency` bridge**: `Effect+`, `StoreType+`, `PostReducerContext+` over [ReactiveConcurrency](https://github.com/luizmb/ReactiveConcurrency)'s cold, natively-`Sendable` `Publisher` (no `Unchecked` wrapper needed). 13 tests.
- **CI** (`ci.yml`, `release.yml`): build/test with `--enable-all-traits` (macOS + Linux) so every bridge is compiled and tested.
- **Docs build** (`docs.yml`): `--enable-all-traits` + add `SwiftRexReactiveConcurrency` / `SwiftRexArchitecture` targets.
- **Stale-name cleanup** (the "old Rex" leftovers): fix `SwiftRexConcurrency` → `SwiftRexSwiftConcurrency` and a phantom `SwiftRexTestingTests` across `.periphery.yml`, `.spi.yml`, `docs.yml`, `release.yml`; fix the release XCFramework job's `--product` → `--target` (target names never resolved as products); rename `CombineRex`/`RxSwiftRex`/`ReactiveSwiftRex` → real target names in `ARCHITECTURE.md` and source doc comments.
- **README**: document the new bridge + the trait opt-in mechanism; fix `SwiftRex.Concurrency` → `SwiftRex.SwiftConcurrency`, `readStateAfter()` → `readLiveState()`, `ctx.stateAfter` → `ctx.liveState`, stale `store.stream` type, and the platform/tools-version floors.

## Notes / follow-ups
- **SPI docs**: Swift Package Index's `.spi.yml` schema has no trait field, so it builds docs with default traits — the three gated bridges may render empty doc pages there. The project's own GitHub Pages docs include them fully via `--enable-all-traits`.
- `ARCHITECTURE.md`'s "Package Structure" section is broadly outdated beyond the names (file tree) — left for the planned doc rewrite.