### PR TITLE
docs(DocC): State & Actions article + compilable example walkthroughs

### DIFF
--- a/Sources/SwiftRex/SwiftRex.docc/AddingEffects.md
+++ b/Sources/SwiftRex/SwiftRex.docc/AddingEffects.md
@@ -1,0 +1,92 @@
+# Adding Effects
+
+Reach the outside world — and fold the result back in as an action.
+
+## Overview
+
+The counter in <doc:BuildYourFirstFeature> was pure. Real features talk to networks, clocks, and databases. In SwiftRex that work lives in exactly one place: an ``Effect`` returned by a ``Behavior``. The behavior stays pure — it *describes* the effect — and the ``Store`` runs it, looping the outcome back as another action. Dependencies arrive through the feature's `Environment`, never as singletons. Every snippet here compiles against the current API.
+
+## Step 1 — Declare the dependency
+
+The `Environment` is whatever the feature needs from the outside. Model it as a value of injectable functions, so tests pass a fake and production passes the real thing.
+
+```swift
+import SwiftRex
+import SwiftRexSwiftConcurrency   // async/await → Effect bridges
+
+struct API: Sendable {
+    var fetch: @Sendable (Int) async throws -> String
+}
+```
+
+## Step 2 — Make the result an action
+
+The async call can succeed or fail; carry that back in as a `Result` case so the reducer remains deterministic.
+
+```swift
+enum LoaderAction: Sendable {
+    case load(Int)
+    case didLoad(Result<String, Error>)
+}
+
+struct LoaderState: Equatable, Sendable {
+    var value = ""
+    var isLoading = false
+}
+```
+
+## Step 3 — Reduce, then produce
+
+On `.load`, flip a flag (``Consequence/reduce(_:)``) **and** kick off the effect (`produce`). `Effect.throwingTask` runs an `async throws` closure and maps its `Result` straight onto your action case — `LoaderAction.didLoad` *is* the transform. When the result arrives as `.didLoad`, just reduce.
+
+```swift
+let loaderBehavior = Behavior<LoaderAction, LoaderState, API>.handle { action, _ in
+    switch action {
+    case .load(let id):
+        .reduce { $0.isLoading = true }
+            .produce { ctx in
+                Effect.throwingTask(LoaderAction.didLoad) {
+                    try await ctx.environment.fetch(id)
+                }
+            }
+    case .didLoad(let result):
+        .reduce {
+            $0.isLoading = false
+            if case .success(let value) = result { $0.value = value }
+        }
+    }
+}
+```
+
+The effect closure receives a ``PostReducerContext`` — `ctx.environment` is the injected `API`, and the effect resolves against post-mutation state.
+
+## Step 4 — Inject and run
+
+```swift
+@MainActor
+func runLoader() {
+    let live = API(fetch: { id in /* URLSession … */ "item \(id)" })
+    let store = Store(initial: LoaderState(), behavior: loaderBehavior, environment: live)
+
+    let token = store.observe(didChange: { print(store.state) })
+    store.dispatch(.load(42))   // isLoading = true → … → value = "item 42", isLoading = false
+    _ = token
+}
+```
+
+In a test you'd pass an `API` whose `fetch` returns a fixture, and drive the whole sequence deterministically with `TestStore` from `SwiftRex.Testing`.
+
+## Why this shape
+
+- **Determinism** — the reducer only ever sees values (the action), never performs the call, so it's pure and trivially testable.
+- **Visibility** — the request *and* its result are actions, so they show up in the action log with their ``ActionSource`` provenance. Nothing happens "invisibly" inside an effect.
+- **Control** — attach an ``EffectScheduling`` (`.scheduling(.debounce(id:delay:))`, `.throttle`, `.cancelInFlight`) to coordinate in-flight work; the ``Store`` owns the bookkeeping.
+
+## See Also
+
+- ``Effect``
+- ``EffectScheduling``
+- ``Behavior``
+- ``Consequence``
+- <doc:BuildYourFirstFeature>
+- <doc:Algebra>

