### PR TITLE
docs(DocC): scaffold documentation catalog (landing page + Algebra article)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,7 @@ jobs:
             --target SwiftRexSwiftUI \
             --target SwiftRexArchitecture \
             --enable-experimental-combined-documentation \
+            --enable-experimental-overloaded-symbol-presentation \
             --output-path .docs \
             --transform-for-static-hosting \
             --hosting-base-path SwiftRex

--- a/Sources/SwiftRex/Behavior/Behavior+LiftEach.swift
+++ b/Sources/SwiftRex/Behavior/Behavior+LiftEach.swift
@@ -176,7 +176,7 @@ extension Behavior {
 // MARK: - liftEach (general container — IndexedTraversal)
 
 extension Behavior {
-    /// Broadcasts across every focus of an ``IndexedTraversal`` (any container, not just
+    /// Broadcasts across every focus of an `IndexedTraversal` (any container, not just
     /// collections); each focus's index is its scoping id. State container via `Lens`.
     public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
         action: @escaping @Sendable (GA) -> Action?,
@@ -193,7 +193,7 @@ extension Behavior {
         )
     }
 
-    /// Broadcasts across every focus of an ``IndexedTraversal``. State container via `WritableKeyPath`.
+    /// Broadcasts across every focus of an `IndexedTraversal`. State container via `WritableKeyPath`.
     public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
         action: @escaping @Sendable (GA) -> Action?,
         embed: @escaping @Sendable (Action, ID) -> GA,

--- a/Sources/SwiftRex/Behavior/Behavior+Transforms.swift
+++ b/Sources/SwiftRex/Behavior/Behavior+Transforms.swift
@@ -37,7 +37,7 @@ extension Behavior {
     }
 
     /// Lifts the action axis using a `\.case` key path (`PrismKeyPath`) — the case-key-path
-    /// spelling of `liftAction(_:)`.
+    /// spelling of ``liftAction(_:)``.
     ///
     /// ```swift
     /// let lifted = authBehavior.liftAction(\.auth)   // instead of AppAction.prism.auth
@@ -226,7 +226,7 @@ extension Behavior {
     /// Lifts all three axes simultaneously using a `Prism` for action, a `WritableKeyPath`
     /// for state, and a closure for environment.
     ///
-    /// Equivalent to chaining `liftAction(_:)`, `liftState(_:)`, and
+    /// Equivalent to chaining ``liftAction(_:)``, ``liftState(_:)``, and
     /// ``liftEnvironment(_:)`` in sequence. Use this when all three axes need widening in a
     /// single step:
     ///

--- a/Sources/SwiftRex/Behavior/Behavior+Transforms.swift
+++ b/Sources/SwiftRex/Behavior/Behavior+Transforms.swift
@@ -36,8 +36,8 @@ extension Behavior {
         }
     }
 
-    /// Lifts the action axis using a `\.case` key path (``PrismKeyPath``) — the case-key-path
-    /// spelling of ``liftAction(_:)``.
+    /// Lifts the action axis using a `\.case` key path (`PrismKeyPath`) — the case-key-path
+    /// spelling of `liftAction(_:)`.
     ///
     /// ```swift
     /// let lifted = authBehavior.liftAction(\.auth)   // instead of AppAction.prism.auth
@@ -59,12 +59,12 @@ extension Behavior {
     /// global state type.
     ///
     /// The key path is used in two ways:
-    /// - To project the ``PreReducerContext<GlobalState>`` to ``PreReducerContext<State>``
+    /// - To project the `PreReducerContext<GlobalState>` to `PreReducerContext<State>`
     ///   (pre-mutation reads via ``PreReducerContext/map(_:)``).
     /// - To lift the returned `EndoMut<State>` through the key path so it mutates the correct
     ///   property inside `GlobalState`.
-    /// - To project the ``PostReducerContext<GlobalState, Environment>`` to
-    ///   ``PostReducerContext<State, Environment>`` (post-mutation reads via `contramapEnvironment`
+    /// - To project the `PostReducerContext<GlobalState, Environment>` to
+    ///   `PostReducerContext<State, Environment>` (post-mutation reads via `contramapEnvironment`
     ///   on the returned `Reader`).
     ///
     /// ```swift
@@ -226,7 +226,7 @@ extension Behavior {
     /// Lifts all three axes simultaneously using a `Prism` for action, a `WritableKeyPath`
     /// for state, and a closure for environment.
     ///
-    /// Equivalent to chaining ``liftAction(_:)``, ``liftState(_:)-7bmm8``, and
+    /// Equivalent to chaining `liftAction(_:)`, `liftState(_:)`, and
     /// ``liftEnvironment(_:)`` in sequence. Use this when all three axes need widening in a
     /// single step:
     ///

--- a/Sources/SwiftRex/Behavior/Behavior.swift
+++ b/Sources/SwiftRex/Behavior/Behavior.swift
@@ -63,13 +63,13 @@ import DataStructure
 /// Feature behaviors operate on local types. Use the lift family to embed them in the app's
 /// global types without changing their logic:
 ///
-/// - ``liftAction(_:)`` — narrows via a `Prism` (enum case)
-/// - ``liftState(_:)-7bmm8`` — widens via `WritableKeyPath`
-/// - ``liftState(_:)-7r4jg`` — widens via `Lens`
-/// - ``liftState(_:)-4hwa6`` — widens via `Prism` (optional enum state)
-/// - ``liftState(_:)-8tflj`` — widens via `AffineTraversal`
+/// - `liftAction(_:)` — narrows via a `Prism` (enum case)
+/// - `liftState(_:)` — widens via `WritableKeyPath`
+/// - `liftState(_:)` — widens via `Lens`
+/// - `liftState(_:)` — widens via `Prism` (optional enum state)
+/// - `liftState(_:)` — widens via `AffineTraversal`
 /// - ``liftEnvironment(_:)`` — narrows via a projection closure
-/// - ``lift(action:state:environment:)-9azuf`` and overloads — all three axes at once
+/// - `lift(action:state:environment:)` and overloads — all three axes at once
 ///
 /// - Note: `Behavior.handle` is `@MainActor`. The ``Store`` calls it on the main actor,
 ///   so `context.stateBefore` is always safe to call directly inside the closure.
@@ -82,7 +82,7 @@ public struct Behavior<Action: Sendable, State: Sendable, Environment: Sendable>
     /// - The returned ``Consequence`` is applied by the Store in phases 2 and 3.
     ///
     /// - Note: Always called on `@MainActor`. Do not perform blocking work here — move
-    ///   async work into the returned ``Consequence/produce(_:)`` closure.
+    ///   async work into the returned `Consequence.produce(_:)` closure.
     public let handle: @MainActor @Sendable (
         _ action: Action,
         _ context: PreReducerContext<State>

--- a/Sources/SwiftRex/Behavior/Behavior.swift
+++ b/Sources/SwiftRex/Behavior/Behavior.swift
@@ -63,13 +63,13 @@ import DataStructure
 /// Feature behaviors operate on local types. Use the lift family to embed them in the app's
 /// global types without changing their logic:
 ///
-/// - `liftAction(_:)` — narrows via a `Prism` (enum case)
-/// - `liftState(_:)` — widens via `WritableKeyPath`
-/// - `liftState(_:)` — widens via `Lens`
-/// - `liftState(_:)` — widens via `Prism` (optional enum state)
-/// - `liftState(_:)` — widens via `AffineTraversal`
+/// - ``liftAction(_:)`` — narrows via a `Prism` (enum case)
+/// - ``liftState(_:)`` — widens via `WritableKeyPath`
+/// - ``liftState(_:)`` — widens via `Lens`
+/// - ``liftState(_:)`` — widens via `Prism` (optional enum state)
+/// - ``liftState(_:)`` — widens via `AffineTraversal`
 /// - ``liftEnvironment(_:)`` — narrows via a projection closure
-/// - `lift(action:state:environment:)` and overloads — all three axes at once
+/// - ``lift(action:state:environment:)`` and overloads — all three axes at once
 ///
 /// - Note: `Behavior.handle` is `@MainActor`. The ``Store`` calls it on the main actor,
 ///   so `context.stateBefore` is always safe to call directly inside the closure.

--- a/Sources/SwiftRex/Behavior/ReducerOutcome.swift
+++ b/Sources/SwiftRex/Behavior/ReducerOutcome.swift
@@ -14,11 +14,11 @@ import CoreFP
 ///
 /// ## Monoid
 ///
-/// `ReducerOutcome` is a ``Monoid`` whose identity is ``unchanged``. ``combine(_:_:)`` short-circuits
+/// `ReducerOutcome` is a `Monoid` whose identity is ``unchanged``. ``combine(_:_:)`` short-circuits
 /// the common case (one mutator among many `unchanged` siblings folds to a single `mutation`, no
 /// nesting); two real mutations compose sequentially via `EndoMut`'s own `Monoid` (lhs then rhs).
 ///
-/// - SeeAlso: ``Consequence``, ``EndoMut``
+/// - SeeAlso: ``Consequence``, `EndoMut`
 public enum ReducerOutcome<State: Sendable>: Sendable {
     /// No mutation — the Store applies nothing and fires no observer notifications.
     case unchanged

--- a/Sources/SwiftRex/Effect/Effect+Factories.swift
+++ b/Sources/SwiftRex/Effect/Effect+Factories.swift
@@ -145,7 +145,7 @@ extension Effect {
     /// without starting a new one.
     ///
     /// This is a pure cancellation operation — no `subscribe` closure is ever called. The
-    /// Store interprets the embedded ``EffectScheduling/cancelInFlight(id:)`` scheduling by
+    /// Store interprets the embedded `EffectScheduling.cancelInFlight(id:)` scheduling by
     /// removing `id` from its registry and calling ``SubscriptionToken/cancel()`` on whatever
     /// was stored there.
     ///
@@ -178,7 +178,7 @@ extension Effect {
 extension Effect {
     /// An effect that does nothing — no actions produced, no work started.
     ///
-    /// Equivalent to ``Monoid/identity`` and useful as a readable no-op return:
+    /// Equivalent to `Monoid.identity` and useful as a readable no-op return:
     ///
     /// ```swift
     /// case .noop:

--- a/Sources/SwiftRex/Effect/Effect+Map.swift
+++ b/Sources/SwiftRex/Effect/Effect+Map.swift
@@ -17,7 +17,7 @@ extension Effect {
     /// let mapped = authEffect.map { AppAction.auth($0) }
     /// ```
     ///
-    /// Internally used by `Middleware.liftAction(_:)` and `Behavior.liftAction(_:)` to
+    /// Internally used by ``Middleware/liftAction(_:)`` and ``Behavior/liftAction(_:)`` to
     /// re-wrap outgoing actions through a `Prism.review` function.
     ///
     /// - Parameter f: A `@Sendable` function from `Action` to `B`. Applied to every emitted

--- a/Sources/SwiftRex/Effect/Effect+Map.swift
+++ b/Sources/SwiftRex/Effect/Effect+Map.swift
@@ -17,7 +17,7 @@ extension Effect {
     /// let mapped = authEffect.map { AppAction.auth($0) }
     /// ```
     ///
-    /// Internally used by ``Middleware/liftAction(_:)`` and ``Behavior/liftAction(_:)`` to
+    /// Internally used by `Middleware.liftAction(_:)` and `Behavior.liftAction(_:)` to
     /// re-wrap outgoing actions through a `Prism.review` function.
     ///
     /// - Parameter f: A `@Sendable` function from `Action` to `B`. Applied to every emitted

--- a/Sources/SwiftRex/Effect/Effect.swift
+++ b/Sources/SwiftRex/Effect/Effect.swift
@@ -35,7 +35,7 @@ import CoreFP
 ///
 /// ## Array-of-components internal representation
 ///
-/// Combining two effects (via ``combine(_:_:)`` or the ``Monoid`` instance) appends their
+/// Combining two effects (via ``combine(_:_:)`` or the `Monoid` instance) appends their
 /// component arrays. The Store schedules each component independently under its own
 /// ``EffectScheduling`` policy, so cancelling by id never affects components with a
 /// different id.
@@ -44,8 +44,8 @@ import CoreFP
 ///
 /// Apply ``scheduling(_:)`` to override the default ``EffectScheduling/immediately`` policy
 /// on all components at once, or build components with individual policies using the
-/// ``Effect/init(subscribe:scheduling:)`` SPI. For most production code, use the dedicated
-/// factories (``just(_:scheduling:file:function:line:)-5i6kl``, ``sequence(_:scheduling:file:function:line:)``).
+/// `Effect.init(subscribe:scheduling:)` SPI. For most production code, use the dedicated
+/// factories (`just(_:scheduling:file:function:line:)`, ``sequence(_:scheduling:file:function:line:)``).
 ///
 /// ## Composing effects
 ///
@@ -116,7 +116,7 @@ extension Effect {
     /// This SPI initialiser is intended for bridge targets (`SwiftRexCombine`, `SwiftRexRxSwift`, etc.) and
     /// extension packages that need to wrap a framework-specific publisher into an `Effect`
     /// without access to the internal `Component` type. Application code should prefer the
-    /// typed factories: ``just(_:scheduling:file:function:line:)-5i6kl``,
+    /// typed factories: `just(_:scheduling:file:function:line:)`,
     /// ``sequence(_:scheduling:file:function:line:)``, or the async/Combine/Rx overloads in
     /// the respective bridge modules.
     ///

--- a/Sources/SwiftRex/Effect/Effect.swift
+++ b/Sources/SwiftRex/Effect/Effect.swift
@@ -45,7 +45,7 @@ import CoreFP
 /// Apply ``scheduling(_:)`` to override the default ``EffectScheduling/immediately`` policy
 /// on all components at once, or build components with individual policies using the
 /// `Effect.init(subscribe:scheduling:)` SPI. For most production code, use the dedicated
-/// factories (`just(_:scheduling:file:function:line:)`, ``sequence(_:scheduling:file:function:line:)``).
+/// factories (``just(_:scheduling:file:function:line:)``, ``sequence(_:scheduling:file:function:line:)``).
 ///
 /// ## Composing effects
 ///
@@ -116,7 +116,7 @@ extension Effect {
     /// This SPI initialiser is intended for bridge targets (`SwiftRexCombine`, `SwiftRexRxSwift`, etc.) and
     /// extension packages that need to wrap a framework-specific publisher into an `Effect`
     /// without access to the internal `Component` type. Application code should prefer the
-    /// typed factories: `just(_:scheduling:file:function:line:)`,
+    /// typed factories: ``just(_:scheduling:file:function:line:)``,
     /// ``sequence(_:scheduling:file:function:line:)``, or the async/Combine/Rx overloads in
     /// the respective bridge modules.
     ///

--- a/Sources/SwiftRex/Effect/EffectScheduling.swift
+++ b/Sources/SwiftRex/Effect/EffectScheduling.swift
@@ -21,10 +21,10 @@
 /// | Goal | Policy |
 /// |---|---|
 /// | Fire-and-forget, no cancellation | ``immediately`` |
-/// | At most one concurrent run | ``replacing(id:)`` |
-/// | Wait for quiet period (search-as-you-type) | ``debounce(id:delay:)`` |
-/// | Rate-limit (scroll events, sensor data) | ``throttle(id:interval:)`` |
-/// | Explicit cancel without replacement | ``cancelInFlight(id:)`` |
+/// | At most one concurrent run | `replacing(id:)` |
+/// | Wait for quiet period (search-as-you-type) | `debounce(id:delay:)` |
+/// | Rate-limit (scroll events, sensor data) | `throttle(id:interval:)` |
+/// | Explicit cancel without replacement | `cancelInFlight(id:)` |
 ///
 /// ```swift
 /// // Debounce live search: reset the 300 ms timer on every keystroke
@@ -58,7 +58,7 @@ public enum EffectScheduling: Sendable {
 
     /// Cancel any existing component registered under `id`, then start this one in its place.
     ///
-    /// Unlike ``cancelInFlight(id:)`` which only removes the existing entry, `.replacing`
+    /// Unlike `cancelInFlight(id:)` which only removes the existing entry, `.replacing`
     /// starts a new component after cancelling the old one. This ensures there is always at most
     /// one component running under a given `id`.
     ///
@@ -79,7 +79,7 @@ public enum EffectScheduling: Sendable {
     /// resets and the previous pending work is cancelled. Only the component whose delay
     /// completes without interruption actually starts executing.
     ///
-    /// Debounced components are also cancellable via ``cancelInFlight(id:)`` at any point —
+    /// Debounced components are also cancellable via `cancelInFlight(id:)` at any point —
     /// both during the delay and after the component has started.
     ///
     /// ```swift
@@ -102,7 +102,7 @@ public enum EffectScheduling: Sendable {
     /// dropped — no work starts. When the interval has elapsed, the component starts and the
     /// timestamp is recorded for future throttle checks.
     ///
-    /// Throttled components are cancellable via ``cancelInFlight(id:)`` while they are running.
+    /// Throttled components are cancellable via `cancelInFlight(id:)` while they are running.
     ///
     /// ```swift
     /// // Update the UI at most once every second when scrolling
@@ -142,25 +142,25 @@ public enum EffectScheduling: Sendable {
 // constructor and the factory.
 
 extension EffectScheduling {
-    /// Creates a ``replacing(id:)`` policy from any `Hashable & Sendable` id.
+    /// Creates a `replacing(id:)` policy from any `Hashable & Sendable` id.
     @_disfavoredOverload
     public static func replacing(id: some Hashable & Sendable) -> Self {
         .replacing(id: AnyHashableSendable(id))
     }
 
-    /// Creates a ``debounce(id:delay:)`` policy from any `Hashable & Sendable` id.
+    /// Creates a `debounce(id:delay:)` policy from any `Hashable & Sendable` id.
     @_disfavoredOverload
     public static func debounce(id: some Hashable & Sendable, delay: Duration) -> Self {
         .debounce(id: AnyHashableSendable(id), delay: delay)
     }
 
-    /// Creates a ``throttle(id:interval:)`` policy from any `Hashable & Sendable` id.
+    /// Creates a `throttle(id:interval:)` policy from any `Hashable & Sendable` id.
     @_disfavoredOverload
     public static func throttle(id: some Hashable & Sendable, interval: Duration) -> Self {
         .throttle(id: AnyHashableSendable(id), interval: interval)
     }
 
-    /// Creates a ``cancelInFlight(id:)`` policy from any `Hashable & Sendable` id.
+    /// Creates a `cancelInFlight(id:)` policy from any `Hashable & Sendable` id.
     @_disfavoredOverload
     public static func cancelInFlight(id: some Hashable & Sendable) -> Self {
         .cancelInFlight(id: AnyHashableSendable(id))

--- a/Sources/SwiftRex/Foundation/ActionSource.swift
+++ b/Sources/SwiftRex/Foundation/ActionSource.swift
@@ -11,7 +11,7 @@
 /// via default parameter values:
 ///
 /// - ``StoreType/dispatch(_:file:function:line:)`` — at the UI or coordinator call site.
-/// - `just(_:scheduling:file:function:line:)` — at the effect factory call site.
+/// - ``Effect/just(_:scheduling:file:function:line:)`` — at the effect factory call site.
 /// - ``Effect/sequence(_:scheduling:file:function:line:)`` — same.
 /// - ``DispatchedAction/init(_:file:function:line:)`` — when wrapping manually.
 /// - The `here()` free function — for point-free pipelines.

--- a/Sources/SwiftRex/Foundation/ActionSource.swift
+++ b/Sources/SwiftRex/Foundation/ActionSource.swift
@@ -11,10 +11,10 @@
 /// via default parameter values:
 ///
 /// - ``StoreType/dispatch(_:file:function:line:)`` — at the UI or coordinator call site.
-/// - ``Effect/just(_:scheduling:file:function:line:)-5i6kl`` — at the effect factory call site.
+/// - `just(_:scheduling:file:function:line:)` — at the effect factory call site.
 /// - ``Effect/sequence(_:scheduling:file:function:line:)`` — same.
 /// - ``DispatchedAction/init(_:file:function:line:)`` — when wrapping manually.
-/// - The ``here()`` free function — for point-free pipelines.
+/// - The `here()` free function — for point-free pipelines.
 ///
 /// ## Usage in middleware
 ///

--- a/Sources/SwiftRex/Foundation/DispatchedAction.swift
+++ b/Sources/SwiftRex/Foundation/DispatchedAction.swift
@@ -9,7 +9,7 @@
 ///
 /// - ``Store/dispatch(_:file:function:line:)`` captures `#file`, `#function`, and `#line`
 ///   at the call site automatically.
-/// - ``Effect`` factories (``Effect/just(_:scheduling:file:function:line:)-5i6kl``,
+/// - ``Effect`` factories (`just(_:scheduling:file:function:line:)`,
 ///   ``Effect/sequence(_:scheduling:file:function:line:)``) do the same.
 /// - The `here()` free function packages the source location into a reusable closure for
 ///   point-free pipelines.

--- a/Sources/SwiftRex/Foundation/DispatchedAction.swift
+++ b/Sources/SwiftRex/Foundation/DispatchedAction.swift
@@ -9,7 +9,7 @@
 ///
 /// - ``Store/dispatch(_:file:function:line:)`` captures `#file`, `#function`, and `#line`
 ///   at the call site automatically.
-/// - ``Effect`` factories (`just(_:scheduling:file:function:line:)`,
+/// - ``Effect`` factories (``Effect/just(_:scheduling:file:function:line:)``,
 ///   ``Effect/sequence(_:scheduling:file:function:line:)``) do the same.
 /// - The `here()` free function packages the source location into a reusable closure for
 ///   point-free pipelines.

--- a/Sources/SwiftRex/Foundation/PreReducerContext.swift
+++ b/Sources/SwiftRex/Foundation/PreReducerContext.swift
@@ -36,7 +36,7 @@
 /// let localContext = context.map { $0.authState }
 /// ```
 ///
-/// - Note: The stored ``stateGetter`` is intentionally `@Sendable` so lifting transforms can safely
+/// - Note: The stored `stateGetter` is intentionally `@Sendable` so lifting transforms can safely
 ///   extract it and compose it when constructing child `PreReducerContext` instances. The
 ///   non-Sendability of the struct itself comes from a non-`@Sendable` sentinel property.
 @MainActor

--- a/Sources/SwiftRex/Foundation/SubscriptionToken.swift
+++ b/Sources/SwiftRex/Foundation/SubscriptionToken.swift
@@ -68,7 +68,7 @@ public final class SubscriptionToken: Sendable {
     /// Cancels the associated subscription or observation.
     ///
     /// For effect subscriptions, this calls the ``SubscriptionToken`` returned from the
-    /// ``Effect/Component/subscribe`` closure. For state observers registered via
+    /// `Effect.Component.subscribe` closure. For state observers registered via
     /// ``StoreType/observe(willChange:didChange:)``, this removes both callbacks. Also invoked
     /// automatically by `deinit` when the last reference is released.
     public func cancel() {

--- a/Sources/SwiftRex/Middleware/Middleware+LiftEach.swift
+++ b/Sources/SwiftRex/Middleware/Middleware+LiftEach.swift
@@ -163,7 +163,7 @@ extension Middleware {
 // MARK: - liftEach (general container — IndexedTraversal)
 
 extension Middleware {
-    /// Broadcasts across every focus of an ``IndexedTraversal`` (any container); each focus's
+    /// Broadcasts across every focus of an `IndexedTraversal` (any container); each focus's
     /// index is its scoping id. State container via `Lens`.
     public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
         action: @escaping @Sendable (GA) -> Action?,
@@ -180,7 +180,7 @@ extension Middleware {
         )
     }
 
-    /// Broadcasts across every focus of an ``IndexedTraversal``. State container via `WritableKeyPath`.
+    /// Broadcasts across every focus of an `IndexedTraversal`. State container via `WritableKeyPath`.
     public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable, ID: Hashable & Sendable>(
         action: @escaping @Sendable (GA) -> Action?,
         embed: @escaping @Sendable (Action, ID) -> GA,

--- a/Sources/SwiftRex/Middleware/Middleware+Transforms.swift
+++ b/Sources/SwiftRex/Middleware/Middleware+Transforms.swift
@@ -34,7 +34,7 @@ extension Middleware {
     /// Lifts the state axis of this middleware using a projection closure, embedding it in a
     /// wider global state type.
     ///
-    /// The ``PreReducerContext<GlobalState>`` is projected to ``PreReducerContext<State>`` using
+    /// The `PreReducerContext<GlobalState>` is projected to `PreReducerContext<State>` using
     /// `f` via ``PreReducerContext/map(_:)``. The same projection is applied in
     /// ``PostReducerContext`` (via `contramapEnvironment` on the returned `Reader`) so the
     /// middleware sees the correct post-mutation state in phase 3. Because ``Middleware`` is
@@ -149,7 +149,7 @@ extension Middleware {
     /// Lifts all three axes simultaneously using a `Prism` for action, a closure for state,
     /// and a closure for environment.
     ///
-    /// Equivalent to chaining ``liftAction(_:)``, ``liftState(_:)-9kjxz``, and
+    /// Equivalent to chaining `liftAction(_:)`, `liftState(_:)`, and
     /// ``liftEnvironment(_:)`` in sequence. The state projection uses a plain function, which
     /// is the most flexible form:
     ///

--- a/Sources/SwiftRex/Middleware/Middleware+Transforms.swift
+++ b/Sources/SwiftRex/Middleware/Middleware+Transforms.swift
@@ -149,7 +149,7 @@ extension Middleware {
     /// Lifts all three axes simultaneously using a `Prism` for action, a closure for state,
     /// and a closure for environment.
     ///
-    /// Equivalent to chaining `liftAction(_:)`, `liftState(_:)`, and
+    /// Equivalent to chaining ``liftAction(_:)``, ``liftState(_:)``, and
     /// ``liftEnvironment(_:)`` in sequence. The state projection uses a plain function, which
     /// is the most flexible form:
     ///

--- a/Sources/SwiftRex/Middleware/Middleware.swift
+++ b/Sources/SwiftRex/Middleware/Middleware.swift
@@ -40,7 +40,7 @@ import DataStructure
 /// ## Single action type
 ///
 /// `Middleware<Action, State, Environment>` uses a single `Action` type for both incoming and
-/// outgoing actions. To narrow the action scope, use ``liftAction(_:)`` with a `Prism` — actions
+/// outgoing actions. To narrow the action scope, use `liftAction(_:)` with a `Prism` — actions
 /// not matched by the prism are silently ignored, and produced actions are wrapped through the
 /// prism's `review` function before re-entering the Store.
 ///
@@ -66,13 +66,13 @@ import DataStructure
 /// Feature middlewares operate on local types. Use the lift family to embed them in the app's
 /// global types:
 ///
-/// - ``liftAction(_:)`` — narrows via a `Prism`
-/// - ``liftState(_:)-9kjxz`` — widens via a getter closure
-/// - ``liftState(_:)-5j4jz`` — widens via a `Lens`
-/// - ``liftState(_:)-3cpnb`` — widens via a `Prism` (optional enum state)
-/// - ``liftState(_:)-4f8n1`` — widens via an `AffineTraversal`
+/// - `liftAction(_:)` — narrows via a `Prism`
+/// - `liftState(_:)` — widens via a getter closure
+/// - `liftState(_:)` — widens via a `Lens`
+/// - `liftState(_:)` — widens via a `Prism` (optional enum state)
+/// - `liftState(_:)` — widens via an `AffineTraversal`
 /// - ``liftEnvironment(_:)`` — narrows via a projection closure
-/// - ``lift(action:state:environment:)-5ttmj`` and overloads — all three axes at once
+/// - `lift(action:state:environment:)` and overloads — all three axes at once
 public struct Middleware<Action: Sendable, State: Sendable, Environment: Sendable>: Sendable {
     /// The core function: given an action and a pre-mutation context, returns a deferred
     /// `Reader<PostReducerContext<State, Environment>, Effect<Action>>` that the Store will

--- a/Sources/SwiftRex/Middleware/Middleware.swift
+++ b/Sources/SwiftRex/Middleware/Middleware.swift
@@ -40,7 +40,7 @@ import DataStructure
 /// ## Single action type
 ///
 /// `Middleware<Action, State, Environment>` uses a single `Action` type for both incoming and
-/// outgoing actions. To narrow the action scope, use `liftAction(_:)` with a `Prism` — actions
+/// outgoing actions. To narrow the action scope, use ``liftAction(_:)`` with a `Prism` — actions
 /// not matched by the prism are silently ignored, and produced actions are wrapped through the
 /// prism's `review` function before re-entering the Store.
 ///
@@ -66,13 +66,13 @@ import DataStructure
 /// Feature middlewares operate on local types. Use the lift family to embed them in the app's
 /// global types:
 ///
-/// - `liftAction(_:)` — narrows via a `Prism`
-/// - `liftState(_:)` — widens via a getter closure
-/// - `liftState(_:)` — widens via a `Lens`
-/// - `liftState(_:)` — widens via a `Prism` (optional enum state)
-/// - `liftState(_:)` — widens via an `AffineTraversal`
+/// - ``liftAction(_:)`` — narrows via a `Prism`
+/// - ``liftState(_:)`` — widens via a getter closure
+/// - ``liftState(_:)`` — widens via a `Lens`
+/// - ``liftState(_:)`` — widens via a `Prism` (optional enum state)
+/// - ``liftState(_:)`` — widens via an `AffineTraversal`
 /// - ``liftEnvironment(_:)`` — narrows via a projection closure
-/// - `lift(action:state:environment:)` and overloads — all three axes at once
+/// - ``lift(action:state:environment:)`` and overloads — all three axes at once
 public struct Middleware<Action: Sendable, State: Sendable, Environment: Sendable>: Sendable {
     /// The core function: given an action and a pre-mutation context, returns a deferred
     /// `Reader<PostReducerContext<State, Environment>, Effect<Action>>` that the Store will

--- a/Sources/SwiftRex/Middleware/Reader+Monoid.swift
+++ b/Sources/SwiftRex/Middleware/Reader+Monoid.swift
@@ -30,7 +30,7 @@ extension Reader {
     /// Creates a `Reader<PostReducerContext<State, Environment>, Effect<Action>>` from a
     /// closure that receives the post-reducer context and returns an `Effect`.
     ///
-    /// Mirrors ``Consequence/produce(_:)`` so `Middleware` and `Behavior` handlers share the
+    /// Mirrors `Consequence.produce(_:)` so `Middleware` and `Behavior` handlers share the
     /// same vocabulary. The two forms below are equivalent:
     ///
     /// ```swift

--- a/Sources/SwiftRex/Reducer/Reducer+LiftEach.swift
+++ b/Sources/SwiftRex/Reducer/Reducer+LiftEach.swift
@@ -5,14 +5,14 @@ import DataStructure
 //
 // `liftEach` is the 0..n sibling of ``Reducer/liftCollection(action:stateContainer:)-``: where
 // `liftCollection` routes a global action to ONE element (selected by id), `liftEach` applies the
-// resolved local action to EVERY focus of a ``Traversal`` at once.
+// resolved local action to EVERY focus of a `Traversal` at once.
 //
 // A `Reducer` carries no effects, so the broadcast is just `Traversal.lift` of the per-element
 // reduce: each focus gets the same `EndoMut<StateType>` applied to its own state, zero-copy on
 // the array buffer. (Per-element effect-id scoping only matters for `Behavior`/`Middleware`.)
 
 extension Reducer {
-    /// Primitive — broadcast across a ``Traversal``, with a `Lens` state container.
+    /// Primitive — broadcast across a `Traversal`, with a `Lens` state container.
     ///
     /// - Parameters:
     ///   - action: Resolves a global action into the local `ActionType` to broadcast. Returns
@@ -30,7 +30,7 @@ extension Reducer {
         }
     }
 
-    /// Primitive — broadcast across a ``Traversal``, with a `WritableKeyPath` state container.
+    /// Primitive — broadcast across a `Traversal`, with a `WritableKeyPath` state container.
     public func liftEach<GA: Sendable, GS: Sendable, Container: Sendable>(
         action: @escaping @Sendable (GA) -> ActionType?,
         each: Traversal<Container, StateType>,

--- a/Sources/SwiftRex/Reducer/Reducer.swift
+++ b/Sources/SwiftRex/Reducer/Reducer.swift
@@ -78,7 +78,7 @@ public struct Reducer<ActionType: Sendable, StateType: Sendable>: Sendable {
     /// Given an action, produces an in-place endomorphism on `StateType`.
     ///
     /// The ``Store`` uses this as `reduce(action).runEndoMut(&_state)` in phase 2 of
-    /// dispatch. Built once from ``units``: a single `EndoMut` that runs every unit in order,
+    /// dispatch. Built once from `units`: a single `EndoMut` that runs every unit in order,
     /// so even a composition of many reducers allocates just one wrapper per call.
     public let reduce: @Sendable (ActionType) -> EndoMut<StateType>
 

--- a/Sources/SwiftRex/Store/Store.swift
+++ b/Sources/SwiftRex/Store/Store.swift
@@ -11,7 +11,7 @@ import Hourglass
 ///
 /// ## Three-phase dispatch
 ///
-/// Every dispatched action runs through four steps in ``runPhases``:
+/// Every dispatched action runs through four steps in `runPhases`:
 ///
 /// ```
 /// 1. behavior.handle(action, stateAccess)    — all Behaviors; stateAccess = pre-mutation state
@@ -29,13 +29,13 @@ import Hourglass
 ///
 /// ## Serialized, never-nested processing
 ///
-/// Actions are serialized through a FIFO ``queue`` guarded by an `isProcessing` flag, so
-/// ``runPhases`` never runs nested. A synchronous ``dispatch(_:source:)`` runs its action — and
+/// Actions are serialized through a FIFO `queue` guarded by an `isProcessing` flag, so
+/// `runPhases` never runs nested. A synchronous ``dispatch(_:source:)`` runs its action — and
 /// any actions dispatched synchronously while it runs (for example a `didChange` observer that
 /// re-dispatches) — within the same run loop turn, draining the queue in order. Because the
 /// pipeline is never re-entered mid-action, observers always see a fully-committed state.
 ///
-/// Actions produced by effects re-enter through a `Task` hop (see ``makeSend``), so they are
+/// Actions produced by effects re-enter through a `Task` hop (see `makeSend`), so they are
 /// always processed on a later turn rather than inline — keeping effect work off the run loop
 /// turn that drove the original UI dispatch.
 ///
@@ -68,7 +68,7 @@ import Hourglass
 ///
 /// ## Effect lifecycle
 ///
-/// Each ``Effect/Component`` is tracked in `effects: [AnyHashableSendable: SubscriptionToken]`.
+/// Each `Effect.Component` is tracked in `effects: [AnyHashableSendable: SubscriptionToken]`.
 /// Anonymous (`.immediately`) components use a `UUID` key that is removed on `complete`.
 /// Named components (`.replacing`, `.debounce`, `.throttle`) use the caller-supplied id.
 ///
@@ -119,7 +119,7 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
     // MARK: - Injected co-effects
 
     /// Clock used for all ``EffectScheduling`` timing (debounce sleep, throttle window). Erased to
-    /// ``AnyClock`` so the Store carries no clock generic; injected at `init` (defaults to
+    /// `AnyClock` so the Store carries no clock generic; injected at `init` (defaults to
     /// `ContinuousClock`, swappable for a `TestClock`/`ImmediateClock` of the same `Duration`).
     private let clock: AnyClock<Swift.Duration>
 
@@ -186,7 +186,7 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
     /// Creates a `Store` extracting the scheduling clock — and optionally the RNG — from the
     /// environment.
     ///
-    /// The concrete clock `C` is inferred at the call site and erased to ``AnyClock`` at
+    /// The concrete clock `C` is inferred at the call site and erased to `AnyClock` at
     /// construction, so `Store` carries no clock generic. Pass a `TestClock`/`ImmediateClock`
     /// for deterministic ``EffectScheduling`` in tests.
     ///
@@ -330,7 +330,7 @@ public final class Store<Action: Sendable, State: Sendable, Environment: Sendabl
     ///
     /// This is the single entry point for every action, whether it comes from a synchronous
     /// `dispatch` call or (via `makeSend`'s `Task` hop) from an effect. The `isProcessing`
-    /// guard guarantees the three-phase pipeline in ``runPhases`` never runs nested.
+    /// guard guarantees the three-phase pipeline in `runPhases` never runs nested.
     private func process(_ dispatched: DispatchedAction<Action>) {
         queue.append(dispatched)
         guard !isProcessing else { return }

--- a/Sources/SwiftRex/SwiftRex.docc/Algebra.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Algebra.md
@@ -1,0 +1,62 @@
+# The Algebra
+
+Why SwiftRex is a handful of monoids and a single interpreter — and what that buys you.
+
+## Overview
+
+SwiftRex's core types form a small, lawful algebra. There is really only one way to put things together — a **monoid** — and only one thing that ever runs — the ``Store``. Once those two ideas click, the rest of the library is a consequence.
+
+## Everything composes the same way: monoids
+
+A **monoid** is a type with a `combine` that takes two values and returns one of the same type, plus an `identity` value that changes nothing when combined. That's it. SwiftRex leans on it everywhere, so "wire two features together" is always the same move — `combine` — and never bespoke glue.
+
+| Type | What `combine` means | `identity` |
+|---|---|---|
+| ``Reducer`` | **sequential** — run `lhs` then `rhs` on the same `inout State`; order matters, `rhs` sees `lhs`'s change | a reducer that mutates nothing |
+| ``Effect`` | **parallel** — both run; the ``Store`` interprets them concurrently | `.empty` |
+| ``ReducerOutcome`` | absorb ``ReducerOutcome/unchanged``; otherwise compose the underlying `EndoMut` mutations | `.unchanged` |
+| ``Consequence`` | **product** — componentwise: the ``ReducerOutcome`` (sequential) × the effect `Reader` (parallel) | `.doNothing` |
+| ``Behavior`` | the primary unit (``Reducer`` + ``Middleware``); a flat fold over its parts | `.identity` |
+| ``Middleware`` | the effect-only half; effects merged | `.identity` |
+
+The keystone is ``Consequence`` — a **product monoid**. A ``Behavior``'s `handle` maps an action to a `Consequence`: the pair of *what state change to apply* (a ``ReducerOutcome``) and *what effect to run afterward* (a `Reader<PostReducerContext, Effect>`). Because a pair of monoids is itself a monoid, composing whole features is just composing their `Behavior`s — the state mutations fold **sequentially**, the effects merge in **parallel**, and you still hold a single value.
+
+```swift
+// Two independent features, composed with the monoid:
+let app = counter.lifted <> profile.lifted        // <> is `combine`
+// `app` is one Behavior; dispatching an action runs both, atomically.
+```
+
+## Only the Store runs: it's an IO runtime
+
+A ``Reducer``, an ``Effect``, a ``Behavior`` are *descriptions*. Building one executes nothing — no task starts, no state changes. The ``Store`` is the sole **interpreter** (think Haskell's `IO` at the program's edge): it's the one place effects fire and state mutates.
+
+For each action, on the main actor, the Store runs three phases:
+
+1. **Pre-mutation.** `behavior.handle(action, preContext)` returns a ``Consequence``. The ``PreReducerContext`` exposes the *current* state.
+2. **Mutation (zero-copy).** If the outcome is ``ReducerOutcome/unchanged``, nothing happens and **no observer is notified**. Otherwise: `willChange` → the `EndoMut` mutates `state` in place → `didChange`.
+3. **Effects.** A ``PostReducerContext`` (now exposing *post-mutation* state and the `Environment`) resolves the effect `Reader`; each ``Effect`` component is scheduled by its ``EffectScheduling`` (``EffectScheduling/immediately``, `.replacing`, `.debounce`, `.throttle`, `.cancelInFlight`). Actions produced by effects loop back to phase 1.
+
+## What the algebra guarantees
+
+The monoid-plus-one-interpreter design isn't aesthetic — it's where the runtime guarantees come from:
+
+- **Exactly one notification per state-changing action.** A composed ``Behavior`` runs *all* its parts inside a single `handle` call; by Swift's Law of Exclusivity the Store regains `state` only after the whole pipeline finishes — observers never see a half-applied state. Pure-routing or effect-only actions resolve to ``ReducerOutcome/unchanged`` and notify **zero** times.
+- **Zero-copy mutation.** State changes through `inout` / `EndoMut`, never a copy-to-diff.
+- **Effects see committed state.** Effect closures resolve against post-mutation state, via ``PostReducerContext``.
+- **Re-entrancy is safe.** Actions dispatched while the Store is mid-drain are queued and processed FIFO; a runaway loop is cut off at ``StoreHooks/reentranceThreshold``.
+
+## The view boundary stays pure too
+
+The ``Store`` never deduplicates — it always notifies, copies nothing. Narrowing for views is done by two pure helpers:
+
+- ``StoreProjection`` — a *stateless* `struct` that maps global action/state to a local slice (a lens with no storage of its own).
+- ``StoreBuffer`` — the caching/deduplicating layer that skips propagation when the projected slice is unchanged (`Equatable`, or a custom predicate).
+
+## See also
+
+- ``Behavior``
+- ``Consequence``
+- ``Store``
+- ``Reducer``
+- ``Effect``

--- a/Sources/SwiftRex/SwiftRex.docc/Reducer.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Reducer.md
@@ -1,0 +1,74 @@
+# ``SwiftRex/Reducer``
+
+The one place state changes — a pure function from an action to an in-place mutation.
+
+## Overview
+
+A `Reducer<ActionType, StateType>` maps an action to an `EndoMut<State>` — an in-place endomorphism on your state. It is the **only** layer in SwiftRex allowed to mutate state, and it does so purely: no side effects, no async work, no environment. Effects live in ``Middleware``; the two combine into a ``Behavior``.
+
+```swift
+let counter = Reducer<CounterAction, Int>.reduce { action, state in
+    switch action {
+    case .increment: state += 1
+    case .decrement: state -= 1
+    case .reset:     state = 0
+    }
+}
+```
+
+### Creating one
+
+There are four `reduce` factories — pick whichever reads best; they all build the same value:
+
+- `reduce { action, state in … }` — the idiomatic **`inout`** form (zero-copy).
+- `reduce { action, state in newState }` — the **pure-return** form, converted to `inout` internally.
+- `reduce { action in EndoMut { … } }` — return an `EndoMut` directly; handy when composing endomorphisms or optimising a hot path.
+- `reduce { action in Endo { … } }` — the value-level `Endo` variant (bridges to `EndoMut`).
+
+### The algebra — a sequential monoid
+
+`Reducer` is a `Monoid`. ``combine(_:_:)`` runs `lhs` then `rhs` on the **same** `inout` state (order matters; `rhs` sees `lhs`'s change); ``identity`` mutates nothing. This is precisely the structure of `EndoMut`'s monoid lifted over actions — see <doc:Algebra>. Build composite reducers with the `@ReducerBuilder` DSL:
+
+```swift
+let app = Reducer.compose {
+    counterReducer
+    historyReducer            // runs after counterReducer, sees its mutation
+}
+```
+
+### Scaling a feature up
+
+A reducer written at *local* types is lifted to your app's *global* types before composing:
+
+- **`lift`** — map the action (a `KeyPath`/`Prism`) and focus the state (a `WritableKeyPath`/`Lens`/`AffineTraversal`), together or one axis at a time.
+- **`liftCollection`** — run a per-element reducer across an `Identifiable`/custom-keyed collection or a dictionary, addressed by id.
+- **`liftEach`** — the broadcast form: apply to *every* element.
+
+See <doc:Algebra> for why lifting composes cleanly, and ``ElementAction`` for how element actions are addressed.
+
+### Becoming a Behavior
+
+``asBehavior()`` turns a `Reducer` into a ``Behavior`` whose effect is always empty — the bridge for combining pure reducers with effectful middleware under one type.
+
+> The `reduce`, `lift`, `liftCollection`, and `liftEach` families are overloaded; DocC lists each overload in the automatic method sections below. They're walked through in the Overview above and in the upcoming Lifting article.
+
+## Topics
+
+### Composing
+
+- ``combine(_:_:)``
+- ``identity``
+- ``mconcat(_:)``
+- ``sconcat(_:_:)``
+- ``ReducerBuilder``
+
+### Bridging
+
+- ``asBehavior()``
+
+## See Also
+
+- ``Behavior``
+- ``Middleware``
+- ``ReducerOutcome``
+- <doc:Algebra>

--- a/Sources/SwiftRex/SwiftRex.docc/Reducer.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Reducer.md
@@ -50,9 +50,11 @@ See <doc:Algebra> for why lifting composes cleanly, and ``ElementAction`` for ho
 
 ``asBehavior()`` turns a `Reducer` into a ``Behavior`` whose effect is always empty — the bridge for combining pure reducers with effectful middleware under one type.
 
-> The `reduce`, `lift`, `liftCollection`, and `liftEach` families are overloaded; DocC lists each overload in the automatic method sections below. They're walked through in the Overview above and in the upcoming Lifting article.
-
 ## Topics
+
+### Creating a Reducer
+
+- ``reduce(_:)``
 
 ### Composing
 
@@ -61,6 +63,12 @@ See <doc:Algebra> for why lifting composes cleanly, and ``ElementAction`` for ho
 - ``mconcat(_:)``
 - ``sconcat(_:_:)``
 - ``ReducerBuilder``
+
+### Lifting to a Larger Scope
+
+- ``lift(action:state:)``
+- ``liftCollection(action:stateContainer:)``
+- ``liftEach(action:each:stateContainer:)``
 
 ### Bridging
 

--- a/Sources/SwiftRex/SwiftRex.docc/SwiftRex.md
+++ b/Sources/SwiftRex/SwiftRex.docc/SwiftRex.md
@@ -1,0 +1,69 @@
+# ``SwiftRex``
+
+Unidirectional dataflow as a small, lawful algebra — pure values you compose, run by a single interpreter.
+
+## Overview
+
+SwiftRex models your whole app as one loop of pure values:
+
+- An **action** describes something that happened.
+- A ``Behavior`` (a ``Reducer`` for the state change, a ``Middleware`` for the effect) maps that action to a ``Consequence`` — *what to change* (a ``ReducerOutcome``) and *what to do next* (an ``Effect``).
+- The ``Store`` is the **only** thing that runs: it applies the mutation, notifies observers exactly once, then executes the effect. Actions the effect produces loop back through the same path.
+
+Everything except the `Store` is inert and composable. Two `Reducer`s combine into a `Reducer`; two `Behavior`s into a `Behavior`; an `Effect` merges with another `Effect`. That "compose two, get one of the same kind, with a do-nothing identity" shape is a **monoid**, and it's the whole story — see <doc:Algebra>.
+
+> New here? Start with the [README](https://github.com/SwiftRex/SwiftRex#readme) for installation and worked examples, then come back for the type-by-type reference below.
+
+## Companion Products
+
+`SwiftRex` is the core. These ship as separate products (each its own import); the third-party bridges are opt-in via package traits:
+
+- **`SwiftRex.SwiftConcurrency`** — `async`/`await` effect bridges (`Task`, `AsyncSequence`), `store.stream`.
+- **`SwiftRex.Combine`** — `asEffect()` on `Publisher`, `store.publisher`, `ctx.readLiveState()`.
+- **`SwiftRex.RxSwift`** · **`SwiftRex.ReactiveSwift`** · **`SwiftRex.ReactiveConcurrency`** — the same bridge surface for each reactive runtime *(each behind a trait of the same name)*.
+- **`SwiftRex.SwiftUI`** — `asObservableObject()`, the `@ViewModel` macro, `HasViewModel`.
+- **`SwiftRex.Architecture`** — the opinionated `@Feature` module pattern.
+- **`SwiftRex.Operators`** — symbolic operators (`<>`, `|>`, …) for the types above.
+- **`SwiftRex.Testing`** — `TestStore` for deterministic, exhaustive unit tests.
+
+## Topics
+
+### Concepts
+
+- <doc:Algebra>
+
+### The Core Loop
+
+- ``Reducer``
+- ``Effect``
+- ``Middleware``
+- ``Behavior``
+- ``Consequence``
+- ``ReducerOutcome``
+
+### Running It — the Store
+
+- ``Store``
+- ``StoreType``
+- ``StoreProjection``
+- ``StoreBuffer``
+- ``StoreHooks``
+- ``StoreReentranceInfo``
+
+### Actions & Context
+
+- ``ActionSource``
+- ``DispatchedAction``
+- ``ElementAction``
+- ``PreReducerContext``
+- ``PostReducerContext``
+
+### Effects & Scheduling
+
+- ``EffectScheduling``
+- ``SubscriptionToken``
+- ``AnyHashableSendable``
+
+### Composition
+
+- ``ReducerBuilder``


### PR DESCRIPTION
## What?
Adds the first piece of the SwiftRex DocC catalog at `Sources/SwiftRex/SwiftRex.docc/`: a curated **landing page** and the **Algebra** deep-dive article.

## Why?
We're moving the project's conceptual documentation into the official, rendered, link-checked, PR-enforced docs (README + DocC) — no more standalone strays like the retired ARCHITECTURE.md. This PR establishes the catalog structure and writing voice so the rest (symbol extensions, per-topic articles, compilable example walkthroughs) can be filled in consistently.

## How?
- **`SwiftRex.md`** — landing page. `## Topics` groups curate **all 21 core public symbols** (The Core Loop, Running It — the Store, Actions & Context, Effects & Scheduling, Composition), plus a Concepts group linking the article. Narrative **Companion Products** section (in prose, before `## Topics`, since task groups only accept links) covers the bridge / SwiftUI / Architecture / Testing products.
- **`Algebra.md`** — article: the monoid lattice (Reducer sequential, Effect parallel, `ReducerOutcome`, `Consequence` = product monoid, Behavior/Middleware), the `Store` as the sole IO interpreter, the three dispatch phases, and the guarantees (one notification per state change, `.unchanged` skips, zero-copy `inout`, committed-state effects, FIFO re-entrancy).
- DocC catalogs under the `SwiftRex` target are picked up automatically by `docs.yml`/`.spi.yml` — **no workflow changes**.
- Verified with `swift package generate-documentation` — **the catalog files build warning-free** and both pages render.

## Tests
- [x] Edge cases covered — N/A (docs)
- [x] Lint approved — no Swift changes
- [x] Periphery approved — no Swift changes
- [x] Docs updated
- [x] README updated — N/A (README unchanged; algebra already landed there in #170, deepened here)

---
**Follow-ups (tracked, not in this PR):**
- Per-entity **symbol extensions** (Reducer, Effect, Middleware, Behavior, Consequence, Store, StoreProjection, StoreBuffer).
- Per-topic **articles**: Lifting, Middleware, Behavior, Store, State+Action, Projection (absorbs and retires the root `Reducer.md`).
- **Example / walkthrough articles** — compilable, step-by-step "build a feature / view / app".
- Pre-existing **inline-comment DocC link debt**: ~59 unresolved/ambiguous `` ``symbol`` `` links in existing `///` comments (cross-module types like `EndoMut`/`Monoid`, overloaded `liftAction`/scheduling cases). Separate cleanup; consider a PR-time DocC-warnings check.