### PR TITLE
docs(DocC): symbol extensions for the remaining seven core types

### DIFF
--- a/Sources/SwiftRex/SwiftRex.docc/Behavior.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Behavior.md
@@ -1,0 +1,59 @@
+# ``SwiftRex/Behavior``
+
+The primary composition unit — a ``Reducer`` and a ``Middleware`` fused into one liftable, composable value.
+
+## Overview
+
+A `Behavior<Action, State, Environment>` maps an action and a pre-mutation ``PreReducerContext`` to a ``Consequence`` — the pair of *what state change to apply* and *what effect to run afterward*. It is how you usually build a feature: rather than wiring a ``Reducer`` and a ``Middleware`` separately, you express both in one value.
+
+```swift
+let form = Behavior<AppAction, AppState, API> { action, _ in
+    guard case .submit(let data) = action else { return .doNothing }
+    return .reduce { $0.isLoading = true }
+        .produce { ctx in ctx.environment.api.submit(data).asEffect(AppAction.submitted) }
+}
+```
+
+Create one from a closure (``handle(_:)``), or from the two halves with `Behavior(reducer:middleware:)`; ``Reducer/asBehavior()`` and ``Middleware/asBehavior`` lift each half on its own.
+
+### The algebra — a flat fold of units
+
+`Behavior` is a `Monoid`. ``combine(_:_:)`` runs both behaviors on the same action, folding their state mutations **sequentially** and merging their effects in **parallel** (its ``Consequence`` is a product monoid); ``identity`` does nothing and — crucially — composes away to a no-op that the ``Store`` skips entirely. Composition is a single flat pass over the underlying units, not a nested closure tree. See <doc:Algebra>.
+
+```swift
+let app = Behavior.combine(counter.lifted, profile.lifted)   // or counter.lifted <> profile.lifted
+```
+
+### Scaling a feature up
+
+``lift(action:state:environment:)`` and the per-axis ``liftAction(_:)`` / ``liftState(_:)`` / ``liftEnvironment(_:)`` raise a feature from its local types to the app's global types; ``liftCollection(action:embed:stateContainer:)`` and ``liftEach(action:embed:each:stateContainer:)`` run a per-element behavior across a collection. ``on(_:reduce:)`` and friends route by action case.
+
+## Topics
+
+### Creating a Behavior
+
+- ``handle(_:)``
+
+### Composing
+
+- ``combine(_:_:)``
+- ``mconcat(_:)``
+- ``sconcat(_:_:)``
+
+### Lifting to a Larger Scope
+
+- ``lift(action:state:environment:)``
+- ``liftAction(_:)``
+- ``liftState(_:)``
+- ``liftEnvironment(_:)``
+- ``liftCollection(action:embed:stateContainer:)``
+- ``liftEach(action:embed:each:stateContainer:)``
+
+## See Also
+
+- ``Reducer``
+- ``Middleware``
+- ``Consequence``
+- ``ReducerOutcome``
+- ``Store``
+- <doc:Algebra>

--- a/Sources/SwiftRex/SwiftRex.docc/Consequence.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Consequence.md
@@ -1,0 +1,33 @@
+# ``SwiftRex/Consequence``
+
+The outcome of handling an action — a state change paired with a deferred effect.
+
+## Overview
+
+A `Consequence<State, Environment, Action>` is what a ``Behavior`` returns: a ``ReducerOutcome`` (the state mutation to apply, or ``ReducerOutcome/unchanged``) paired with a `Reader<PostReducerContext, Effect>` (the effect to run afterward). The ``Store`` applies the mutation in phase 2 and resolves the effect, against post-mutation state, in phase 3.
+
+### Building one
+
+- ``reduce(_:)`` — a pure state mutation, no effect.
+- `produce { ctx in … }` — an effect, no mutation.
+- chain them — `.reduce { … }.produce { ctx in … }` — for both.
+- ``doNothing`` — neither (the monoid identity); the ``Store`` fires no notifications for it.
+
+### The algebra — a product monoid
+
+`Consequence` is a `Monoid`: ``combine(_:_:)`` composes componentwise — the ``ReducerOutcome`` mutations fold **sequentially**, the effect `Reader`s merge in **parallel** — with ``doNothing`` as the identity. This product structure is exactly why composing ``Behavior``s composes *both* their state changes and their effects in a single value. See <doc:Algebra>.
+
+## Topics
+
+### Building a Consequence
+
+- ``reduce(_:)``
+- ``doNothing``
+
+## See Also
+
+- ``Behavior``
+- ``ReducerOutcome``
+- ``Effect``
+- ``PostReducerContext``
+- <doc:Algebra>

