### PR TITLE
Bump FP to 1.13.0; drop @Lenses optional workarounds; case-constructor bindings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "c3d76935a6b3b368dec230419cbed0c11ae2817779658229f767877dc3b08ced",
+  "originHash" : "06ee577977bf52d63ea1a1505f616e404b427e3a23052120075acadf44b86efd",
   "pins" : [
     {
       "identity" : "fp",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/FP.git",
       "state" : {
-        "revision" : "1b93d54ee5d35a9696c038b323563d2f22f60a2c",
-        "version" : "1.12.0"
+        "revision" : "c1b32932021b444d8b21ca873c80bfcd4c6b8ecb",
+        "version" : "1.13.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .default(enabledTraits: [])
     ],
     dependencies: [
-        .package(url: "https://github.com/luizmb/FP.git", from: "1.12.0"),
+        .package(url: "https://github.com/luizmb/FP.git", from: "1.13.0"),
         .package(url: "https://github.com/luizmb/Hourglass.git", from: "0.6.2"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.2.0"),

--- a/README.md
+++ b/README.md
@@ -1445,7 +1445,7 @@ viewStore.dispatch(.<action>)    // send
 `ViewStore` and `TrackedViewStore` both conform to `StoreType`, so the store-backed SwiftUI helpers work on the `viewStore` directly:
 
 ```swift
-viewStore.binding(\.field, set: { .someAction($0) })     // two-way TextField/Toggle/…
+viewStore.binding(\.field, set: Action.someAction)       // two-way TextField/Toggle/…
 viewStore.presence(\.optional, dismiss: .close)          // .sheet(isPresented:)
 viewStore.item(\.selected, dismiss: .deselect)           // .sheet(item:)
 ```
@@ -1590,7 +1590,8 @@ struct HeroDetailsView: View {
     var body: some View {
         Form {
             Text(viewStore.state.displayName).font(.headline)
-            TextField("Powers", text: viewStore.binding(\.powersText, set: { .editedPowers($0) }))
+            // `set:` is `(Value) -> ViewAction`, so pass the case constructor directly:
+            TextField("Powers", text: viewStore.binding(\.powersText, set: HeroDetails.ViewAction.editedPowers))
             Toggle("Retired", isOn: viewStore.binding(\.isRetired, set: { _ in .tappedRetirement }))
         }
     }
@@ -1644,7 +1645,7 @@ public enum Library {
         var shelfID: String
         var isLoading = false
         var books: [Book] = []
-        var selected: Book? = nil  // non-nil ⇒ present the detail sheet (explicit = nil for @Lenses init)
+        var selected: Book?        // non-nil ⇒ present the detail sheet
     }
 
     public enum Action: Sendable {

--- a/Sources/SwiftRex/SwiftRex.docc/Features.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Features.md
@@ -150,7 +150,8 @@ struct HeroDetailsView: View {
     var body: some View {
         Form {
             Text(viewStore.state.displayName).font(.headline)
-            TextField("Powers", text: viewStore.binding(\.powersText, set: { .editedPowers($0) }))
+            // `set:` is `(Value) -> ViewAction`, so pass the case constructor directly:
+            TextField("Powers", text: viewStore.binding(\.powersText, set: HeroDetails.ViewAction.editedPowers))
             Toggle("Retired", isOn: viewStore.binding(\.isRetired, set: { _ in .tappedRetirement }))
         }
     }
@@ -206,7 +207,7 @@ public enum Library {
         var shelfID: String
         var isLoading = false
         var books: [Book] = []
-        var selected: Book? = nil  // non-nil ⇒ present the detail sheet (explicit `= nil`: @Lenses's init)
+        var selected: Book?        // non-nil ⇒ present the detail sheet
     }
 
     public enum Action: Sendable {

--- a/Tests/SwiftRexArchitectureTests/DocExamplesTests.swift
+++ b/Tests/SwiftRexArchitectureTests/DocExamplesTests.swift
@@ -22,10 +22,7 @@ enum Library {
         var shelfID: String
         var isLoading = false
         var books: [Book] = []
-        // Explicit `= nil`: @Lenses (applied by @Feature) generates the memberwise init and only
-        // defaults params whose property has an explicit default.
-        // swiftlint:disable:next implicit_optional_initialization
-        var selected: Book? = nil
+        var selected: Book?   // @Lenses (FP 1.13+) defaults optionals to nil in the generated init
     }
 
     enum Action: Sendable {
@@ -112,7 +109,7 @@ enum Editor {
 @BoundTo(Editor.self, strategy: .observationSimple)
 struct EditorView: View {
     var body: some View {
-        TextField("Powers", text: viewStore.binding(\.powersText, set: { .editedPowers($0) }))
+        TextField("Powers", text: viewStore.binding(\.powersText, set: Editor.ViewAction.editedPowers))
     }
 }
 
@@ -127,8 +124,7 @@ enum AppAction: Sendable {
 @Lenses
 struct AppState: Sendable {
     var library = Library.State(shelfID: "sci-fi")
-    // swiftlint:disable:next implicit_optional_initialization
-    var editor: Editor.State? = nil
+    var editor: Editor.State?
 }
 
 struct AppEnv: Sendable {


### PR DESCRIPTION
## What
Adopt FP 1.13.0 (whose `@Lenses` now defaults optional params to `nil`), remove the workarounds that required, and tidy the binding docs.

## Why
Follows FP [#78](https://github.com/luizmb/FP/pull/78). Previously an optional property in a `@Feature`/`@Lenses` state needed an explicit `= nil` for the generated init — which then tripped SwiftLint's `implicit_optional_initialization`. 1.13.0 fixes that at the source, so `var x: T?` now both compiles and lints clean.

## Changes
- `Package.swift`: FP `from: "1.12.0"` → `"1.13.0"`.
- Dropped `= nil` + `// swiftlint:disable` on optional feature-state properties in the doc-examples harness (`Library.State.selected`, `AppState.editor`) and the `Features.md` / README `Library.State` snippets.
- Binding docs favour the case-constructor form `set: Action.caseName` over `set: { .caseName($0) }` (the `set:` param is `(Value) -> Action`).
- Kept `action: AppAction.prism.library` for `lift`/`liftOptional`: a rootless `PrismKeyPath` (`\.library`) doesn't infer the action generic there, so the `Prism` form stays the clean one.

496 tests + swiftlint `--strict` green; the harness compiles against FP 1.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)