### PR TITLE
Nav S3: navigation reducers (stack/modal/selection + veto)

### DIFF
--- a/Sources/SwiftRexArchitecture/NavigationReducer.swift
+++ b/Sources/SwiftRexArchitecture/NavigationReducer.swift
@@ -1,0 +1,98 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+import SwiftRex
+
+// MARK: - Navigation action vocabulary
+
+/// The standard operations on a **stack** (`[Route]`) navigation slice. Embed one case of this in
+/// your feature's `Action` (e.g. `case nav(StackNavigation<AppRoute>)`) and reduce it with
+/// ``Behavior/navigationStack(_:action:allow:)``.
+public enum StackNavigation<Route: Hashable & Sendable>: Sendable {
+    case push(Route)
+    case pop
+    case popToRoot
+    /// Replace the whole path — what `NavigationStack(path:)`'s binding delivers on any change
+    /// (push, back-swipe, pop-to-root), so a single case covers interactive navigation.
+    case setPath([Route])
+}
+
+/// The standard operations on a **modal / optional** (`Item?`) navigation slice — present sets the
+/// slice to `.some`, dismiss clears it. Reduce with ``Behavior/navigationItem(_:action:allow:)``.
+public enum ModalNavigation<Item: Sendable>: Sendable {
+    case present(Item)
+    case dismiss
+}
+
+/// The operation on a **selection** (1-of-N) navigation slice. Reduce with
+/// ``Behavior/navigationSelection(_:action:allow:)``.
+public enum SelectionNavigation<Selection: Sendable>: Sendable {
+    case select(Selection)
+}
+
+// MARK: - Navigation reducers
+
+extension Behavior {
+    /// A behavior that reduces ``StackNavigation`` operations into a `[Route]` slice of state.
+    ///
+    /// Add it to your app's behavior list (`Behavior.combine([…, navigationStack(…)])`). The default
+    /// is to **apply** every operation; pass `allow` to veto or gate one (return `false` to block —
+    /// e.g. refuse to pop while a form is dirty). Navigation stays a function of state: a blocked
+    /// operation simply leaves the path unchanged, and the `NavigationStack` binding re-presents it.
+    ///
+    /// ```swift
+    /// Behavior.navigationStack(\.path, action: \.nav)                         // always apply
+    /// Behavior.navigationStack(\.path, action: \.nav) { op, s in !s.isDirty } // veto pop while dirty
+    /// ```
+    public static func navigationStack<Route: Hashable & Sendable>(
+        _ path: WritableKeyPath<State, [Route]>,
+        action navigation: PrismKeyPath<Action, StackNavigation<Route>>,
+        allow: (@Sendable (StackNavigation<Route>, State) -> Bool)? = nil
+    ) -> Behavior where Action: Prismatic {
+        let preview = Prism(navigation).preview
+        return .reduce { action, state in
+            guard let op = preview(action), allow?(op, state) != false else { return }
+            switch op {
+            case .push(let route):  state[keyPath: path].append(route)
+            case .pop:              if !state[keyPath: path].isEmpty { state[keyPath: path].removeLast() }
+            case .popToRoot:        state[keyPath: path].removeAll()
+            case .setPath(let new): state[keyPath: path] = new
+            }
+        }
+    }
+
+    /// A behavior that reduces ``ModalNavigation`` into an optional (`Item?`) slice — present sets
+    /// `.some`, dismiss clears. `allow` gates an operation (return `false` to block, e.g. refuse to
+    /// dismiss with unsaved edits). For sheets/covers/popovers driven by ``StoreType/item(_:dismiss:)``.
+    public static func navigationItem<Item: Sendable>(
+        _ item: WritableKeyPath<State, Item?>,
+        action navigation: PrismKeyPath<Action, ModalNavigation<Item>>,
+        allow: (@Sendable (ModalNavigation<Item>, State) -> Bool)? = nil
+    ) -> Behavior where Action: Prismatic {
+        let preview = Prism(navigation).preview
+        return .reduce { action, state in
+            guard let op = preview(action), allow?(op, state) != false else { return }
+            switch op {
+            case .present(let value): state[keyPath: item] = value
+            case .dismiss:            state[keyPath: item] = nil
+            }
+        }
+    }
+
+    /// A behavior that reduces ``SelectionNavigation`` into a selection slice — for
+    /// `TabView(selection:)` / split view. `allow` gates a change (return `false` to block, e.g.
+    /// refuse to leave a tab mid-task). Unlike modal dismiss, selecting is a normal state change.
+    public static func navigationSelection<Selection: Sendable>(
+        _ selection: WritableKeyPath<State, Selection>,
+        action navigation: PrismKeyPath<Action, SelectionNavigation<Selection>>,
+        allow: (@Sendable (SelectionNavigation<Selection>, State) -> Bool)? = nil
+    ) -> Behavior where Action: Prismatic {
+        let preview = Prism(navigation).preview
+        return .reduce { action, state in
+            guard let op = preview(action), allow?(op, state) != false else { return }
+            switch op {
+            case .select(let value): state[keyPath: selection] = value
+            }
+        }
+    }
+}
+#endif