--- a/Sources/SwiftRex/SwiftRex.docc/Effect.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Effect.md
@@ -1,0 +1,55 @@
+# ``SwiftRex/Effect``
+
+A lazy, framework-agnostic description of side-effecting work — it runs only when the Store executes it.
+
+## Overview
+
+An `Effect<Action>` is the unit of side effect a ``Middleware`` (or a ``Behavior``) returns. It is **inert until run**: constructing one starts nothing — no `Task`, no network call — until the ``Store`` subscribes to it. That is what keeps the reducer/behavior layer pure. An effect produces zero or more actions that loop back into the Store.
+
+`Effect` exposes no `Task`, `AsyncStream`, `Publisher`, or `Observable` in its API — those live in the companion products (`SwiftRex.SwiftConcurrency`, `SwiftRex.Combine`, `SwiftRex.RxSwift`, `SwiftRex.ReactiveSwift`, `SwiftRex.ReactiveConcurrency`), each adding `asEffect()` bridges.
+
+### Creating one
+
+- ``just(_:scheduling:file:function:line:)`` — dispatch a single action.
+- ``sequence(_:scheduling:file:function:line:)`` — dispatch a fixed list of actions.
+- ``empty`` — do nothing (the monoid identity).
+- a companion product's `asEffect()` — bridge a publisher / observable / async sequence.
+
+### Scheduling
+
+Attach an ``EffectScheduling`` policy with ``scheduling(_:)``: run immediately, or under an id so the Store can debounce, throttle, replace, or cancel it in flight. The mutable bookkeeping (timers, in-flight handles) lives in the ``Store``, never in the effect.
+
+```swift
+api.search(query).asEffect(AppAction.results)
+    .scheduling(.debounce(id: "search", delay: .milliseconds(300)))
+```
+
+### The algebra — a parallel monoid
+
+`Effect` is a `Monoid`: ``combine(_:_:)`` merges two effects so the ``Store`` runs them **concurrently**, and ``empty`` is the identity. It is a Functor via ``map(_:)``. See <doc:Algebra>.
+
+## Topics
+
+### Creating an Effect
+
+- ``just(_:scheduling:file:function:line:)``
+- ``sequence(_:scheduling:file:function:line:)``
+- ``empty``
+
+### Scheduling
+
+- ``scheduling(_:)``
+
+### Transforming & Composing
+
+- ``map(_:)``
+- ``combine(_:_:)``
+- ``identity``
+
+## See Also
+
+- ``EffectScheduling``
+- ``Middleware``
+- ``Behavior``
+- ``SubscriptionToken``
+- <doc:Algebra>

