### PR TITLE
Nav S1: Scope — declare child wiring once; Behavior.combine([...])

### DIFF
--- a/Sources/SwiftRex/Behavior/Behavior+Combine.swift
+++ b/Sources/SwiftRex/Behavior/Behavior+Combine.swift
@@ -1,0 +1,25 @@
+extension Behavior {
+    /// Folds an array of behaviors into one, in order, using the ``Behavior`` monoid
+    /// (``identity`` as the empty element, ``combine(_:_:)`` as the binary operation).
+    ///
+    /// This is the variadic-collection companion to ``combine(_:_:)`` — handy when composing a
+    /// whole app's behaviors from a list (e.g. one lifted child behavior per feature, plus a
+    /// navigation reducer and cross-cutting behaviors like logging):
+    ///
+    /// ```swift
+    /// let appBehavior = Behavior.combine([
+    ///     homeScope.lifted,
+    ///     detailScope.lifted,
+    ///     navigationReducer,
+    ///     loggingBehavior,
+    /// ])
+    /// ```
+    ///
+    /// An empty array yields ``identity`` (the no-op behavior).
+    ///
+    /// - Parameter behaviors: The behaviors to fold, applied left-to-right.
+    /// - Returns: A single behavior equivalent to `behaviors[0] <> behaviors[1] <> …`.
+    public static func combine(_ behaviors: [Behavior]) -> Behavior {
+        behaviors.reduce(.identity, Behavior.combine)
+    }
+}

--- a/Sources/SwiftRexArchitecture/Scope.swift
+++ b/Sources/SwiftRexArchitecture/Scope.swift
@@ -1,0 +1,92 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+import SwiftRex
+
+/// The wiring that scopes a child feature into a parent (app) store — declared **once** and reused
+/// by both behavior composition and (in a later stage) navigation.
+///
+/// A `Scope` captures how a child feature's `(Action, State, Environment)` embeds into the parent's
+/// `(GlobalAction, GlobalState, GlobalEnvironment)`: the action prism, the state key path, and the
+/// environment-narrowing closure. From those it derives the child's **lifted behavior**
+/// (``lifted``), typed at the global types so a whole app's behaviors are homogeneous and fold with
+/// the ``Behavior`` monoid.
+///
+/// ## Compile-time proof of wiring
+///
+/// Constructing a `Scope` *is* the proof the feature is wired: the initializer will not type-check
+/// unless the global state slot, global action case (prism), environment-narrowing, and the child's
+/// own `(Action, State, Environment)` all exist and line up. Forget the slot, the case, or the
+/// env-narrowing and you get a **compile error at the `Scope` literal** — not a silent missing
+/// screen at runtime.
+///
+/// ```swift
+/// let homeScope = Scope(
+///     behavior:    HomeFeature.behavior(),
+///     action:      \.home,          // PrismKeyPath<AppAction, HomeFeature.Action>
+///     state:       \.home,          // WritableKeyPath<AppState, HomeFeature.State>
+///     environment: \.homeEnv        // KeyPath<World, HomeFeature.Environment>
+/// )
+/// // homeScope.lifted : Behavior<AppAction, AppState, World>
+/// ```
+///
+/// Register every scope's ``lifted`` behavior in one homogeneous list so you can't forget to
+/// compose one:
+///
+/// ```swift
+/// let appBehavior = Behavior.combine([homeScope.lifted, detailScope.lifted, navigationReducer])
+/// ```
+///
+/// A scope over an **optional** child state (`ChildState?`) lifts with `liftOptional`, so the child
+/// behavior runs only while its slice is `.some` — the shape a presented/pushed screen uses.
+public struct Scope<GlobalAction: Sendable, GlobalState: Sendable, GlobalEnvironment: Sendable>: Sendable {
+    /// The child behavior lifted to the global `(Action, State, Environment)` — homogeneous across
+    /// every scope, so a whole app's behaviors fold with ``Behavior/combine(_:)-(Array)``.
+    public let lifted: Behavior<GlobalAction, GlobalState, GlobalEnvironment>
+
+    // MARK: - Always-present child state (env as closure)
+
+    /// Scopes a child whose state is always present in the parent (a sibling slice — the shape used
+    /// for tabs/split children that all stay alive).
+    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
+        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
+        action: PrismKeyPath<GlobalAction, ChildAction>,
+        state: WritableKeyPath<GlobalState, ChildState>,
+        environment: @escaping @Sendable (GlobalEnvironment) -> ChildEnvironment
+    ) where GlobalAction: Prismatic {
+        lifted = behavior.lift(action: action, state: state, environment: environment)
+    }
+
+    /// Env-as-key-path convenience for an always-present child.
+    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
+        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
+        action: PrismKeyPath<GlobalAction, ChildAction>,
+        state: WritableKeyPath<GlobalState, ChildState>,
+        environment: KeyPath<GlobalEnvironment, ChildEnvironment> & Sendable
+    ) where GlobalAction: Prismatic {
+        self.init(behavior: behavior, action: action, state: state, environment: { $0[keyPath: environment] })
+    }
+
+    // MARK: - Optional child state (present-while-.some)
+
+    /// Scopes a child whose state is **optional** — the child behavior runs only while the slice is
+    /// `.some` (the shape a presented sheet / pushed screen uses). Lifts with `liftOptional`.
+    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
+        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
+        action: PrismKeyPath<GlobalAction, ChildAction>,
+        state: WritableKeyPath<GlobalState, ChildState?>,
+        environment: @escaping @Sendable (GlobalEnvironment) -> ChildEnvironment
+    ) where GlobalAction: Prismatic {
+        lifted = behavior.liftOptional(action: action, state: state, environment: environment)
+    }
+
+    /// Env-as-key-path convenience for an optional child.
+    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
+        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
+        action: PrismKeyPath<GlobalAction, ChildAction>,
+        state: WritableKeyPath<GlobalState, ChildState?>,
+        environment: KeyPath<GlobalEnvironment, ChildEnvironment> & Sendable
+    ) where GlobalAction: Prismatic {
+        self.init(behavior: behavior, action: action, state: state, environment: { $0[keyPath: environment] })
+    }
+}
+#endif

