### PR TITLE
Feature entry-point groundwork: initialState(with:), mapState env-injection, unwrap lift + store bindings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cb602f11d129e729632bbff022c4a840200b18718c7785fb8275e7ae740c59d4",
+  "originHash" : "1eaac09fd8b596c9cfa714a0b95ba86ff7bcc55b86d625a219c6aa63fd64592f",
   "pins" : [
     {
       "identity" : "fp",
@@ -17,33 +17,6 @@
       "state" : {
         "revision" : "ec2ff5aac99e59d2ea208e4d391fe54da8961608",
         "version" : "0.6.2"
-      }
-    },
-    {
-      "identity" : "reactiveconcurrency",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/luizmb/ReactiveConcurrency.git",
-      "state" : {
-        "revision" : "e7c8f6dcf6ffa3d2a148f92081f7fbcc935077a1",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "reactiveswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
-      "state" : {
-        "revision" : "a44317ce38b5bcce173b03f5d36cfdc939e1768b",
-        "version" : "7.2.1"
-      }
-    },
-    {
-      "identity" : "rxswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveX/RxSwift.git",
-      "state" : {
-        "revision" : "132aea4f236ccadc51590b38af0357a331d51fa2",
-        "version" : "6.10.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -151,6 +151,7 @@ let package = Package(
                 "SwiftRex",
                 "SwiftRexSwiftUI",
                 "SwiftRexMacros",
+                .product(name: "DataStructure", package: "FP"),
                 .product(name: "FPMacros", package: "FP")
             ],
             path: "Sources/SwiftRexArchitecture"
@@ -166,7 +167,8 @@ let package = Package(
             dependencies: [
                 "SwiftRex",
                 "SwiftRexSwiftUI",
-                "SwiftRexArchitecture"
+                "SwiftRexArchitecture",
+                .product(name: "DataStructure", package: "FP")
             ],
             path: "Sources/SwiftRexTesting"
         ),
@@ -211,7 +213,12 @@ let package = Package(
         ),
         .testTarget(
             name: "SwiftRexArchitectureTests",
-            dependencies: ["SwiftRexArchitecture", "SwiftRex", "SwiftRexTesting"],
+            dependencies: [
+                "SwiftRexArchitecture",
+                "SwiftRex",
+                "SwiftRexTesting",
+                .product(name: "DataStructure", package: "FP")
+            ],
             path: "Tests/SwiftRexArchitectureTests"
         )
     ],

--- a/Sources/SwiftRex/Behavior/Behavior+Transforms.swift
+++ b/Sources/SwiftRex/Behavior/Behavior+Transforms.swift
@@ -188,6 +188,42 @@ extension Behavior {
             }
         )
     }
+
+    /// Lifts this behavior over an **optional** sub-state — the 0-or-1 sibling of ``liftCollection``
+    /// and ``liftEach`` (which are 0-or-n).
+    ///
+    /// While the optional is `nil`, the behavior is a complete no-op — no mutation, no effects — and
+    /// its supervised channels are torn down by the reconciler. While it is `.some`, the behavior
+    /// runs focused on the unwrapped value. This is exactly the shape presentation uses: a child
+    /// module whose state exists only while it is shown.
+    ///
+    /// ```swift
+    /// // Runs only while AppState.currentDay is non-nil:
+    /// let lifted = dayBehavior.liftOptional(\AppState.currentDay)   // currentDay: DayDetail.State?
+    /// ```
+    ///
+    /// - Parameter optional: A `WritableKeyPath<GlobalState, State?>` to the optional sub-state.
+    /// - Returns: A `Behavior<Action, GlobalState, Environment>` that no-ops while the focus is absent.
+    public func liftOptional<GlobalState: Sendable>(
+        _ optional: WritableKeyPath<GlobalState, State?>
+    ) -> Behavior<Action, GlobalState, Environment> {
+        let traversal = affineTraversal(optional)
+        return Behavior<Action, GlobalState, Environment>(
+            // While the sub-state is `nil` the inner behavior is skipped entirely — it is never even
+            // asked to `handle`, so it neither mutates nor produces effects.
+            handle: { action, context in
+                guard context.stateBefore?[keyPath: optional] != nil else { return .doNothing }
+                let c = self.handle(action, context.compactMap(traversal.preview))
+                return Reaction(
+                    mutation: c.mutation.map { traversal.lift($0) },
+                    produce: c.produce.contramapEnvironment { $0.compactMap(traversal.preview) }
+                )
+            },
+            supervisor: self.supervisor.map { inner in
+                { @MainActor @Sendable (state: GlobalState) in traversal.preview(state).map { inner($0) } ?? Reader { _ in [] } }
+            }
+        )
+    }
 }
 
 // MARK: - Environment axis
@@ -349,6 +385,27 @@ extension Behavior {
     ) -> Behavior<GA, GS, GE> {
         liftAction(prism).liftState(traversal).liftEnvironment(g)
     }
+
+    /// Lifts all three axes over an **optional** sub-state — `Prism` action, optional
+    /// `WritableKeyPath` state, closure environment. The 0-or-1 counterpart of ``liftCollection``.
+    ///
+    /// The behavior is a complete no-op while the optional sub-state is `nil`, and runs focused on
+    /// the unwrapped value while it is `.some`.
+    ///
+    /// ```swift
+    /// let appBehavior = dayBehavior.liftOptional(
+    ///     action:      AppAction.prism.day,
+    ///     state:       \AppState.currentDay,     // currentDay: DayDetail.State?
+    ///     environment: { $0.day }
+    /// )
+    /// ```
+    public func liftOptional<GA: Sendable, GS: Sendable, GE: Sendable>(
+        action prism: Prism<GA, Action>,
+        state optional: WritableKeyPath<GS, State?>,
+        environment g: @escaping @Sendable (GE) -> Environment
+    ) -> Behavior<GA, GS, GE> {
+        liftAction(prism).liftOptional(optional).liftEnvironment(g)
+    }
 }
 
 // MARK: - Combined lift with a `\.case` action key path
@@ -392,5 +449,15 @@ extension Behavior {
         environment g: @escaping @Sendable (GE) -> Environment
     ) -> Behavior<GA, GS, GE> {
         lift(action: Prism(path), state: traversal, environment: g)
+    }
+
+    /// Lifts all three axes over an **optional** sub-state — `\.case` action, optional
+    /// `WritableKeyPath` state, closure environment.
+    public func liftOptional<GA: Prismatic & Sendable, GS: Sendable, GE: Sendable>(
+        action path: PrismKeyPath<GA, Action>,
+        state optional: WritableKeyPath<GS, State?>,
+        environment g: @escaping @Sendable (GE) -> Environment
+    ) -> Behavior<GA, GS, GE> {
+        liftAction(Prism(path)).liftOptional(optional).liftEnvironment(g)
     }
 }

--- a/Sources/SwiftRex/Middleware/Middleware+Transforms.swift
+++ b/Sources/SwiftRex/Middleware/Middleware+Transforms.swift
@@ -129,6 +129,36 @@ extension Middleware {
         )
     }
 