--- a/Sources/SwiftRex/SwiftRex.docc/BuildYourFirstFeature.md
+++ b/Sources/SwiftRex/SwiftRex.docc/BuildYourFirstFeature.md
@@ -1,0 +1,111 @@
+# Build Your First Feature
+
+A complete, compiling counter — from state to a SwiftUI screen — in a few small steps.
+
+## Overview
+
+This walkthrough builds a tiny but complete feature with the core `SwiftRex` package (and, for the screen, `SwiftRex.SwiftUI`). Every snippet compiles against the current API — paste them into a file, import `SwiftRex`, and follow along. By the end you'll have a counter you can drive from code and render in SwiftUI.
+
+## Step 1 — Model the state
+
+State is a value type — the feature's single source of truth.
+
+```swift
+import SwiftRex
+
+struct CounterState: Equatable, Sendable {
+    var count = 0
+}
+```
+
+## Step 2 — Enumerate the actions
+
+Actions are *events* that can happen to the feature.
+
+```swift
+enum CounterAction: Sendable {
+    case increment
+    case decrement
+    case reset
+}
+```
+
+## Step 3 — Write the behavior
+
+A ``Behavior`` maps each action to a ``Consequence``. Here every action is a pure state change, so each returns ``Consequence/reduce(_:)``. (`Void` is the environment — this feature has no dependencies yet.)
+
+```swift
+let counterBehavior = Behavior<CounterAction, CounterState, Void>.handle { action, _ in
+    switch action {
+    case .increment: .reduce { $0.count += 1 }
+    case .decrement: .reduce { $0.count -= 1 }
+    case .reset:     .reduce { $0.count = 0 }
+    }
+}
+```
+
+## Step 4 — Create the store and drive it
+
+The ``Store`` is the only thing that runs. Create one with the initial state and the behavior, then dispatch actions and observe changes. ``StoreType/observe(didChange:)`` returns a ``SubscriptionToken`` you must **retain** — when it's released, the observation stops.
+
+```swift
+@MainActor
+func runCounter() {
+    let store = Store(initial: CounterState(), behavior: counterBehavior)
+
+    let token = store.observe(didChange: { print("count =", store.state.count) })
+
+    store.dispatch(.increment)   // count = 1
+    store.dispatch(.increment)   // count = 2
+    store.dispatch(.reset)       // count = 0
+
+    _ = token                    // keep the observer alive
+}
+```
+
+That's a fully working feature — no UI required, and trivially testable with `TestStore` from `SwiftRex.Testing`.
+
+## Step 5 — Put it on screen
+
+Add `SwiftRex.SwiftUI` and turn the store into an `ObservableObject` with `asObservableObject()`. The view reads ``StoreType/state`` and sends actions with ``StoreType/dispatch(_:source:)``.
+
+```swift
+import SwiftUI
+import SwiftRexSwiftUI
+
+struct CounterView: View {
+    @ObservedObject var store: ObservableObjectStore<CounterAction, CounterState>
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("\(store.state.count)").font(.largeTitle)
+            HStack {
+                Button("–") { store.dispatch(.decrement) }
+                Button("Reset") { store.dispatch(.reset) }
+                Button("+") { store.dispatch(.increment) }
+            }
+        }
+    }
+}
+
+#Preview {
+    let store = Store(initial: CounterState(), behavior: counterBehavior)
+    return CounterView(store: store.asObservableObject())
+}
+```
+
+`withAnimation { store.dispatch(.increment) }` works too — the `Store` is `@MainActor`, so the change lands in the right SwiftUI transaction.
+
+## Where to go next
+
+- **Side effects** — return an ``Effect`` from the behavior (`.reduce { … }.produce { ctx in … }`) to call a network or a clock, feeding the result back as another action. Inject what the effect needs through the `Environment` instead of `Void`.
+- **Scaling up** — once you have more than one feature, lift each into the app and compose them: <doc:Lifting> and <doc:Modularisation>.
+- **The model behind it** — <doc:Algebra> explains why all of this composes.
+
+## See Also
+
+- ``Behavior``
+- ``Store``
+- ``Consequence``
+- <doc:StateAndActions>
+- <doc:Lifting>