--- a/Tests/SwiftRexArchitectureTests/ScopeTests.swift
+++ b/Tests/SwiftRexArchitectureTests/ScopeTests.swift
@@ -1,0 +1,118 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+@testable import SwiftRex
+@testable import SwiftRexArchitecture
+import Testing
+
+// A child feature reduced to the essentials Scope needs: a behavior + (Action, State, Environment).
+// No @Feature required — Scope takes the behavior + optics as values.
+private enum SCCounter {
+    struct State: Sendable, Equatable { var count = 0 }
+    enum Action: Sendable, Equatable { case inc, pull, add(Int) }
+    struct Environment: Sendable { var step: Int }
+
+    static func behavior() -> Behavior<Action, State, Environment> {
+        .handle { action, _ in
+            switch action {
+            case .inc:        .reduce { $0.count += 1 }
+            case .pull:       .produce { ctx in Effect.just(.add(ctx.environment.step)) } // reads env
+            case .add(let n): .reduce { $0.count += n }
+            }
+        }
+    }
+}
+
+// @Prisms/@Lenses require >= fileprivate (they reject `private`).
+// swiftlint:disable private_over_fileprivate
+@Prisms
+fileprivate enum SCAction: Sendable, Equatable {
+    case counter(SCCounter.Action)
+    case sheet(SCCounter.Action)
+}
+
+@Lenses
+fileprivate struct SCState: Sendable, Equatable {
+    var counter = SCCounter.State()
+    var sheet: SCCounter.State?
+}
+// swiftlint:enable private_over_fileprivate
+
+private struct SCWorld: Sendable {
+    var step: Int = 10
+    var counterEnv: SCCounter.Environment { .init(step: step) }
+}
+
+@Suite("Scope")
+@MainActor
+struct ScopeTests {
+    // The Scope literal itself is a compile-time proof of wiring: it would not compile if the
+    // action case, state slot, or env-narrowing didn't line up with SCCounter's own types.
+    private func counterScope() -> Scope<SCAction, SCState, SCWorld> {
+        Scope(behavior: SCCounter.behavior(), action: \.counter, state: \.counter, environment: { _ in .init(step: 0) })
+    }
+
+    @Test func presentScopeLiftsActionAndState() {
+        let store = Store(initial: SCState(), behavior: counterScope().lifted, environment: SCWorld())
+        store.dispatch(.counter(.inc))
+        #expect(store.state.counter.count == 1) // action prism + state key path both applied
+    }
+
+    @Test func envIsNarrowedFromWorld() async {
+        let scope = Scope<SCAction, SCState, SCWorld>(
+            behavior: SCCounter.behavior(),
+            action: \.counter,
+            state: \.counter,
+            environment: { SCCounter.Environment(step: $0.step) } // narrow SCWorld.step
+        )
+        let store = Store(initial: SCState(), behavior: scope.lifted, environment: SCWorld(step: 7))
+        store.dispatch(.counter(.pull)) // effect reads env.step=7 → .add(7)
+        await Task.yield()
+        #expect(store.state.counter.count == 7)
+    }
+
+    @Test func envAsKeyPathConvenience() async {
+        let scope = Scope<SCAction, SCState, SCWorld>(
+            behavior: SCCounter.behavior(),
+            action: \.counter,
+            state: \.counter,
+            environment: \.counterEnv // KeyPath<SCWorld, SCCounter.Environment>
+        )
+        let store = Store(initial: SCState(), behavior: scope.lifted, environment: SCWorld(step: 3))
+        store.dispatch(.counter(.pull))
+        await Task.yield()
+        #expect(store.state.counter.count == 3) // env-narrow via key path reached the effect
+    }
+
+    @Test func optionalScopeRunsWhenSome() {
+        let scope = Scope<SCAction, SCState, SCWorld>(
+            behavior: SCCounter.behavior(),
+            action: \.sheet,
+            state: \.sheet, // WritableKeyPath<SCState, SCCounter.State?>
+            environment: { _ in .init(step: 0) }
+        )
+        var initial = SCState(); initial.sheet = SCCounter.State(count: 5)
+        let store = Store(initial: initial, behavior: scope.lifted, environment: SCWorld())
+        store.dispatch(.sheet(.inc))
+        #expect(store.state.sheet?.count == 6)
+    }
+
+    @Test func optionalScopeSkipsWhenNil() {
+        let scope = Scope<SCAction, SCState, SCWorld>(
+            behavior: SCCounter.behavior(),
+            action: \.sheet,
+            state: \.sheet,
+            environment: { _ in .init(step: 0) }
+        )
+        let store = Store(initial: SCState(), behavior: scope.lifted, environment: SCWorld()) // sheet nil
+        store.dispatch(.sheet(.inc))
+        #expect(store.state.sheet == nil) // child behavior never runs while slice is nil
+    }
+
+    @Test func scopesFoldIntoOneAppBehavior() {
+        let app = Behavior.combine([counterScope().lifted])
+        let store = Store(initial: SCState(), behavior: app, environment: SCWorld())
+        store.dispatch(.counter(.inc))
+        #expect(store.state.counter.count == 1)
+    }
+}
+#endif

