### PR TITLE
Nav S2: path & selection bindings

### DIFF
--- a/Sources/SwiftRexSwiftUI/StoreType+Bindings.swift
+++ b/Sources/SwiftRexSwiftUI/StoreType+Bindings.swift
@@ -75,5 +75,61 @@ extension StoreType {
             }
         )
     }
+
+    /// A `Binding<[Element]>` for `NavigationStack(path:)` — the **stack** navigation shape.
+    ///
+    /// SwiftUI hands the binding the *whole* new path on every structural change, so a single
+    /// `set` action carries push (append), pop / back-swipe (truncate), and pop-to-root (empty)
+    /// uniformly. The stack is a function of state; the reducer decides what a new path means
+    /// (see the navigation reducer for standard `push`/`pop`/`setPath` handling).
+    ///
+    /// ```swift
+    /// NavigationStack(path: store.path(\.path, set: NavAction.setPath)) { root }
+    ///     .navigationDestination(for: Route.self) { route in router.view(for: route) }
+    /// ```
+    @MainActor
+    public func path<Element>(
+        _ keyPath: KeyPath<State, [Element]>,
+        set: @escaping @Sendable ([Element]) -> Action,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Binding<[Element]> {
+        binding(keyPath, set: set, file: file, function: function, line: line)
+    }
+
+    /// A `Binding<Value>` for `TabView(selection:)` / `TabView(.page)` / carousels — the **selection**
+    /// shape (exactly one of N, all children alive).
+    ///
+    /// Unlike ``presence(_:dismiss:)`` / ``item(_:dismiss:)`` (which only dispatch on *dismiss*),
+    /// selection dispatches on **every** change — picking a tab is a real state transition the
+    /// reducer honors (and may veto/redirect).
+    ///
+    /// ```swift
+    /// TabView(selection: store.selection(\.tab, set: AppAction.selectTab)) { … }
+    /// ```
+    @MainActor
+    public func selection<Value>(
+        _ keyPath: KeyPath<State, Value>,
+        set: @escaping @Sendable (Value) -> Action,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Binding<Value> {
+        binding(keyPath, set: set, file: file, function: function, line: line)
+    }
+
+    /// A `Binding<Value?>` for `NavigationSplitView`-style **optional** selection (nothing selected
+    /// yet, or a cleared sidebar). Dispatches on every change, including selecting `nil`.
+    @MainActor
+    public func selection<Value>(
+        _ keyPath: KeyPath<State, Value?>,
+        set: @escaping @Sendable (Value?) -> Action,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Binding<Value?> {
+        binding(keyPath, set: set, file: file, function: function, line: line)
+    }
 }
 #endif

--- a/Tests/SwiftRexArchitectureTests/StoreBindingsTests.swift
+++ b/Tests/SwiftRexArchitectureTests/StoreBindingsTests.swift
@@ -29,11 +29,11 @@ struct StoreBindingsTests {
             initial: S(),
             behavior: Reducer.reduce { (action: A, state: inout S) in
                 switch action {
-                case .setName(let n):       state.name = n
+                case .setName(let n): state.name = n
                 case .presentEditor(let v): state.editor = v
-                case .dismissEditor:        state.editor = nil
-                case .select(let item):     state.selected = item
-                case .deselect:             state.selected = nil
+                case .dismissEditor: state.editor = nil
+                case .select(let item): state.selected = item
+                case .deselect: state.selected = nil
                 }
             }.asBehavior(),
             environment: ()
@@ -93,6 +93,78 @@ struct StoreBindingsTests {
         item.wrappedValue = nil // SwiftUI clearing the sheet
         await Task.yield()
         #expect(store.state.selected == nil)
+    }
+}
+
+// MARK: - Stack (path) + selection bindings
+
+@Suite("StoreType navigation bindings — path & selection")
+@MainActor
+struct StoreNavBindingsTests {
+    private enum Route: Hashable, Sendable { case a, b, c }
+    private enum Tab: Hashable, Sendable { case home, search, profile }
+
+    private struct S: Sendable, Equatable {
+        var path: [Route] = []
+        var tab: Tab = .home
+        var sidebar: Route?
+    }
+    private enum A: Sendable, Equatable {
+        case setPath([Route])
+        case selectTab(Tab)
+        case selectSidebar(Route?)
+    }
+
+    private func makeStore() -> Store<A, S, Void> {
+        Store(
+            initial: S(),
+            behavior: Reducer.reduce { (action: A, state: inout S) in
+                switch action {
+                case .setPath(let p): state.path = p
+                case .selectTab(let t): state.tab = t
+                case .selectSidebar(let r): state.sidebar = r
+                }
+            }.asBehavior(),
+            environment: ()
+        )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func pathReadsAndDispatchesWholeNewPath() async {
+        let store = makeStore()
+        store.dispatch(.setPath([.a]))
+        await Task.yield()
+        let path = store.path(\.path, set: A.setPath)
+        #expect(path.wrappedValue == [.a])
+        path.wrappedValue = [.a, .b] // SwiftUI push
+        await Task.yield()
+        #expect(store.state.path == [.a, .b])
+        path.wrappedValue = [.a] // SwiftUI pop / back-swipe
+        await Task.yield()
+        #expect(store.state.path == [.a])
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func selectionDispatchesOnEveryChange() async {
+        let store = makeStore()
+        let tab = store.selection(\.tab, set: A.selectTab)
+        #expect(tab.wrappedValue == .home)
+        tab.wrappedValue = .search // selecting a tab is a real state change (not dismiss-only)
+        await Task.yield()
+        #expect(store.state.tab == .search)
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func optionalSelectionHandlesNilAndValue() async {
+        let store = makeStore()
+        let sidebar = store.selection(\.sidebar, set: A.selectSidebar)
+        #expect(sidebar.wrappedValue == nil)
+        sidebar.wrappedValue = .c
+        await Task.yield()
+        #expect(store.state.sidebar == .c)
+        sidebar.wrappedValue = nil // clearing the sidebar selection
+        await Task.yield()
+        #expect(store.state.sidebar == nil)
     }
 }
 #endif


### PR DESCRIPTION
## What
Adds `path(_:set:)` and `selection(_:set:)` store-backed SwiftUI bindings, completing the four state-shape → binding set. Stacked on #184.

## Why
`item`/`presence` (optional shape) shipped earlier. The stack shape needs a `Binding<[Route]>` for `NavigationStack(path:)`, and the selection shape (1-of-N, all children alive) needs a `Binding<Value>` for `TabView(selection:)`/split view. Naming them makes the state-shape mapping discoverable.

## Changes
- `path(_:set:) -> Binding<[Element]>` — SwiftUI hands the whole new path each change, so one `setPath` action carries push/pop/pop-to-root uniformly.
- `selection(_:set:) -> Binding<Value>` (TabView) + `Binding<Value?>` overload (NavigationSplitView). Dispatches on **every** change (selecting is a real transition, not dismiss-only).
- Thin, documented specializations of the existing `binding(_:set:)` — no new dialect.
- Tests: push/pop round-trip, tab + optional selection.

**Decision:** kept these as thin wrappers over `binding` rather than bespoke bindings — they add semantic naming + docs without duplicating logic. Green: 507 tests + swiftlint `--strict`.

## Stack
#184 S1 → **S2 (this)** → S3 nav-reducer → S4 router → S5 multi-scene → S6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)