### PR TITLE
docs: document StoreProjection O(n) by-id read + container trade-off

### DIFF
--- a/Sources/SwiftRex/Store/StoreProjection.swift
+++ b/Sources/SwiftRex/Store/StoreProjection.swift
@@ -110,6 +110,8 @@ public struct StoreProjection<Action: Sendable, State: Sendable>: StoreType {
         actionReview: @escaping @Sendable (ElementAction<C.Element.ID, Action>) -> GA,
         stateCollection: KeyPath<GS, C>
     ) where C.Element: Identifiable & Sendable, C.Element.ID: Hashable & Sendable, State == C.Element? {
+        // O(n) per read: linear scan re-runs on every state access. See the perf discussion on
+        // StoreType.projection(element:actionReview:stateCollection:) for the Array/dictionary trade-off.
         _state    = { store.state[keyPath: stateCollection].first { $0.id == id } }
         _dispatch = { action, source in store.dispatch(actionReview(ElementAction(id, action: action)), source: source) }
         _observe  = { wc, dc in store.observe(willChange: wc, didChange: dc) }
@@ -142,6 +144,8 @@ public struct StoreProjection<Action: Sendable, State: Sendable>: StoreType {
         stateCollection: KeyPath<GS, C>,
         identifier: @escaping @Sendable (C.Element) -> ID
     ) where C.Element: Sendable, State == C.Element? {
+        // O(n) per read: linear scan re-runs on every state access. See the perf discussion on
+        // StoreType.projection(element:actionReview:stateCollection:identifier:) for the trade-off.
         _state    = { store.state[keyPath: stateCollection].first { identifier($0) == id } }
         _dispatch = { action, source in store.dispatch(actionReview(ElementAction(id, action: action)), source: source) }
         _observe  = { wc, dc in store.observe(willChange: wc, didChange: dc) }

--- a/Sources/SwiftRex/Store/StoreType+CollectionProjection.swift
+++ b/Sources/SwiftRex/Store/StoreType+CollectionProjection.swift
@@ -25,6 +25,23 @@ extension StoreType {
     /// // todoStore: StoreProjection<TodoAction, Todo?>
     /// ```
     ///
+    /// **Performance.** The element is resolved with a linear `first { $0.id == id }` scan **on
+    /// every state read** — i.e. on every observation/render — so projecting one element out of a
+    /// collection of `n` costs O(n) per read. Choosing a container:
+    ///
+    /// - Prefer a plain `Array` (this factory) for **small collections**, for collections with
+    ///   **frequent inserts / removals / reordering**, or **whenever display order matters** — the
+    ///   O(n) read is negligible at small `n`, and `Array` keeps insertion order and cheap
+    ///   structural edits.
+    /// - For **large, read-heavy (or edit-in-place-by-id) collections where order is irrelevant**,
+    ///   store the data as `[ID: Element]` and use ``projection(key:actionReview:stateDictionary:)``
+    ///   instead — dictionary lookup is O(1) per read.
+    /// - Caveat: a dictionary is **unordered**, so driving a list UI directly from one produces
+    ///   arbitrary, unstable row order. If you need both O(1) by-id access *and* stable order,
+    ///   keep a separate `[ID]` order array alongside it, or wait for a dedicated ordered indexed
+    ///   container. Do **not** reach for a dictionary purely to avoid the O(n) read when order
+    ///   matters — accept the linear read on the `Array` instead.
+    ///
     /// Delegates to ``StoreProjection/init(store:element:actionReview:stateCollection:)``.
     ///
     /// - Parameters:
@@ -64,6 +81,11 @@ extension StoreType {
     /// // featureStore: StoreProjection<FeatureAction, Feature?>
     /// ```
     ///
+    /// **Performance.** Same O(n)-per-read cost as
+    /// ``projection(element:actionReview:stateCollection:)`` — a linear `first(where:)` scan runs on
+    /// every state read. See that factory's discussion for when to prefer an `Array`, a dictionary,
+    /// or a dedicated ordered indexed container.
+    ///
     /// Delegates to ``StoreProjection/init(store:element:actionReview:stateCollection:identifier:)``.
     ///
     /// - Parameters:
@@ -101,6 +123,11 @@ extension StoreType {
     /// )
     /// // settingStore: StoreProjection<SettingAction, SettingValue?>
     /// ```
+    ///
+    /// **Performance.** Dictionary lookup is O(1) per read — the O(1) counterpart to the
+    /// `Array`-based ``projection(element:actionReview:stateCollection:)``. Prefer this for large,
+    /// read-heavy collections keyed by id where ordering is **not** required; if you need stable
+    /// display order, see that factory's discussion (a dictionary alone cannot provide it).
     ///
     /// Delegates to ``StoreProjection/init(store:key:actionReview:stateDictionary:)``.
     ///


### PR DESCRIPTION
## What
Document the O(n)-per-read cost of the by-id `StoreProjection` element factories and give honest guidance on choosing a state container.

## Why
`projection(element:…)` (Identifiable and custom-identifier) resolves the element with a linear `first { $0.id == id }` scan **on every state read** — i.e. on every observation/render — so projecting one element out of `n` costs O(n) per read. This is invisible at the call site; the docs now make the cost and the trade-off explicit (item 23 of the performance track, scoped to documentation).

## Changes
- `StoreType+CollectionProjection.swift`: add a **Performance** section to the three projection factories —
  - Identifiable by-id: full guidance — prefer `Array` for small collections, frequent inserts/removals/reordering, or when display order matters; use the O(1) dictionary projection for large read-heavy/edit-in-place collections where order is irrelevant; and an explicit caveat that a dictionary is unordered, so it should **not** be reached for purely to dodge the O(n) when order matters (a list UI driven by one gets arbitrary row order).
  - Custom-identifier by-id: points back to the above (same O(n) characteristics).
  - Dictionary-by-key: notes its O(1) lookup and that it cannot provide stable order.
- `StoreProjection.swift`: terse `// O(n) per read` markers at the two implementation read sites.

Documentation only — no API or behavior change. A future ordered, O(1)-by-id indexed container (with optics + lifts) is tracked separately and is out of this PR's scope.