--- a/Tests/SwiftRexTests/BehaviorTests/BehaviorCombineArrayTests.swift
+++ b/Tests/SwiftRexTests/BehaviorTests/BehaviorCombineArrayTests.swift
@@ -1,0 +1,25 @@
+@testable import SwiftRex
+import Testing
+
+@Suite("Behavior.combine(array)")
+@MainActor
+struct BehaviorCombineArrayTests {
+    private struct S: Sendable, Equatable { var a = 0; var b = 0; var log = "" }
+    private enum A: Sendable { case go }
+
+    @Test func foldsAllInOrder() {
+        let r1 = Behavior<A, S, Void>.reduce { _, s in s.a += 1; s.log += "1" }
+        let r2 = Behavior<A, S, Void>.reduce { _, s in s.b += 1; s.log += "2" }
+        let store = Store(initial: S(), behavior: .combine([r1, r2]), environment: ())
+        store.dispatch(.go)
+        #expect(store.state.a == 1)
+        #expect(store.state.b == 1)
+        #expect(store.state.log == "12")   // left-to-right order preserved
+    }
+
+    @Test func emptyIsIdentity() {
+        let store = Store(initial: S(), behavior: Behavior<A, S, Void>.combine([]), environment: ())
+        store.dispatch(.go)
+        #expect(store.state == S())        // no-op
+    }
+}


### PR DESCRIPTION
## What
First PR of the state-driven navigation stack (design: memory `design-navigation`). Introduces **`Scope`** — the wiring that scopes a child feature into the app store, declared once and reused by both behavior composition and (later PRs) navigation — plus `Behavior.combine([...])`.

## Why
Registering a feature today means separately declaring a state slot, an action case, and lifting its behavior — forget the lift and you get a silent missing feature. `Scope` makes the wiring a single value whose construction is a **compile-time proof**, and `combine([...])` makes "register every scope's behavior" a homogeneous fold you can't forget.

## Changes
- `Sources/SwiftRexArchitecture/Scope.swift` — `Scope<GlobalAction, GlobalState, GlobalEnvironment>`: captures `(action prism, state key path, env-narrowing)`, derives `lifted: Behavior<Global…>`. Present-state (`lift`) and optional-state (`liftOptional`, present-while-`.some`) initializers; env as closure or `KeyPath`. Won't compile if the slot/case/env don't line up with the child's types.
- `Sources/SwiftRex/Behavior/Behavior+Combine.swift` — `Behavior.combine([Behavior])` array fold (Behavior monoid; empty → identity).
- Tests: present/optional lift, env narrowing (closure + key path), the fold.

**Decisions made** (for your review):
- **No `Feature` protocol reintroduced.** The redesign retired it because a public protocol forces `.internalOnly` features' witnesses public. `Scope` instead takes the child's `behavior()` + optics as **values**, keeping the compile-proof without the protocol.
- **`Scope` lives in `SwiftRexArchitecture`** (SwiftUI-gated) since navigation is SwiftUI-only; `combine([...])` is in core (pure, ungated, useful everywhere).
- The **view/router side of `Scope` lands in S4** (it needs the router). S1 is behavior-registration only.

Green: full suite (504 tests) + swiftlint `--strict`.

## Stack
S1 (this) → S2 bindings → S3 nav-reducer → S4 router/Routable → S5 multi-scene → S6 (deferred macro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)