### PR TITLE
feat(effects): state-driven Reaction (stacked on #175)

### DIFF
--- a/Sources/SwiftRex/Effect/EffectEngine.swift
+++ b/Sources/SwiftRex/Effect/EffectEngine.swift
@@ -36,6 +36,11 @@ package final class EffectEngine<Action: Sendable> {
     /// Monotonic source of anonymous effect keys (internal, never surfaced).
     private var nextAnonymousEffectKey: UInt64 = 0
 
+    /// The last desired-set this engine reconciled, keyed by `(owner, id)` → value-identity. This is
+    /// the *only* memory a state-driven `Reaction` needs: the reaction recomputes the full desired set
+    /// each cycle and the engine diffs it against this, deriving start/stop/pipe operations.
+    private var reconciledValues: [AnyHashableSendable: AnyHashableSendable] = [:]
+
     private let clock: AnyClock<Swift.Duration>
     private let send: @Sendable (DispatchedAction<Action>) -> Void
 
@@ -70,12 +75,7 @@ package final class EffectEngine<Action: Sendable> {
 
         // Cancel-only sentinel: remove the id and start nothing.
         if scheduling.cancelsOnly {
-            if let id = scheduling.id {
-                runningEffects[id]?.cancel()
-                runningEffects.removeValue(forKey: id)
-                channelSinks.removeValue(forKey: id)
-                pendingDeliver.removeValue(forKey: id)
-            }
+            if let id = scheduling.id { cancel(key: id) }
             return
         }
 
@@ -182,5 +182,57 @@ package final class EffectEngine<Action: Sendable> {
         } else {
             deliver()
         }
+    }
+
+    /// Cancels and forgets whatever runs under `key` across all registries (the cancel-only path,
+    /// and the "no longer desired" path of ``reconcile(_:)``). A no-op if nothing is registered.
+    ///
+    /// Cancellation is driven by releasing the token (RAII `deinit`), not an explicit `cancel()` call:
+    /// the token is sole-owned by `runningEffects`, so `removeValue` drops the last reference and
+    /// cancels it **exactly once**. Calling `cancel()` *and* releasing would fire a side-effecting
+    /// teardown (e.g. a channel's `socket.close()`) twice.
+    private func cancel(key: AnyHashableSendable) {
+        runningEffects.removeValue(forKey: key)
+        channelSinks.removeValue(forKey: key)
+        pendingDeliver.removeValue(forKey: key)
+    }
+
+    // MARK: - Reconcile (state-driven `Reaction`)
+
+    /// A single desired state-driven effect for one reconcile cycle.
+    ///
+    /// The `component`'s `scheduling.id` is the owner-stamped `(owner, id)` key — state-driven effects
+    /// must be keyed (an unkeyed entry is skipped). `valueIdentity` drives change detection: when it
+    /// changes between cycles the engine re-schedules (which **pipes** for a channel, **recreates** for
+    /// a one-shot); `nil` means presence-only (started once, never re-scheduled until it drops out).
+    package struct ReconcileEntry: Sendable {
+        package let component: Effect<Action>.Component
+        package let valueIdentity: AnyHashableSendable?
+
+        package init(component: Effect<Action>.Component, valueIdentity: AnyHashableSendable?) {
+            self.component = component
+            self.valueIdentity = valueIdentity
+        }
+    }
+
+    /// Sentinel value-identity for presence-only entries, so "still desired, unchanged" compares equal.
+    private struct PresenceMarker: Hashable, Sendable {}
+
+    /// Reconciles the running state-driven effects against the **complete** `desired` set for this
+    /// cycle: starts keys newly present, cancels keys now absent, and re-schedules keys whose
+    /// `valueIdentity` changed. An unchanged desired set produces **zero** operations — the engine
+    /// keeps the registry; the caller (a `Reaction`) keeps nothing.
+    package func reconcile(_ desired: [ReconcileEntry]) {
+        let presence = AnyHashableSendable(PresenceMarker())
+        var next: [AnyHashableSendable: AnyHashableSendable] = [:]
+        next.reserveCapacity(desired.count)
+        for entry in desired {
+            guard let key = entry.component.scheduling.id else { continue }
+            let identity = entry.valueIdentity ?? presence
+            next[key] = identity
+            if reconciledValues[key] != identity { schedule(entry.component) }
+        }
+        for key in reconciledValues.keys where next[key] == nil { cancel(key: key) }
+        reconciledValues = next
     }
 }

--- a/Tests/SwiftRexTests/EffectTests/EffectEngineReconcileTests.swift
+++ b/Tests/SwiftRexTests/EffectTests/EffectEngineReconcileTests.swift
@@ -1,0 +1,109 @@
+import CoreFP
+import Hourglass
+@testable import SwiftRex
+import Testing
+
+// MARK: - EffectEngine.reconcile — the state-driven (Reaction) diff
+
+@Suite("EffectEngine reconcile")
+@MainActor
+struct EffectEngineReconcileTests {
+    /// Builds an engine whose produced actions land in `received`, driven by an `ImmediateClock`.
+    private func makeEngine(_ received: LockProtected<[Int]>) -> EffectEngine<Int> {
+        EffectEngine<Int>(
+            clock: ImmediateClock().eraseToAnyClock(),
+            send: { d in received.mutate { $0.append(d.action) } }
+        )
+    }
+
+    /// A keyed channel that records every piped value into `log` and its teardown into `cancels`.
+    private func channelEntry(
+        id: String,
+        value: Int,
+        log: LockProtected<[Int]>,
+        cancels: LockProtected<[String]>,
+        valueIdentity: AnyHashableSendable?
+    ) -> EffectEngine<Int>.ReconcileEntry {
+        let effect = Effect<Int>.channel(value: value, scheduling: .keyed(id: id)) { _, _ in
+            ChannelHandler(
+                receive: { v in log.mutate { $0.append(v) } },
+                cancel: { cancels.mutate { $0.append(id) } }
+            )
+        }
+        return .init(component: effect.components[0], valueIdentity: valueIdentity)
+    }
+
+    @Test func startsDesiredAndCancelsWhenItDropsOut() {
+        let log = LockProtected([Int]())
+        let cancels = LockProtected([String]())
+        let engine = makeEngine(LockProtected([Int]()))
+
+        // First cycle: "socket" is desired → opens + delivers 1.
+        engine.reconcile([channelEntry(id: "socket", value: 1, log: log, cancels: cancels, valueIdentity: AnyHashableSendable(1))])
+        #expect(log.value == [1])
+        #expect(cancels.value.isEmpty)
+
+        // Next cycle: "socket" no longer desired → cancelled.
+        engine.reconcile([])
+        #expect(cancels.value == ["socket"])
+    }
+
+    @Test func unchangedValueIdentityProducesZeroOperations() {
+        let log = LockProtected([Int]())
+        let cancels = LockProtected([String]())
+        let engine = makeEngine(LockProtected([Int]()))
+        let id = AnyHashableSendable(7)
+
+        engine.reconcile([channelEntry(id: "s", value: 1, log: log, cancels: cancels, valueIdentity: id)])
+        engine.reconcile([channelEntry(id: "s", value: 1, log: log, cancels: cancels, valueIdentity: id)])
+        engine.reconcile([channelEntry(id: "s", value: 1, log: log, cancels: cancels, valueIdentity: id)])
+
+        #expect(log.value == [1])          // delivered once — identity never changed
+        #expect(cancels.value.isEmpty)     // still desired across all three cycles
+    }
+
+    @Test func changedValueIdentityPipesIntoTheSameLiveChannel() {
+        let log = LockProtected([Int]())
+        let cancels = LockProtected([String]())
+        let engine = makeEngine(LockProtected([Int]()))
+
+        engine.reconcile([channelEntry(id: "s", value: 1, log: log, cancels: cancels, valueIdentity: AnyHashableSendable(1))])
+        engine.reconcile([channelEntry(id: "s", value: 2, log: log, cancels: cancels, valueIdentity: AnyHashableSendable(2))])
+        engine.reconcile([channelEntry(id: "s", value: 3, log: log, cancels: cancels, valueIdentity: AnyHashableSendable(3))])
+
+        #expect(log.value == [1, 2, 3])    // piped each changed value into the same channel
+        #expect(cancels.value.isEmpty)     // never torn down — the channel stayed alive
+    }
+
+    @Test func presenceOnlyEntryStartsOnceAndIsNotReScheduled() {
+        let log = LockProtected([Int]())
+        let cancels = LockProtected([String]())
+        let engine = makeEngine(LockProtected([Int]()))
+
+        // valueIdentity nil → presence-only. Three cycles, all desired.
+        for _ in 0..<3 {
+            engine.reconcile([channelEntry(id: "s", value: 9, log: log, cancels: cancels, valueIdentity: nil)])
+        }
+        #expect(log.value == [9])          // started once, never re-delivered
+        #expect(cancels.value.isEmpty)
+    }
+
+    @Test func independentKeysReconcileIndependently() {
+        let log = LockProtected([Int]())
+        let cancels = LockProtected([String]())
+        let engine = makeEngine(LockProtected([Int]()))
+
+        func entryA(_ v: Int) -> EffectEngine<Int>.ReconcileEntry {
+            channelEntry(id: "a", value: v, log: log, cancels: cancels, valueIdentity: AnyHashableSendable(v))
+        }
+        func entryB(_ v: Int) -> EffectEngine<Int>.ReconcileEntry {
+            channelEntry(id: "b", value: v, log: log, cancels: cancels, valueIdentity: AnyHashableSendable(v))
+        }
+
+        engine.reconcile([entryA(1), entryB(10)])     // both start
+        engine.reconcile([entryB(10)])                // a drops out → only a cancelled
+        #expect(cancels.value == ["a"])
+        engine.reconcile([])                          // b drops out
+        #expect(cancels.value == ["a", "b"])
+    }
+}


### PR DESCRIPTION
## What
Builds the **state-driven `Reaction`** entity (Elm's `Sub` — effects derived from *state*, reconciled each cycle) on top of the shared `EffectEngine` from #175. **Stacked on `feature/effect-scheduler-engine` (#175)** — review that first; this PR's diff will narrow to just the new work once #175 merges.

## Why
Today's effects are action-driven (`produce`, Elm's `Cmd`). That desyncs under Redux DevTools time-travel — a state-derived effect instead recomputes and reconciles, surviving time-travel like state-driven UI does. This completes the half-model SwiftRex already has.

Names settled with maintainer: entity **`Reaction`**, verb **`react`** (pairs with `produce`).

## Changes (incremental)
- **`EffectEngine.reconcile([ReconcileEntry])`** — diffs the complete desired set against last cycle's by `(owner, id)`: start newly-present, cancel now-absent, re-schedule changed-value (pipes a channel / recreates a one-shot), unchanged → zero ops. The reaction keeps no memory; the engine's `reconciledValues` is the only state.
- Fixes a latent **double-cancel** in `cancel(key:)` (RAII deinit now cancels exactly once — matters for channels with real teardown).

_More commits to follow on this branch: the `Reaction` type + Monoid, Store wiring (reconcile on didChange), and folding into `Behavior` as the third closure._

🤖 Generated with [Claude Code](https://claude.com/claude-code)