### PR TITLE
fix: stabilize flaky clamped-debounce timing test on Linux CI

### DIFF
--- a/Tests/SwiftRexTests/StoreTests/StoreTests.swift
+++ b/Tests/SwiftRexTests/StoreTests/StoreTests.swift
@@ -211,7 +211,13 @@ struct StoreEffectSchedulingTests {
             environment: ()
         )
         store.dispatch(0)
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        // The clamped-to-zero debounce still fires through a real-time scheduler hop, so poll
+        // (up to ~2s) for the looped-back action rather than asserting after one fixed sleep —
+        // the fixed 100ms wait raced under load on the Linux CI runner.
+        for _ in 0..<200 {
+            if store.state == 5 { break }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
         #expect(store.state == 5)
     }
 }


### PR DESCRIPTION
## What
Make `negativeDebounceDelayIsClampedAndFires` wait for the looped-back action by polling, instead of asserting after a single fixed `Task.sleep`.

## Why
Main went red on the **Linux** CI job (macOS passed). The one real failure was:

```
✘ negativeDebounceDelayIsClampedAndFires() — Expectation failed: (store.state → 0) == 5
```

The test dispatches an action whose effect debounces with a **negative** delay (clamped to zero) and loops back action `5`. It then waited a fixed 100ms and asserted `store.state == 5`. The clamped-to-zero debounce still fires through a real-time scheduler hop, so under load on the slower Linux runner the loopback hadn't been processed within 100ms → state still `0`.

This is a pre-existing real-time flake (the test predates the traits/ReactiveConcurrency PR #167 and is unrelated to it); the extra parallel test load from #167's new bridge targets likely tipped it over on Linux. The other 4 issues in the run are *known* issues (xfail), not failures.

## Changes
- `StoreTests.swift`: replace the single fixed 100ms sleep with a bounded poll (≤ ~2s, 10ms steps) that breaks as soon as `store.state == 5` — instant in the normal case, tolerant of a loaded runner.

Test-only; no production change. The proper long-term fix (deterministic scheduling via injected clock for the live Store, like the `Store clock injection` suite already does with `TestClock`) is tracked separately in the roadmap.