--- a/Sources/SwiftRex/SwiftRex.docc/Middleware.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Middleware.md
@@ -1,0 +1,66 @@
+# ``SwiftRex/Middleware``
+
+The effect-only half of a feature — it reads state and the environment and returns an ``Effect``, but never mutates state.
+
+## Overview
+
+A `Middleware<Action, State, Environment>` maps an action and a pre-mutation ``PreReducerContext`` to a `Reader<PostReducerContext, Effect>` — a deferred effect the ``Store`` resolves in phase 3 (post-mutation), with access to the `Environment` and the committed `liveState`. It is the only layer allowed side effects; it never changes state — that is ``Reducer``. Combine a `Reducer` and a `Middleware` to get a ``Behavior``.
+
+```swift
+let search = Middleware<AppAction, AppState, API>.handle { action, _ in
+    guard case .search(let query) = action else { return Reader { _ in .empty } }
+    return Reader { ctx in
+        ctx.environment.search(query).asEffect(AppAction.results)
+    }
+}
+```
+
+### The algebra — a parallel monoid
+
+`Middleware` is a `Monoid`: ``combine(_:_:)`` runs both middlewares on the same action and **merges their effects**; ``identity`` produces no effect. See <doc:Algebra>.
+
+### Scaling a feature up
+
+A middleware written at *local* types is lifted to your app's *global* types before composing:
+
+- ``lift(action:state:environment:)`` — all three axes at once.
+- ``liftAction(_:)`` / ``liftState(_:)`` / ``liftEnvironment(_:)`` — one axis at a time (`Prism`/`KeyPath`/`Lens`/`AffineTraversal`/projection closure).
+- ``liftCollection(action:embed:stateContainer:)`` / ``liftEach(action:embed:each:stateContainer:)`` — run a per-element middleware across a keyed collection, or broadcast to all elements.
+
+Use the `on(…)` family to route by action case without a manual `guard case`.
+
+### Becoming a Behavior
+
+``asBehavior`` lifts a `Middleware` into a ``Behavior`` whose state mutation is always ``ReducerOutcome/unchanged`` — the bridge for combining pure effects with reducers under one type.
+
+## Topics
+
+### Creating a Middleware
+
+- ``handle(_:)``
+
+### Composing
+
+- ``combine(_:_:)``
+
+### Lifting to a Larger Scope
+
+- ``lift(action:state:environment:)``
+- ``liftAction(_:)``
+- ``liftState(_:)``
+- ``liftEnvironment(_:)``
+- ``liftCollection(action:embed:stateContainer:)``
+- ``liftEach(action:embed:each:stateContainer:)``
+
+### Bridging
+
+- ``asBehavior``
+
+## See Also
+
+- ``Reducer``
+- ``Behavior``
+- ``Effect``
+- ``PreReducerContext``
+- ``PostReducerContext``
+- <doc:Algebra>