--- a/Sources/SwiftRex/SwiftRex.docc/StateAndActions.md
+++ b/Sources/SwiftRex/SwiftRex.docc/StateAndActions.md
@@ -1,0 +1,82 @@
+# Modelling State & Actions
+
+How to shape the two value types every SwiftRex feature is built from.
+
+## Overview
+
+A SwiftRex feature is defined by two pure values: a **State** (everything the feature needs to render and decide) and an **Action** (everything that can happen to it). There is no `Action` or `State` protocol to adopt — they are plain Swift types you design. Getting their shape right is most of the work; the ``Reducer`` and ``Behavior`` then almost write themselves.
+
+## State is a value, and the single source of truth
+
+Model state as a **value type** — usually a `struct` of `var` properties, or an `enum` when it's a state machine. It is the one place the feature's truth lives; views derive from it, they don't hold their own copies.
+
+```swift
+struct ProfileState: Equatable {
+    var name: String = ""
+    var age: Int = 0
+    var birthday: Date = .distantPast
+}
+```
+
+### Don't store what you can derive
+
+If a value can be *computed* from other state, compute it — don't store it, or you have to remember to keep it in sync.
+
+```swift
+struct ProfileState: Equatable {
+    var firstName = ""
+    var lastName = ""
+    var greeting: String { "Hello, \(firstName) \(lastName)" }   // ✓ derived, not stored
+}
+```
+
+Heavy-to-recompute values are the exception — cache those deliberately and guard them carefully. For view formatting, keep the derivation in the view's slice (a ``StoreProjection``), so the domain state stays minimal.
+
+### Use enums for state machines
+
+When a value moves through a fixed set of phases, an `enum` makes the illegal states unrepresentable:
+
+```swift
+enum Movies: Equatable {
+    case neverLoaded
+    case loading
+    case loaded([Movie])
+    case failed(String)
+}
+```
+
+(The FP library's `Loading` type captures this `idle → loading → loaded/failed` shape generically.) Project into the right case with a `Prism` when lifting — see <doc:Lifting>.
+
+## Actions describe what happened, not what to do
+
+An **Action** is an enum of *events* — "the user tapped save", "the request came back" — not imperative commands. Carry just enough payload, and fold async results into the action so the reducer stays deterministic:
+
+```swift
+enum ProfileAction {
+    case nameChanged(String)
+    case saveTapped
+    case saveResponse(Result<Profile, SaveError>)   // the effect loops the outcome back as an action
+}
+```
+
+Wrapping a failable result in the action (rather than in the ``Effect``) is the idiom — the enum case *is* the transform a bridge's `asEffect()` takes. Effects produce actions; the ``Store`` runs the loop.
+
+### Optics for free with macros
+
+The FP macros generate the optics that lifting uses:
+
+- `@Prisms` on an action (or enum state) generates a `Prism` / key-path per case — `\AppAction.profile`, `AppAction.prism.profile` — so a feature's action narrows into the app's.
+- `@Lenses` on a `struct` state generates a `Lens` per field, for focusing `let`/immutable slices when a `WritableKeyPath` won't do.
+
+## Every action carries its origin
+
+When an action is dispatched, SwiftRex wraps it in a ``DispatchedAction`` carrying an ``ActionSource`` — the `file`/`function`/`line` of the call site. Middlewares and loggers see *who* dispatched what, which makes the action log a faithful trace of the app. You never construct these by hand; the framework captures the source at each dispatch and effect-factory call site. Element actions in a collection are addressed by id with ``ElementAction``.
+
+## See Also
+
+- ``Reducer``
+- ``Behavior``
+- ``ActionSource``
+- ``DispatchedAction``
+- ``ElementAction``
+- <doc:Lifting>

--- a/Sources/SwiftRex/SwiftRex.docc/SwiftRex.md
+++ b/Sources/SwiftRex/SwiftRex.docc/SwiftRex.md
@@ -28,8 +28,14 @@ Everything except the `Store` is inert and composable. Two `Reducer`s combine in
 
 ## Topics
 
+### Start Here
+
+- <doc:BuildYourFirstFeature>
+- <doc:AddingEffects>
+
 ### Concepts
 
+- <doc:StateAndActions>
 - <doc:Algebra>
 - <doc:Lifting>
 - <doc:Modularisation>


### PR DESCRIPTION
## What?
Adds the catalog's remaining distinct content: a **Modelling State & Actions** article and two **compilable example walkthroughs** (Build Your First Feature, Adding Effects).

## Why?
The standard calls for deep articles *and* paste-into-Xcode-and-compile examples. The per-type articles (Middleware/Behavior/Store/Projection) were intentionally skipped — they'd duplicate the symbol extensions; this is the genuinely-missing, non-redundant content.

## How?
- **`StateAndActions.md`** — value-type state, derive-don't-store, enums for state machines, actions as events with `Result` folded in, `@Prisms`/`@Lenses` optics, `ActionSource` provenance.
- **`BuildYourFirstFeature.md`** — state → actions → behavior → store → dispatch/observe → SwiftUI screen via `asObservableObject()`.
- **`AddingEffects.md`** — inject a dependency through `Environment`, return an `Effect` (`reduce` + `produce` via `Effect.throwingTask`), fold the `Result` back as an action.
- Curated into **Start Here** / **Concepts** on the landing page.

**Every walkthrough snippet was compiled against the current API** (in a scratch target) before being written into the docs — then the scratch was removed. Verified with `--enable-experimental-overloaded-symbol-presentation`: **0 warnings**; build + strict lint green.

## Tests
- [x] Docs updated
- [x] README updated — N/A
- [x] Lint approved — no Swift changes
- [x] Periphery approved — no Swift changes

---
**This completes the DocC catalog** per the documentation standard: landing page · 6 articles (Algebra, Lifting, Modularisation, State & Actions, + 2 walkthroughs) · 8 symbol extensions · clean inline links + overload-group linking · both repo-root MD strays retired.