--- a/Tests/SwiftRexArchitectureTests/NavigationReducerTests.swift
+++ b/Tests/SwiftRexArchitectureTests/NavigationReducerTests.swift
@@ -1,0 +1,116 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+@testable import SwiftRex
+@testable import SwiftRexArchitecture
+import Testing
+
+private enum NavRoute: Hashable, Sendable { case a, b, c }
+private struct NavItem: Sendable, Equatable { var id: Int }
+private enum NavTab: Hashable, Sendable { case home, search }
+
+// @Prisms requires >= fileprivate.
+// swiftlint:disable private_over_fileprivate
+@Prisms
+fileprivate enum NavAction: Sendable {
+    case stack(StackNavigation<NavRoute>)
+    case modal(ModalNavigation<NavItem>)
+    case select(SelectionNavigation<NavTab>)
+}
+// swiftlint:enable private_over_fileprivate
+
+private struct NavState: Sendable, Equatable {
+    var path: [NavRoute] = []
+    var sheet: NavItem?
+    var tab: NavTab = .home
+    var locked = false
+}
+
+@Suite("Navigation reducer")
+@MainActor
+struct NavigationReducerTests {
+    private func makeStore(_ behavior: Behavior<NavAction, NavState, Void>, _ initial: NavState = .init()) -> Store<NavAction, NavState, Void> {
+        Store(initial: initial, behavior: behavior, environment: ())
+    }
+
+    // MARK: Stack
+
+    @Test func stackPushPopSetPath() {
+        let store = makeStore(.navigationStack(\.path, action: \.stack))
+        store.dispatch(.stack(.push(.a)))
+        store.dispatch(.stack(.push(.b)))
+        #expect(store.state.path == [.a, .b])
+        store.dispatch(.stack(.pop))
+        #expect(store.state.path == [.a])
+        store.dispatch(.stack(.setPath([.a, .b, .c])))
+        #expect(store.state.path == [.a, .b, .c])
+        store.dispatch(.stack(.popToRoot))
+        #expect(store.state.path == [])
+    }
+
+    @Test func stackVetoBlocks() {
+        // block pop while locked
+        let store = makeStore(
+            .navigationStack(\.path, action: \.stack) { op, state in
+                if case .pop = op, state.locked { return false }
+                return true
+            },
+            NavState(path: [.a, .b], locked: true)
+        )
+        store.dispatch(.stack(.pop))
+        #expect(store.state.path == [.a, .b])   // vetoed
+    }
+
+    // MARK: Modal
+
+    @Test func modalPresentDismiss() {
+        let store = makeStore(.navigationItem(\.sheet, action: \.modal))
+        store.dispatch(.modal(.present(.init(id: 7))))
+        #expect(store.state.sheet == NavItem(id: 7))
+        store.dispatch(.modal(.dismiss))
+        #expect(store.state.sheet == nil)
+    }
+
+    @Test func modalVetoBlocksDismiss() {
+        let store = makeStore(
+            .navigationItem(\.sheet, action: \.modal) { op, _ in
+                if case .dismiss = op { return false }
+                return true
+            },
+            NavState(sheet: NavItem(id: 1))
+        )
+        store.dispatch(.modal(.dismiss))
+        #expect(store.state.sheet == NavItem(id: 1))   // vetoed
+    }
+
+    // MARK: Selection
+
+    @Test func selectionSelects() {
+        let store = makeStore(.navigationSelection(\.tab, action: \.select))
+        store.dispatch(.select(.select(.search)))
+        #expect(store.state.tab == .search)
+    }
+
+    @Test func selectionVetoBlocks() {
+        let store = makeStore(
+            .navigationSelection(\.tab, action: \.select) { _, state in !state.locked },
+            NavState(locked: true)
+        )
+        store.dispatch(.select(.select(.search)))
+        #expect(store.state.tab == .home)   // vetoed
+    }
+
+    // MARK: Composition — nav reducers fold with feature behaviors
+
+    @Test func foldsWithOtherBehaviors() {
+        let app = Behavior<NavAction, NavState, Void>.combine([
+            .navigationStack(\.path, action: \.stack),
+            .navigationItem(\.sheet, action: \.modal)
+        ])
+        let store = makeStore(app)
+        store.dispatch(.stack(.push(.a)))
+        store.dispatch(.modal(.present(.init(id: 2))))
+        #expect(store.state.path == [.a])
+        #expect(store.state.sheet == NavItem(id: 2))
+    }
+}
+#endif


### PR DESCRIPTION
## What
Framework `Behavior` factories that reduce the standard navigation ops into a state slice — the **WHEN** side of navigation. Stacked on #185.

## Changes
- `StackNavigation<Route>` (push/pop/popToRoot/setPath) → `Behavior.navigationStack(\.path, action:)`
- `ModalNavigation<Item>` (present/dismiss) → `Behavior.navigationItem(\.sheet, action:)`
- `SelectionNavigation<Sel>` (select) → `Behavior.navigationSelection(\.tab, action:)`
- Each accepts an optional `allow` predicate (default applies everything); return `false` to veto/gate — navigation stays a function of state, so a vetoed op leaves state unchanged and the SwiftUI binding re-presents.
- Pure `Behavior`; folds into the app behavior list via `combine([...])`.

**Decisions:**
- **Veto = a Bool `allow` predicate** (`false` blocks), not a richer reshape enum — simplest that covers the stated cases; reshape can be added later without a breaking change.
- **Explicit factories, not `@Feature` auto-merge.** The design's "`@Feature` auto-merges the nav reducer" is a macro change — **deferred**; explicit is testable and macro-free. You add `navigationStack(...)` to your `combine([...])` list.

Green: 514 tests + swiftlint `--strict`. Tests cover all three shapes, veto blocking, and folding with other behaviors.

## Stack
#184 S1 → #185 S2 → **S3 (this)** → S4 router → S5 multi-scene → S6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)