+    /// Lifts this middleware over an **optional** sub-state — the 0-or-1 sibling of
+    /// ``liftCollection``/``liftEach`` (0-or-n).
+    ///
+    /// The middleware is skipped entirely while the optional is `nil`, and runs focused on the
+    /// unwrapped value while it is `.some` — the shape presentation uses for a child shown only
+    /// while its state exists.
+    ///
+    /// ```swift
+    /// let lifted = dayMiddleware.liftOptional(\AppState.currentDay)   // currentDay: DayDetail.State?
+    /// ```
+    ///
+    /// - Parameter optional: A `WritableKeyPath<GlobalState, State?>` to the optional sub-state.
+    /// - Returns: A `Middleware<Action, GlobalState, Environment>` skipped entirely while absent.
+    public func liftOptional<GlobalState: Sendable>(
+        _ optional: WritableKeyPath<GlobalState, State?>
+    ) -> Middleware<Action, GlobalState, Environment> {
+        let traversal = affineTraversal(optional)
+        return Middleware<Action, GlobalState, Environment>(
+            // While the sub-state is `nil` the inner middleware is skipped — no effect is produced.
+            handle: { action, context in
+                guard context.stateBefore?[keyPath: optional] != nil else { return Reader { _ in .empty } }
+                return self.handle(action, context.compactMap(traversal.preview))
+                    .contramapEnvironment { $0.compactMap(traversal.preview) }
+            },
+            supervisor: self.supervisor.map { inner in
+                { @MainActor @Sendable (state: GlobalState) in traversal.preview(state).map { inner($0) } ?? Reader { _ in [] } }
+            }
+        )
+    }
+
     /// Lifts the environment axis of this middleware using a projection closure, embedding it
     /// in a wider global environment.
     ///
@@ -261,5 +291,23 @@ extension Middleware {
         environment g: @escaping @Sendable (GE) -> Environment
     ) -> Middleware<GA, GS, GE> {
         liftAction(prism).liftState(traversal).liftEnvironment(g)
+    }
+
+    /// Lifts all three axes over an **optional** sub-state — `Prism` action, optional
+    /// `WritableKeyPath` state, closure environment. A complete no-op while the sub-state is `nil`.
+    ///
+    /// ```swift
+    /// let lifted = dayMiddleware.liftOptional(
+    ///     action:      AppAction.prism.day,
+    ///     state:       \AppState.currentDay,     // currentDay: DayDetail.State?
+    ///     environment: { $0.day }
+    /// )
+    /// ```
+    public func liftOptional<GA: Sendable, GS: Sendable, GE: Sendable>(
+        action prism: Prism<GA, Action>,
+        state optional: WritableKeyPath<GS, State?>,
+        environment g: @escaping @Sendable (GE) -> Environment
+    ) -> Middleware<GA, GS, GE> {
+        liftAction(prism).liftOptional(optional).liftEnvironment(g)
     }
 }

--- a/Sources/SwiftRex/SwiftRex.docc/Modularisation.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Modularisation.md
@@ -51,7 +51,7 @@ Crossing the **environment** boundary is the same idea applied to dependencies: 
 
 ## The opinionated layer: `SwiftRex.Architecture`
 
-`SwiftRex.Architecture` packages this pattern so a feature is a single namespace. The `@Feature` macro synthesizes a feature's `initialState()` and conformance to the `Feature` protocol, and a `Module` co-locates a feature's `Action`/`State`/`Environment` **and** its SwiftUI `Content` view in one value — with a single `lift(...)` that raises the whole module (all three axes) to the app's global types, and `view(for:)` to render it from a store. `FeatureHost` hosts a feature at the app root. It's optional sugar over the same core lifting you saw above — reach for it when you want the whole feature, view included, to travel as one liftable unit.
+`SwiftRex.Architecture` packages this pattern so a feature is a single namespace. The `@Feature` macro synthesizes a feature's `initialState(with:)` and conformance to the `Feature` protocol, and a `Module` co-locates a feature's `Action`/`State`/`Environment` **and** its SwiftUI `Content` view in one value — with a single `lift(...)` that raises the whole module (all three axes) to the app's global types, and `view(for:environment:)` to render it from a store (the environment feeds `mapState`, so the view can format with live dependencies). `FeatureHost` hosts a feature at the app root. It's optional sugar over the same core lifting you saw above — reach for it when you want the whole feature, view included, to travel as one liftable unit.
 
 ## See Also
 

--- a/Sources/SwiftRexArchitecture/Feature.swift
+++ b/Sources/SwiftRexArchitecture/Feature.swift
@@ -1,4 +1,5 @@
 #if canImport(Observation) && canImport(SwiftUI)
+import DataStructure
 import Observation
 import SwiftRex
 import SwiftRexSwiftUI
@@ -51,17 +52,20 @@ import SwiftUI
 ///         }
 ///     }
 ///
-///     static let mapState: @MainActor @Sendable (State) -> ViewModel.ViewState = { state in
-///         .init(
-///             rows: state.movies.map { m in
-///                 .init(id: m.id,
-///                       title: "\(m.title) (\(m.year))",
-///                       subtitle: m.characters.map { "\($0.name) by \($0.actor.name)" }.joined(separator: ", "),
-///                       starred: m.isFavorite)
-///             },
-///             isLoading: state.isLoading,
-///             error: state.error.map { $0.localizedDescription }
-///         )
+///     // A Reader over Environment; this view formats via `env.formatMoney`, so it uses it.
+///     static let mapState = Reader<Environment, @MainActor @Sendable (State) -> ViewModel.ViewState> { env in
+///         { state in
+///             .init(
+///                 rows: state.movies.map { m in
+///                     .init(id: m.id,
+///                           title: "\(m.title) (\(m.year))",
+///                           subtitle: m.characters.map { "\($0.name) by \($0.actor.name)" }.joined(separator: ", "),
+///                           starred: m.isFavorite)
+///                 },
+///                 isLoading: state.isLoading,
+///                 error: state.error.map { $0.localizedDescription }
+///             )
+///         }
 ///     }
 ///
 ///     static let mapAction: @Sendable (ViewModel.ViewAction) -> Action = { viewAction in