--- a/Sources/SwiftRex/SwiftRex.docc/Store.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Store.md
@@ -1,0 +1,53 @@
+# ``SwiftRex/Store``
+
+The single interpreter — the only place state mutates and effects run.
+
+## Overview
+
+`Store<Action, State, Environment>` owns your app's state and is the sole executor of effects. You dispatch actions; for each one it runs the ``Behavior`` in three phases — compute the ``Consequence`` against pre-mutation state, apply the mutation in place (bracketed by `willChange`/`didChange` notifications), then resolve and schedule the effect against post-mutation state. Actions produced by effects loop back. Its whole surface is `@MainActor`, so `withAnimation { store.dispatch(...) }` works with no special API.
+
+The `Store` is the interpreter for the inert values the rest of the library builds (`IO` at the program's edge). See <doc:Algebra> for the guarantees this yields: one notification per state-changing action, zero-copy mutation, committed-state effects, and FIFO-safe re-entrancy.
+
+### Creating one
+
+```swift
+let store = Store(initial: AppState(), behavior: appBehavior, environment: env)
+```
+
+When `Environment == Void` a convenience initialiser omits it; another accepts an injected `Clock`/`Date`/`UUID` for deterministic time in tests.
+
+### Dispatching & observing
+
+``dispatch(_:source:)`` enqueues an action (synchronous from `@MainActor`). ``observe(willChange:didChange:)`` registers a `@MainActor` observer and returns a ``SubscriptionToken`` you must retain — releasing it cancels the observation.
+
+### Narrowing for views
+
+``StoreType/projection(action:state:)`` maps the store to a local action/state slice (a stateless ``StoreProjection``); ``StoreType/buffer()`` wraps it in a deduplicating ``StoreBuffer``. Run-away dispatch loops are cut off via ``StoreHooks``.
+
+## Topics
+
+### Dispatching
+
+- ``dispatch(_:source:)``
+
+### Observing
+
+- ``observe(willChange:didChange:)``
+
+### Narrowing for Views
+
+- ``StoreType/projection(action:state:)``
+- ``StoreType/buffer()``
+
+### Diagnostics
+
+- ``StoreHooks``
+- ``StoreReentranceInfo``
+
+## See Also
+
+- ``StoreType``
+- ``StoreProjection``
+- ``StoreBuffer``
+- ``Behavior``
+- <doc:Algebra>

--- a/Sources/SwiftRex/SwiftRex.docc/StoreBuffer.md
+++ b/Sources/SwiftRex/SwiftRex.docc/StoreBuffer.md
@@ -1,0 +1,32 @@
+# ``SwiftRex/StoreBuffer``
+
+A caching, deduplicating wrapper — propagates a state change only when the slice actually changed.
+
+## Overview
+
+`StoreBuffer<Action, State>` is a `@MainActor` `final class` that wraps any ``StoreType`` and adds **caching and deduplication**: it holds a `state` snapshot and notifies its observers only when the new value differs — by `Equatable`, or by a predicate you supply. The plain ``Store`` always notifies and copies nothing; `StoreBuffer` is where you opt into "skip the redundant render", which makes it the natural backing for SwiftUI observation.
+
+```swift
+let buffered = appStore
+    .projection(action: AppAction.counter, state: \.counterView)  // narrow (StoreProjection)
+    .buffer()                                                     // dedup — CounterView: Equatable
+```
+
+A typical pipeline is **``Store`` → ``StoreProjection`` (narrow) → `StoreBuffer` (dedup) → view**.
+
+## Topics
+
+### Creating a Buffer
+
+- ``StoreType/buffer()``
+
+### Reading & Dispatching
+
+- ``state``
+- ``dispatch(_:source:)``
+
+## See Also
+
+- ``Store``
+- ``StoreProjection``
+- ``StoreType``

--- a/Sources/SwiftRex/SwiftRex.docc/StoreProjection.md
+++ b/Sources/SwiftRex/SwiftRex.docc/StoreProjection.md
@@ -1,0 +1,32 @@
+# ``SwiftRex/StoreProjection``
+
+A stateless lens onto a Store — presents a narrower action and state to a feature or view.
+
+## Overview
+
+`StoreProjection<Action, State>` is a `struct` that holds no state of its own: it maps a global store's action and state to a local slice, recomputing `state` on each read from its stored closures. It conforms to ``StoreType``, so a feature can be handed a `StoreProjection` and never needs to know where its slice lives in the global state.
+
+```swift
+let counter = appStore.projection(
+    action: AppAction.counter,        // CounterAction → AppAction
+    state: \.counterState             // AppState → CounterState
+)
+```
+
+Focus a single collection element with the `projection(element:…)` (by `Identifiable` id or custom identifier) or `projection(key:…)` (dictionary) factories — actions are wrapped in an ``ElementAction``.
+
+`StoreProjection` does **no** deduplication — the underlying ``Store`` always notifies. When you want to skip redundant view updates, wrap it in a ``StoreBuffer`` via ``StoreType/buffer()``.
+
+## Topics
+
+### Reading & Dispatching
+
+- ``state``
+- ``dispatch(_:source:)``
+
+## See Also
+
+- ``Store``
+- ``StoreBuffer``
+- ``StoreType``
+- ``ElementAction``


### PR DESCRIPTION
## What?
Adds DocC symbol extensions for `Effect`, `Middleware`, `Behavior`, `Consequence`, `Store`, `StoreProjection`, and `StoreBuffer`, completing the set started by `Reducer`.

## Why?
Per the documentation standard, every big entity gets a rich type page — what it does, its place in the algebra, examples, and curated members with cross-links — so the reference docs teach, not just list signatures.

## How?
Each `Sources/SwiftRex/SwiftRex.docc/<Type>.md` follows the locked exemplar shape:
- **Overview** — purpose, how to create it, its **algebra** (linked to `<doc:Algebra>`), the key operations and the lifting/bridging story, all with short examples.
- **`## Topics`** — curates the unambiguous members and overload groups.
- **`## See Also`** — related types + the Algebra article.

Verified with `swift package generate-documentation --enable-experimental-overloaded-symbol-presentation`: **0 link/curation warnings**, all seven pages render. The landing page already links these type pages (now enriched), so no change there. Docs-only — no Swift, build/lint untouched.

## Tests
- [x] Docs updated
- [x] README updated — N/A (README unchanged)
- [x] Lint approved — no Swift changes
- [x] Periphery approved — no Swift changes

---
**Remaining catalog work (follow-ups):** topic articles (Lifting, **Modularisation & Feature**, Middleware/Behavior/Store/State+Action/Projection — absorbing/retiring the root `Reducer.md`) and compilable example/walkthrough articles.