@@ -149,11 +153,23 @@ public protocol Feature: Sendable {
 
     // MARK: - Mappings
 
-    /// Projects the full internal `State` to the view-facing `ViewModel.ViewState`.
+    /// Projects the full internal `State` to the view-facing `ViewModel.ViewState`, given the
+    /// feature's `Environment`.
     ///
-    /// Must be `@MainActor @Sendable` — state is read on the main actor and the closure is
-    /// captured inside a `StoreProjection`. Declare as a `static let` so it is computed once.
-    static var mapState: @MainActor @Sendable (State) -> ViewModel.ViewState { get }
+    /// Curried over `Environment` so the view layer can perform environment-dependent
+    /// presentation — number/date/money formatting, calendar/locale-aware rendering — without
+    /// pushing those concerns into `Behavior` (which would force pre-formatted strings into
+    /// `State`). The `Environment` is supplied at view-build time by the composition root (see
+    /// ``Module/view(for:environment:)``); effects still receive their environment from the
+    /// `Store` at runtime — this is the *view* half only.
+    ///
+    /// Features whose view needs no environment ignore it: `{ _ in { state in … } }`.
+    ///
+    /// A `Reader` over `Environment` — the same shape `produce`/`supervise` use — so environment
+    /// narrowing composes via `contramapEnvironment`. The inner closure must be `@MainActor
+    /// @Sendable`: state is read on the main actor and it is captured inside a `StoreProjection`.
+    /// Declare as a `static let` so it is computed once.
+    static var mapState: Reader<Environment, @MainActor @Sendable (State) -> ViewModel.ViewState> { get }
 
     /// Translates a `ViewModel.ViewAction` dispatched by the view into the internal `Action`.
     ///
@@ -190,7 +206,10 @@ public protocol Feature: Sendable {
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 extension Feature where State == ViewModel.ViewState {
     /// Identity projection — no declaration needed when `State` is typealiased to `ViewModel.ViewState`.
-    public static var mapState: @MainActor @Sendable (State) -> ViewModel.ViewState { { $0 } }
+    /// Ignores the environment.
+    public static var mapState: Reader<Environment, @MainActor @Sendable (State) -> ViewModel.ViewState> {
+        Reader { _ in { $0 } }
+    }
 }
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)

--- a/Sources/SwiftRexArchitecture/Feature.swift
+++ b/Sources/SwiftRexArchitecture/Feature.swift
@@ -71,7 +71,7 @@ import SwiftUI
 ///         }
 ///     }
 ///
-///     static func initialState() -> State { .init() }
+///     // `initialState(with:)` defaults to `State.init()` when `Input` is `Void`.
 ///
 ///     static func behavior() -> Behavior<Action, State, Environment> {
 ///         .handle { action, _ in
@@ -130,6 +130,14 @@ public protocol Feature: Sendable {
     /// Live dependencies injected at build time (network, persistence, clocks…).
     associatedtype Environment: Sendable
 
+    /// Construction-time seed for the initial state — a caller-supplied context (a selected id,
+    /// a deep-link payload…) fed to ``initialState(with:)`` when the feature is opened.
+    ///
+    /// Defaults to `Void` for features that need no seed; declare a nested `Input` type (or
+    /// `typealias Input = …`) to require one. This is a *seed*, distinct from any runtime
+    /// message port — it only participates in building the initial state.
+    associatedtype Input = Void
+
     // MARK: - ViewModel
 
     /// The `@ViewModel`-annotated class that owns `ViewState` and `ViewAction` and drives the view.
@@ -154,11 +162,12 @@ public protocol Feature: Sendable {
 
     // MARK: - Lifecycle
 
-    /// Returns the feature's initial state.
+    /// Returns the feature's initial state, seeded with the caller-supplied ``Input``.
     ///
     /// Called by parent stores when seeding their initial `AppState` slice, and in tests
-    /// when constructing a standalone store for this feature.
-    static func initialState() -> State
+    /// when constructing a standalone store for this feature. When ``Input`` is `Void`, the
+    /// no-argument ``initialState()`` convenience is available.
+    static func initialState(with input: Input) -> State
 
     /// Returns the feature's `Behavior` — the reducer combined with any side-effect middleware.
     ///
@@ -188,6 +197,17 @@ extension Feature where State == ViewModel.ViewState {
 extension Feature where Action == ViewModel.ViewAction {
     /// Identity translation — no declaration needed when `Action` is typealiased to `ViewModel.ViewAction`.
     public static var mapAction: @Sendable (ViewModel.ViewAction) -> Action { { $0 } }
+}
+
+// MARK: - Void-Input convenience
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension Feature where Input == Void {
+    /// Builds the initial state without a seed — available when ``Input`` is `Void`.
+    ///
+    /// Forwards to ``initialState(with:)`` with `()`, so existing call sites that don't pass a
+    /// seed keep working unchanged.
+    public static func initialState() -> State { initialState(with: ()) }
 }
 
 // MARK: - Module factory

--- a/Sources/SwiftRexArchitecture/Macros.swift
+++ b/Sources/SwiftRexArchitecture/Macros.swift
@@ -2,6 +2,7 @@
 // A single `import SwiftRexArchitecture` covers everything:
 // @Prisms/@Lenses (FPMacros), @ViewModel/@BoundTo (SwiftRexSwiftUI),
 // and @ObservationIgnored/ObservationRegistrar (Observation) used in @ViewModel expansions.
+@_exported import DataStructure
 @_exported import FPMacros
 @_exported import Observation
 @_exported import SwiftRexSwiftUI

--- a/Sources/SwiftRexArchitecture/Macros.swift
+++ b/Sources/SwiftRexArchitecture/Macros.swift
@@ -16,7 +16,8 @@
 /// - Applies `@Prisms` to the nested `Action` enum (for ``TestStore`` `receive` assertions)
 /// - Applies `@Lenses` to the nested `State` struct (for `liftState` ergonomics)
 /// - Applies `@ViewModel` to the nested `ViewModel` class (no manual annotation needed)
-/// - Synthesizes `static func initialState() -> State { .init() }` when you don't write one
+/// - Synthesizes `static func initialState(with _: Void) -> State { .init() }` when you don't
+///   write one (skipped if you declare a custom `Input` seed)
 ///
 /// ```swift
 /// @Feature
@@ -31,8 +32,8 @@
 ///
 ///     static let mapState = ...
 ///     static let mapAction = ...
-///     // `initialState()` is synthesized as `State.init()` — declare your own only when
-///     // `State` lacks an empty initializer (a property without a default value).
+///     // `initialState(with:)` is synthesized as `State.init()` (Void seed) — declare your own
+///     // only when `State` lacks an empty initializer or you need a non-`Void` `Input` seed.
 ///     static func behavior() -> Behavior<Action, State, Environment> { ... }
 ///
 ///     typealias Content = MovieListView      // still required — links feature to its view

--- a/Sources/SwiftRexArchitecture/Module.swift
+++ b/Sources/SwiftRexArchitecture/Module.swift
@@ -1,4 +1,5 @@
 #if canImport(Observation) && canImport(SwiftUI)
+import DataStructure
 import SwiftRex
 import SwiftRexSwiftUI
 import SwiftUI
@@ -27,8 +28,8 @@ import SwiftUI
 ///     state:       AppState.lens.home,
 ///     environment: \.xmlDecoder >>> HomeFeature.Environment.init
 /// )
-/// lifted.behavior        // Behavior<AppAction, AppState, World>
-/// lifted.view(for: store) // HomeView  — fully typed, no AnyView
+/// lifted.behavior                       // Behavior<AppAction, AppState, World>
+/// lifted.view(for: store, environment: world) // HomeView  — fully typed, no AnyView
 /// ```
 ///
 /// ## Routing boundary
@@ -53,7 +54,11 @@ public struct Module<Action: Sendable, State: Sendable, Environment: Sendable, C
     public let behavior: Behavior<Action, State, Environment>
 
     /// Type-erased view factory — closed over the Feature's `ViewModel` and `Content` types.
-    private let _makeView: @MainActor @Sendable (any StoreType<Action, State>) -> Content
+    ///
+    /// Takes the feature's `Environment` alongside the store: the environment is applied to
+    /// `mapState` at view-build time so the projection can format/render with live dependencies.
+    /// Effects are unaffected — they still receive their environment from the `Store` at runtime.
+    private let _makeView: @MainActor @Sendable (any StoreType<Action, State>, Environment) -> Content
 
     // MARK: - Init from Feature type
 
@@ -67,10 +72,10 @@ public struct Module<Action: Sendable, State: Sendable, Environment: Sendable, C
     public init<F: Feature>(_ feature: F.Type)
     where F.Action == Action, F.State == State, F.Environment == Environment, F.Content == Content {
         behavior = F.behavior()
-        _makeView = { @MainActor store in
+        _makeView = { @MainActor store, environment in
             let vm = F.ViewModel(store: store.projection(
                 action: F.mapAction,
-                state: F.mapState
+                state: F.mapState(environment)
             ))
             return F.Content(viewModel: vm)
         }
@@ -86,7 +91,7 @@ public struct Module<Action: Sendable, State: Sendable, Environment: Sendable, C
     /// ```swift
     /// Module(
     ///     behavior: InternalFeature.behavior(),
-    ///     view: { store in
+    ///     view: { store, environment in
     ///         let vm = InternalFeature.ViewModel(store: store.projection(...))
     ///         return PublicContent(InternalFeature.Content(viewModel: vm))
     ///     }
@@ -94,7 +99,7 @@ public struct Module<Action: Sendable, State: Sendable, Environment: Sendable, C
     /// ```
     public init(
         behavior: Behavior<Action, State, Environment>,
-        view: @escaping @MainActor @Sendable (any StoreType<Action, State>) -> Content
+        view: @escaping @MainActor @Sendable (any StoreType<Action, State>, Environment) -> Content
     ) {
         self.behavior = behavior
         _makeView = view
@@ -102,16 +107,21 @@ public struct Module<Action: Sendable, State: Sendable, Environment: Sendable, C
 
     // MARK: - View production
 
-    /// Returns the feature's view wired to the given store.
+    /// Returns the feature's view wired to the given store and environment.
     ///
     /// Pass any `StoreType` whose `Action` and `State` match this module's type parameters —
-    /// typically a projection of a parent store scoped to the feature's slice.
+    /// typically a projection of a parent store scoped to the feature's slice — and the
+    /// `Environment` (the composition root's `World` for a lifted module). The environment is
+    /// applied to `mapState` so the view can format/render with live dependencies; it does not
+    /// touch effects (those get their environment from the `Store` at runtime).
     ///
-    /// - Parameter store: A store (or projection) whose `Action` and `State` match this module.
+    /// - Parameters:
+    ///   - store: A store (or projection) whose `Action` and `State` match this module.
+    ///   - environment: The environment supplied to the view projection.
     /// - Returns: The concrete `Content` view — no `AnyView` wrapping.
     @MainActor
-    public func view(for store: some StoreType<Action, State>) -> Content {
-        _makeView(store)
+    public func view(for store: some StoreType<Action, State>, environment: Environment) -> Content {
+        _makeView(store, environment)
     }
 
     // MARK: - Lifting
@@ -126,8 +136,8 @@ public struct Module<Action: Sendable, State: Sendable, Environment: Sendable, C
     ///     state:       AppState.lens.calculator,
     ///     environment: \.solver >>> CalculatorFeature.Environment.init
     /// )
-    /// store.install(lifted.behavior)  // Behavior<AppAction, AppState, World>
-    /// lifted.view(for: appStore)      // CalculatorView — still typed
+    /// store.install(lifted.behavior)               // Behavior<AppAction, AppState, World>
+    /// lifted.view(for: appStore, environment: world) // CalculatorView — still typed
     /// ```
     ///
     /// - Parameters:
@@ -143,8 +153,11 @@ public struct Module<Action: Sendable, State: Sendable, Environment: Sendable, C
         let makeView = _makeView
         return Module<GA, GS, GE, Content>(
             behavior: behavior.lift(action: action, state: state, environment: environment),
-            view: { @MainActor @Sendable store in
-                makeView(store.projection(action: action.review, state: state.get))
+            view: { @MainActor @Sendable store, globalEnvironment in
+                makeView(
+                    store.projection(action: action.review, state: state.get),
+                    environment(globalEnvironment)
+                )
             }
         )
     }
@@ -165,8 +178,21 @@ public struct Module<Action: Sendable, State: Sendable, Environment: Sendable, C
         let makeView = _makeView
         return Module<Action, State, Environment, AnyView>(
             behavior: behavior,
-            view: { @MainActor @Sendable store in AnyView(makeView(store)) }
+            view: { @MainActor @Sendable store, environment in AnyView(makeView(store, environment)) }
         )
+    }
+}
+
+// MARK: - Void-environment view convenience
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension Module where Environment == Void {
+    /// Returns the feature's view without supplying an environment — available when `Environment`
+    /// is `Void` (a standalone feature, or a test host). Forwards to
+    /// ``view(for:environment:)`` with `()`.
+    @MainActor
+    public func view(for store: some StoreType<Action, State>) -> Content {
+        view(for: store, environment: ())
     }
 }
 
@@ -181,10 +207,10 @@ extension Module where Content == AnyView {
     public init<F: Feature>(_ feature: F.Type)
     where F.Action == Action, F.State == State, F.Environment == Environment {
         behavior = F.behavior()
-        _makeView = { @MainActor store in
+        _makeView = { @MainActor store, environment in
             let vm = F.ViewModel(store: store.projection(
                 action: F.mapAction,
-                state: F.mapState
+                state: F.mapState(environment)
             ))
             return AnyView(F.Content(viewModel: vm))
         }

--- a/Sources/SwiftRexMacros/FeatureMacro.swift
+++ b/Sources/SwiftRexMacros/FeatureMacro.swift
@@ -18,15 +18,17 @@ public struct FeatureMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro {
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // `initialState()` defaults to `State.init()` — the common case where every
-        // `State` property has a default. Only synthesize when the feature has a nested
-        // `State` type and hasn't supplied its own `initialState()`; a `State` without an
-        // empty initializer must declare `initialState()` explicitly.
+        // `initialState(with:)` defaults to `State.init()` for the common `Void`-seed case where
+        // every `State` property has a default. Only synthesize when the feature has a nested
+        // `State`, has NOT declared a custom `Input` seed (which would need a bespoke builder),
+        // and hasn't supplied its own `initialState`. A `State` without an empty initializer, or a
+        // feature with a non-`Void` `Input`, must declare `initialState(with:)` explicitly.
         guard declaration.is(EnumDeclSyntax.self),
               hasNestedType("State", in: declaration),
+              !hasNestedType("Input", in: declaration),
               !hasInitialState(in: declaration)
         else { return [] }
-        return ["static func initialState() -> State { .init() }"]
+        return ["static func initialState(with _: Void) -> State { .init() }"]
     }
 
     // MARK: - ExtensionMacro

--- a/Sources/SwiftRexSwiftUI/StoreType+Bindings.swift
+++ b/Sources/SwiftRexSwiftUI/StoreType+Bindings.swift
@@ -1,0 +1,79 @@
+#if canImport(SwiftUI)
+import SwiftRex
+import SwiftUI
+
+// MARK: - Store-backed SwiftUI bindings
+//
+// These bridge a unidirectional ``StoreType`` to SwiftUI's *native* two-way modifiers — no new
+// navigation dialect. Reads come from `store.state`; writes dispatch an ``Action``. Presentation is
+// state-driven: the presence/item bindings only ever dispatch a *dismiss* (SwiftUI clearing the
+// value); they never drive presentation from the binding, so `showing` is always a function of state.
+//
+//     // TextField:            TextField("Name", text: store.binding(\.name, set: Action.setName))
+//     // Push (NavigationStack): NavigationStack(path: store.binding(\.path, set: Action.setPath)) { … }
+//     // Sheet (isPresented):   .sheet(isPresented: store.presence(\.editor, dismiss: .dismissEditor)) { … }
+//     // Sheet (item):          .sheet(item: store.item(\.selected, dismiss: .deselect)) { item in … }
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension StoreType {
+    /// A two-way `Binding` that reads `state[keyPath:]` and dispatches `set(newValue)` on write.
+    ///
+    /// The general form under every navigation binding: use it directly for `TextField`,
+    /// `NavigationStack(path:)`, `TabView(selection:)`, `Toggle`, sliders — anything with a
+    /// `Binding`, where a write maps to a state-setting `Action`.
+    @MainActor
+    public func binding<Value>(
+        _ keyPath: KeyPath<State, Value>,
+        set: @escaping @Sendable (Value) -> Action,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Binding<Value> {
+        Binding(
+            get: { self.state[keyPath: keyPath] },
+            set: { self.dispatch(set($0), source: ActionSource(file: file, function: function, line: line)) }
+        )
+    }
+
+    /// A `Binding<Bool>` that is `true` while the optional sub-state at `keyPath` is `.some`.
+    ///
+    /// Setting it to `false` — SwiftUI dismissing — dispatches `dismiss`. It never sets `true`:
+    /// presentation is driven by state (dispatch whatever action makes the sub-state `.some`), not
+    /// by the binding. For `.sheet(isPresented:)`, `.fullScreenCover(isPresented:)`, alerts, etc.
+    @MainActor
+    public func presence<Wrapped>(
+        _ keyPath: KeyPath<State, Wrapped?>,
+        dismiss: Action,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Binding<Bool> {
+        Binding(
+            get: { self.state[keyPath: keyPath] != nil },
+            set: { isPresented in
+                guard !isPresented else { return }
+                self.dispatch(dismiss, source: ActionSource(file: file, function: function, line: line))
+            }
+        )
+    }
+
+    /// A `Binding<Item?>` for `.sheet(item:)` / `.popover(item:)` / `.fullScreenCover(item:)` —
+    /// present while the sub-state is `.some`, and dispatch `dismiss` when SwiftUI clears it.
+    @MainActor
+    public func item<Item: Identifiable>(
+        _ keyPath: KeyPath<State, Item?>,
+        dismiss: Action,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Binding<Item?> {
+        Binding(
+            get: { self.state[keyPath: keyPath] },
+            set: { newValue in
+                guard newValue == nil else { return }
+                self.dispatch(dismiss, source: ActionSource(file: file, function: function, line: line))
+            }
+        )
+    }
+}
+#endif

--- a/Sources/SwiftRexTesting/TestFeature.swift
+++ b/Sources/SwiftRexTesting/TestFeature.swift
@@ -123,13 +123,27 @@ public final class TestFeature<F: Feature> where F.State: Equatable {
 
     /// Creates a `TestFeature` using the feature's default initial state.
     ///
+    /// Available when the feature's ``Feature/Input`` is `Void`. For a feature with a custom
+    /// seed, use ``init(input:environment:exhaustive:)``.
+    ///
     /// - Parameters:
     ///   - environment: The environment injected into effects.
     ///   - exhaustive: When `true` (default), each ``FeatureStep`` fails if effects or received
     ///     actions are left unprocessed when the step goes out of scope.
-    public init(environment: F.Environment, exhaustive: Bool = true) {
+    public convenience init(environment: F.Environment, exhaustive: Bool = true) where F.Input == Void {
+        self.init(input: (), environment: environment, exhaustive: exhaustive)
+    }
+
+    /// Creates a `TestFeature` seeding the initial state with the feature's ``Feature/Input``.
+    ///
+    /// - Parameters:
+    ///   - input: The construction-time seed threaded into ``Feature/initialState(with:)``.
+    ///   - environment: The environment injected into effects.
+    ///   - exhaustive: When `true` (default), each ``FeatureStep`` fails if effects or received
+    ///     actions are left unprocessed when the step goes out of scope.
+    public init(input: F.Input, environment: F.Environment, exhaustive: Bool = true) {
         let store = TestStore(
-            initial: F.initialState(),
+            initial: F.initialState(with: input),
             behavior: F.behavior(),
             environment: environment,
             exhaustive: exhaustive
@@ -298,7 +312,9 @@ public final class TestFeature<F: Feature> where F.State: Equatable {
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 extension TestFeature where F.Environment == Void {
     /// Creates a `TestFeature` with a `Void` environment using the feature's default initial state.
-    public convenience init(exhaustive: Bool = true) {
+    ///
+    /// Available when the feature's ``Feature/Input`` is also `Void`.
+    public convenience init(exhaustive: Bool = true) where F.Input == Void {
         self.init(environment: (), exhaustive: exhaustive)
     }
 

--- a/Sources/SwiftRexTesting/TestFeature.swift
+++ b/Sources/SwiftRexTesting/TestFeature.swift
@@ -1,4 +1,5 @@
 #if canImport(Observation) && canImport(SwiftUI)
+import DataStructure
 import Observation
 import SwiftRex
 import SwiftRexArchitecture
@@ -94,8 +95,8 @@ public final class TestFeature<F: Feature> where F.State: Equatable {
     /// The current domain state, after all dispatched and received actions have been processed.
     public var state: F.State { _store.state }
 
-    /// The current view state derived from `state` via `F.mapState`.
-    public var viewState: F.ViewModel.ViewState { F.mapState(_store.state) }
+    /// The current view state derived from `state` via `F.mapState`, applying the current environment.
+    public var viewState: F.ViewModel.ViewState { F.mapState(_store.environment)(_store.state) }
 
     /// Calls ``flush()`` then runs `body` while the underlying ``TestStore`` is frozen:
     /// any ``TestStore/dispatch(_:source:)`` from the view layer is a no-op for the
@@ -148,7 +149,7 @@ public final class TestFeature<F: Feature> where F.State: Equatable {
             environment: environment,
             exhaustive: exhaustive
         )
-        let vm = F.ViewModel(store: store.projection(action: F.mapAction, state: F.mapState))
+        let vm = F.ViewModel(store: store.projection(action: F.mapAction, state: F.mapState(environment)))
         _store = store
         _viewModel = vm
         view = F.Content(viewModel: vm)
@@ -167,7 +168,7 @@ public final class TestFeature<F: Feature> where F.State: Equatable {
             environment: environment,
             exhaustive: exhaustive
         )
-        let vm = F.ViewModel(store: store.projection(action: F.mapAction, state: F.mapState))
+        let vm = F.ViewModel(store: store.projection(action: F.mapAction, state: F.mapState(environment)))
         _store = store
         _viewModel = vm
         view = F.Content(viewModel: vm)

--- a/Tests/SwiftRexArchitectureTests/FeatureTests.swift
+++ b/Tests/SwiftRexArchitectureTests/FeatureTests.swift
@@ -1,4 +1,5 @@
 #if canImport(Observation) && canImport(SwiftUI)
+import DataStructure
 import Observation
 @testable import SwiftRex
 @testable import SwiftRexArchitecture
@@ -50,13 +51,15 @@ private enum HeroDetailsFeature: Feature {
         }
     }
 
-    static let mapState: @MainActor @Sendable (State) -> ViewModel.ViewState = { s in
-        .init(
-            displayName: s.aliases.first ?? s.codename,
-            powersText: s.powers.joined(separator: ", "),
-            threatIndex: s.threatIndex,
-            isRetired: s.isRetired
-        )
+    static let mapState = Reader<Environment, @MainActor @Sendable (State) -> ViewModel.ViewState> { _ in
+        { s in
+            .init(
+                displayName: s.aliases.first ?? s.codename,
+                powersText: s.powers.joined(separator: ", "),
+                threatIndex: s.threatIndex,
+                isRetired: s.isRetired
+            )
+        }
     }
 
     static let mapAction: @Sendable (ViewModel.ViewAction) -> Action = { va in
@@ -96,7 +99,7 @@ private func makeViewModel() -> HeroDetailsFeature.ViewModel {
     )
     return HeroDetailsFeature.ViewModel(store: store.projection(
         action: HeroDetailsFeature.mapAction,
-        state: HeroDetailsFeature.mapState
+        state: HeroDetailsFeature.mapState(.init())
     ))
 }
 
@@ -105,36 +108,34 @@ private func makeViewModel() -> HeroDetailsFeature.ViewModel {
 @Suite("HeroDetailsFeature.mapState")
 @MainActor
 struct MapStateTests {
+    // `mapState` is curried over Environment; this feature's view ignores it (empty Environment).
+    private func project(_ state: HeroDetailsFeature.State) -> HeroDetailsFeature.ViewModel.ViewState {
+        HeroDetailsFeature.mapState(.init())(state)
+    }
+
     @Test func usesFirstAliasAsDisplayName() {
-        let vs = HeroDetailsFeature.mapState(.init())
-        #expect(vs.displayName == "Superman")
+        #expect(project(.init()).displayName == "Superman")
     }
 
     @Test func fallsBackToCodenameWhenNoAliases() {
-        let vs = HeroDetailsFeature.mapState(
-            .init(codename: "Unknown", aliases: [], powers: [], threatIndex: 0, isRetired: false)
-        )
+        let vs = project(.init(codename: "Unknown", aliases: [], powers: [], threatIndex: 0, isRetired: false))
         #expect(vs.displayName == "Unknown")
     }
 
     @Test func joinsPowersWithComma() {
-        let vs = HeroDetailsFeature.mapState(.init())
-        #expect(vs.powersText == "flight, heat vision")
+        #expect(project(.init()).powersText == "flight, heat vision")
     }
 
     @Test func passesThroughThreatIndexAndRetired() {
-        let state = HeroDetailsFeature.State(
-            codename: "X", aliases: [], powers: [], threatIndex: 3, isRetired: true
-        )
-        let vs = HeroDetailsFeature.mapState(state)
+        let vs = project(.init(codename: "X", aliases: [], powers: [], threatIndex: 3, isRetired: true))
         #expect(vs.threatIndex == 3)
         #expect(vs.isRetired == true)
     }
 
     @Test func equatableDeduplication() {
-        let a = HeroDetailsFeature.mapState(.init())
-        let b = HeroDetailsFeature.mapState(.init())
-        let c = HeroDetailsFeature.mapState(.init(
+        let a = project(.init())
+        let b = project(.init())
+        let c = project(.init(
             codename: "Kryptonian",
             aliases: ["Superman", "Man of Steel"],
             powers: ["flight"],
@@ -242,7 +243,9 @@ private enum CounterFeature {
         }
     }
 
-    static let mapState: @MainActor @Sendable (State) -> ViewModel.ViewState = { .init(count: $0.count) }
+    static let mapState = Reader<Environment, @MainActor @Sendable (State) -> ViewModel.ViewState> { _ in
+        { .init(count: $0.count) }
+    }
     static let mapAction: @Sendable (ViewModel.ViewAction) -> Action = { _ in .increment }
 
     // No `initialState()` here — synthesized by `@Feature`.
@@ -289,7 +292,9 @@ private enum OverrideFeature {
         }
     }
 
-    static let mapState: @MainActor @Sendable (State) -> ViewModel.ViewState = { .init(count: $0.count) }
+    static let mapState = Reader<Environment, @MainActor @Sendable (State) -> ViewModel.ViewState> { _ in
+        { .init(count: $0.count) }
+    }
     static let mapAction: @Sendable (ViewModel.ViewAction) -> Action = { _ in .noop }
 
     static func initialState(with _: Void) -> State { .init(count: 99) }
@@ -337,7 +342,9 @@ private enum SeededFeature {
         }
     }
 
-    static let mapState: @MainActor @Sendable (State) -> ViewModel.ViewState = { .init(count: $0.count) }
+    static let mapState = Reader<Environment, @MainActor @Sendable (State) -> ViewModel.ViewState> { _ in
+        { .init(count: $0.count) }
+    }
     static let mapAction: @Sendable (ViewModel.ViewAction) -> Action = { _ in .noop }
 
     static func initialState(with input: Input) -> State { .init(count: input.startingCount) }
@@ -373,6 +380,70 @@ struct FeatureInitialStateTests {
     @Test func customInputSeedsInitialState() {
         // A non-`Void` `Input` threads a construction-time seed into the initial state.
         #expect(SeededFeature.initialState(with: .init(startingCount: 42)).count == 42)
+    }
+}
+
+// MARK: - mapState environment injection
+//
+// A feature whose view formats via an injected dependency — proves `mapState` is curried over
+// `Environment` and the value reaches the projection at view-build time, without pushing
+// formatting into `Behavior`/`State`.
+
+private struct FormattingView: View, HasViewModel {
+    typealias VM = FormattingFeature.ViewModel
+    let viewModel: FormattingFeature.ViewModel
+    var body: Never { fatalError("test stub") }
+}
+
+@Feature
+private enum FormattingFeature {
+    struct State: Sendable, Equatable {
+        var amount: Int = 5
+    }
+
+    enum Action: Sendable, Equatable {
+        case noop
+    }
+
+    struct Environment: Sendable {
+        var formatMoney: @Sendable (Int) -> String
+    }
+
+    // swiftlint:disable:next convenience_type
+    final class ViewModel {
+        struct ViewState: Sendable, Equatable {
+            var display: String
+        }
+        enum ViewAction: Sendable {
+            case tapped
+        }
+    }
+
+    static let mapState = Reader<Environment, @MainActor @Sendable (State) -> ViewModel.ViewState> { env in
+        { state in .init(display: env.formatMoney(state.amount)) }
+    }
+    static let mapAction: @Sendable (ViewModel.ViewAction) -> Action = { _ in .noop }
+
+    static func behavior() -> Behavior<Action, State, Environment> {
+        Reducer.reduce { (_: Action, _: inout State) in }.asBehavior()
+    }
+
+    typealias Content = FormattingView
+}
+
+@Suite("mapState — environment injection")
+@MainActor
+struct MapStateEnvironmentTests {
+    @Test func mapStateUsesInjectedEnvironment() {
+        let env = FormattingFeature.Environment(formatMoney: { "$\($0).00" })
+        #expect(FormattingFeature.mapState(env)(.init(amount: 7)).display == "$7.00")
+    }
+
+    @Test func differentEnvironmentsFormatDifferently() {
+        let dollars = FormattingFeature.Environment(formatMoney: { "$\($0)" })
+        let euros = FormattingFeature.Environment(formatMoney: { "€\($0)" })
+        #expect(FormattingFeature.mapState(dollars)(.init(amount: 3)).display == "$3")
+        #expect(FormattingFeature.mapState(euros)(.init(amount: 3)).display == "€3")
     }
 }
 #endif

--- a/Tests/SwiftRexArchitectureTests/FeatureTests.swift
+++ b/Tests/SwiftRexArchitectureTests/FeatureTests.swift
@@ -70,7 +70,7 @@ private enum HeroDetailsFeature: Feature {
         }
     }
 
-    static func initialState() -> State { .init() }
+    static func initialState(with _: Void) -> State { .init() }
 
     static func behavior() -> Behavior<Action, State, Environment> {
         Reducer.reduce { (action: Action, state: inout State) in
@@ -292,13 +292,61 @@ private enum OverrideFeature {
     static let mapState: @MainActor @Sendable (State) -> ViewModel.ViewState = { .init(count: $0.count) }
     static let mapAction: @Sendable (ViewModel.ViewAction) -> Action = { _ in .noop }
 
-    static func initialState() -> State { .init(count: 99) }
+    static func initialState(with _: Void) -> State { .init(count: 99) }
 
     static func behavior() -> Behavior<Action, State, Environment> {
         Reducer.reduce { (_: Action, _: inout State) in }.asBehavior()
     }
 
     typealias Content = OverrideView
+}
+
+// A feature with a non-`Void` `Input` seed — `@Feature` must NOT synthesize `initialState`
+// (it can't know how to build `State` from a custom seed), so the feature writes its own
+// `initialState(with:)` that threads the seed into the initial state.
+
+private struct SeededView: View, HasViewModel {
+    typealias VM = SeededFeature.ViewModel
+    let viewModel: SeededFeature.ViewModel
+    var body: Never { fatalError("test stub") }
+}
+
+@Feature
+private enum SeededFeature {
+    struct Input: Sendable {
+        var startingCount: Int
+    }
+
+    struct State: Sendable {
+        var count: Int = 0
+    }
+
+    enum Action: Sendable, Equatable {
+        case noop
+    }
+
+    struct Environment: Sendable {}
+
+    // swiftlint:disable:next convenience_type
+    final class ViewModel {
+        struct ViewState: Sendable, Equatable {
+            var count: Int
+        }
+        enum ViewAction: Sendable {
+            case tapped
+        }
+    }
+
+    static let mapState: @MainActor @Sendable (State) -> ViewModel.ViewState = { .init(count: $0.count) }
+    static let mapAction: @Sendable (ViewModel.ViewAction) -> Action = { _ in .noop }
+
+    static func initialState(with input: Input) -> State { .init(count: input.startingCount) }
+
+    static func behavior() -> Behavior<Action, State, Environment> {
+        Reducer.reduce { (_: Action, _: inout State) in }.asBehavior()
+    }
+
+    typealias Content = SeededView
 }
 
 @Suite("@Feature — initialState synthesis")
@@ -320,6 +368,11 @@ struct FeatureInitialStateTests {
         // Compiles only because `@Feature` skipped synthesis (no redeclaration), and returns
         // the user's value rather than `State.init()` defaults.
         #expect(OverrideFeature.initialState().count == 99)
+    }
+
+    @Test func customInputSeedsInitialState() {
+        // A non-`Void` `Input` threads a construction-time seed into the initial state.
+        #expect(SeededFeature.initialState(with: .init(startingCount: 42)).count == 42)
     }
 }
 #endif

--- a/Tests/SwiftRexArchitectureTests/StoreBindingsTests.swift
+++ b/Tests/SwiftRexArchitectureTests/StoreBindingsTests.swift
@@ -1,0 +1,98 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import SwiftRex
+@testable import SwiftRexArchitecture
+import SwiftUI
+import Testing
+
+// Exercises the store-backed SwiftUI bindings (`binding` / `presence` / `item`) — get reads state,
+// set dispatches, and presence/item only ever dispatch a dismiss.
+
+@Suite("StoreType SwiftUI bindings")
+@MainActor
+struct StoreBindingsTests {
+    private struct S: Sendable, Equatable {
+        var name = "a"
+        var editor: Int?
+        var selected: Item?
+    }
+    private struct Item: Identifiable, Sendable, Equatable { var id: Int }
+    private enum A: Sendable, Equatable {
+        case setName(String)
+        case presentEditor(Int)
+        case dismissEditor
+        case select(Item)
+        case deselect
+    }
+
+    private func makeStore() -> Store<A, S, Void> {
+        Store(
+            initial: S(),
+            behavior: Reducer.reduce { (action: A, state: inout S) in
+                switch action {
+                case .setName(let n):       state.name = n
+                case .presentEditor(let v): state.editor = v
+                case .dismissEditor:        state.editor = nil
+                case .select(let item):     state.selected = item
+                case .deselect:             state.selected = nil
+                }
+            }.asBehavior(),
+            environment: ()
+        )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func bindingGetReadsState() {
+        #expect(makeStore().binding(\.name, set: A.setName).wrappedValue == "a")
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func bindingSetDispatches() async {
+        let store = makeStore()
+        store.binding(\.name, set: A.setName).wrappedValue = "z"
+        await Task.yield()
+        #expect(store.state.name == "z")
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func presenceIsFalseWhenNilTrueWhenSome() async {
+        let store = makeStore()
+        let presence = store.presence(\.editor, dismiss: .dismissEditor)
+        #expect(presence.wrappedValue == false)
+        store.dispatch(.presentEditor(7))
+        await Task.yield()
+        #expect(presence.wrappedValue == true)
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func presenceSetFalseDispatchesDismiss() async {
+        let store = makeStore()
+        store.dispatch(.presentEditor(7))
+        await Task.yield()
+        let presence = store.presence(\.editor, dismiss: .dismissEditor)
+        presence.wrappedValue = false // SwiftUI dismissing
+        await Task.yield()
+        #expect(store.state.editor == nil)
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func presenceSetTrueIsIgnored() async {
+        let store = makeStore()
+        let presence = store.presence(\.editor, dismiss: .dismissEditor)
+        presence.wrappedValue = true // binding never drives presentation
+        await Task.yield()
+        #expect(store.state.editor == nil)
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func itemReadsAndDismisses() async {
+        let store = makeStore()
+        store.dispatch(.select(.init(id: 3)))
+        await Task.yield()
+        let item = store.item(\.selected, dismiss: .deselect)
+        #expect(item.wrappedValue == Item(id: 3))
+        item.wrappedValue = nil // SwiftUI clearing the sheet
+        await Task.yield()
+        #expect(store.state.selected == nil)
+    }
+}
+#endif

--- a/Tests/SwiftRexTests/BehaviorTests/BehaviorTests.swift
+++ b/Tests/SwiftRexTests/BehaviorTests/BehaviorTests.swift
@@ -290,6 +290,56 @@ struct BehaviorLiftStateTests {
         sut.handle(6, PreReducerContext(source: anySource, getter: { initial })).mutation.runEndoMut(&state)
         #expect(state.nums.isEmpty)
     }
+
+    // MARK: liftOptional (0-or-1 — sibling of liftCollection/liftEach)
+
+    @Test func liftOptionalMutatesWhenPresent() {
+        struct OptGS: Sendable { var current: Int? }
+        let sut = adder.liftOptional(\OptGS.current)
+        let initial = OptGS(current: 10)
+        var state = initial
+        sut.handle(5, PreReducerContext(source: anySource, getter: { initial })).mutation.runEndoMut(&state)
+        #expect(state.current == 15)
+    }
+
+    @Test func liftOptionalIsNoOpWhenNil() {
+        struct OptGS: Sendable { var current: Int? }
+        let sut = adder.liftOptional(\OptGS.current)
+        let initial = OptGS(current: nil)
+        var state = initial
+        sut.handle(5, PreReducerContext(source: anySource, getter: { initial })).mutation.runEndoMut(&state)
+        #expect(state.current == nil)
+    }
+
+    @Test func liftOptionalStateAccessSeesUnwrapped() {
+        struct OptGS: Sendable { var current: Int? }
+        let seen = LockProtected([Int]())
+        let observer = Behavior<Int, Int, Void>.handle { _, context in
+            seen.mutate { $0.append(context.stateBefore ?? -1) }
+            return .doNothing
+        }
+        let present = observer.liftOptional(\OptGS.current)
+        _ = present.handle(0, PreReducerContext(source: anySource, getter: { OptGS(current: 42) }))
+        _ = present.handle(0, PreReducerContext(source: anySource, getter: { OptGS(current: nil) }))
+        #expect(seen.value == [42])   // second dispatch is skipped while nil
+    }
+
+    @Test func combinedLiftOptionalMutatesOnlyWhenPresent() {
+        struct GA: Sendable { var day: Int? }
+        struct GS: Sendable { var day: Int? }
+        let dayPrism = Prism<GA, Int>(preview: { $0.day }, review: { GA(day: $0) })
+        let sut = adder.liftOptional(action: dayPrism, state: \GS.day, environment: { (_: Void) in () })
+
+        let present = GS(day: 100)
+        var presentState = present
+        sut.handle(GA(day: 5), PreReducerContext(source: anySource, getter: { present })).mutation.runEndoMut(&presentState)
+        #expect(presentState.day == 105)
+
+        let absent = GS(day: nil)
+        var absentState = absent
+        sut.handle(GA(day: 5), PreReducerContext(source: anySource, getter: { absent })).mutation.runEndoMut(&absentState)
+        #expect(absentState.day == nil)
+    }
 }
 
 // MARK: - liftEnvironment

--- a/Tests/SwiftRexTests/MiddlewareTests/MiddlewareTests.swift
+++ b/Tests/SwiftRexTests/MiddlewareTests/MiddlewareTests.swift
@@ -310,3 +310,27 @@ struct MiddlewareContextTimingTests {
         #expect(received.value == [10])
     }
 }
+
+// MARK: - liftOptional (0-or-1 — sibling of liftCollection/liftEach)
+
+@Suite("Middleware liftOptional")
+@MainActor
+struct MiddlewareLiftOptionalTests {
+    // Emits the current (local) sub-state via an effect, so we can observe whether it ran.
+    private let echo = Middleware<Int, Int, Void>.handle { _, context in
+        let seen = context.stateBefore ?? -1
+        return Reader { _ in .just(seen) }
+    }
+
+    @Test func runsWhenPresent() {
+        struct OptGS: Sendable { var current: Int? }
+        let sut = echo.liftOptional(\OptGS.current)
+        #expect(actions(sut, action: 0, state: OptGS(current: 7), env: ()) == [7])
+    }
+
+    @Test func skippedWhenNil() {
+        struct OptGS: Sendable { var current: Int? }
+        let sut = echo.liftOptional(\OptGS.current)
+        #expect(actions(sut, action: 0, state: OptGS(current: nil), env: ()).isEmpty)
+    }
+}


### PR DESCRIPTION
## What
Four incremental, independently-valuable pieces of the Feature/module redesign — construction-time `Input`, environment-injected view formatting, the unwrap (`ifLet`) lift, and store-backed SwiftUI navigation bindings.

## Why
Groundwork for the larger Feature-as-module-entry-point / navigation design (captured separately). Each piece stands on its own on the current architecture and is green, so they land as one PR without waiting on the full container/macro redesign.

## Changes

**`initialState(with: Input)` — construction-time seed**
- `Feature` gains `associatedtype Input = Void` and `initialState(with:)`; `where Input == Void` keeps the no-arg form.
- `@Feature` synthesizes `initialState(with _: Void)` (skipped when a custom `Input` is declared).
- `TestFeature.init(input:environment:)`; the no-seed inits gain `where F.Input == Void`.

**`mapState` as `Reader<Environment, (State) -> ViewState>` — view-side env injection**
- The view projection can now format/render with live dependencies (locale/formatters), instead of pushing pre-formatted strings into `State`. Same `Reader` shape as `produce`/`supervise`.
- `Module.view(for:environment:)` (+ a `where Environment == Void` convenience); `lift` composes env into the view factory alongside action/state.
- `DataStructure` added to the architecture/testing targets + `@_exported` so feature authors get `Reader` for free.

**Unwrap (`ifLet`) lift over an optional sub-state key path**
- `liftState(_:WritableKeyPath<GS, State?>)` + combined `lift(action:state:environment:)` on `Behavior` and `Middleware`. While the sub-state is `nil` the child is skipped entirely (no mutation, no effect, channels torn down); while `.some` it runs focused. The 0..1 sibling of `liftEach`.

**Store-backed SwiftUI bindings — the view half of the navigation primitives**
- `binding` / `presence` / `item` on `StoreType`, bridging a unidirectional store to SwiftUI's *native* `.sheet(item:)` / `NavigationStack(path:)` / `TabView(selection:)` — no new dialect. Presentation stays state-driven; bindings only ever dispatch a *dismiss*.

**Tests:** +6 unwrap-lift, +6 store-binding, +construction-input and env-injection coverage. Full suite green (482), swiftlint `--strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)