### PR TITLE
Nav S4: router mechanism — resolves the env-into-child-view crux

### DIFF
--- a/Sources/SwiftRex/Store/StoreType+ScopedProjection.swift
+++ b/Sources/SwiftRex/Store/StoreType+ScopedProjection.swift
@@ -1,0 +1,27 @@
+import CoreFP
+
+extension StoreType where Action: Prismatic {
+    /// Projects this store to a child feature using a **prism key path** for the action and a
+    /// read key path for the state — the ergonomic form for a router that resolves a route to a
+    /// child view.
+    ///
+    /// The prism's `review` embeds the child action back into this store's action; the key path
+    /// reads the child's state slice. Equivalent to the closure-based
+    /// ``projection(action:state:)`` with `action: prism.review` and `state: { $0[keyPath:] }`.
+    ///
+    /// ```swift
+    /// // in a router's @ViewBuilder switch:
+    /// Detail.view(
+    ///     store: store.projection(action: \.detail, state: \.detail),
+    ///     environment: world.detailEnvironment
+    /// )
+    /// ```
+    @MainActor
+    public func projection<LocalAction: Sendable, LocalState: Sendable>(
+        action prism: PrismKeyPath<Action, LocalAction>,
+        state keyPath: KeyPath<State, LocalState>
+    ) -> StoreProjection<LocalAction, LocalState> {
+        let review = Prism(prism).review
+        return projection(action: review, state: { $0[keyPath: keyPath] })
+    }
+}

--- a/Sources/SwiftRexSwiftUI/Routable.swift
+++ b/Sources/SwiftRexSwiftUI/Routable.swift
@@ -1,0 +1,40 @@
+#if canImport(SwiftUI)
+/// A view that navigates — it holds a **router** it was handed at construction and asks it to build
+/// destination views on demand.
+///
+/// This is the opt-in seam for navigation. A view that presents/pushes other features conforms to
+/// `Routable`, stores its router as a `let`, and calls it from destination closures:
+///
+/// ```swift
+/// struct HomeView: View, Routable {
+///     let viewStore: ViewStore<Home.State, Home.Action>
+///     let router: AppRouter                        // handed in at construction, traps store + world
+///
+///     var body: some View {
+///         List { … }
+///             .sheet(isPresented: viewStore.presence(\.route, dismiss: .dismiss)) {
+///                 router.view(for: .detail)        // env-free body; the router supplies env
+///             }
+///     }
+/// }
+/// ```
+///
+/// ## Why hold the router, not read it ambiently
+///
+/// A router injected at construction is deterministic across sheet/modal boundaries — the exact
+/// place SwiftUI's `@Environment` propagation is unreliable. Because the router builds every view,
+/// it re-hands itself at each construction, so nested flows (a sheet that itself navigates) always
+/// have their router. See ``Router`` for the destination-building side.
+///
+/// A view conforms manually today; a future `routing:` argument on the feature macros can synthesize
+/// the `router` property and this conformance.
+public protocol Routable {
+    /// The router type this view navigates through — a concrete app router, or a narrow per-feature
+    /// routing protocol it conforms to (so the view sees only the destinations it needs).
+    associatedtype Routing
+
+    /// The router, trapped at construction. Building a destination (`router.view(for:)`) supplies
+    /// the child's store projection and environment — the view body never touches `Environment`.
+    var router: Routing { get }
+}
+#endif

--- a/Tests/SwiftRexArchitectureTests/RouterCruxTests.swift
+++ b/Tests/SwiftRexArchitectureTests/RouterCruxTests.swift
@@ -1,0 +1,122 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+@testable import SwiftRex
+@testable import SwiftRexArchitecture
+import SwiftUI
+import Testing
+
+// Proves the navigation crux is resolved: a parent view whose body is ENVIRONMENT-FREE presents a
+// child built WITH its environment — supplied by the router, never by the view body. Also proves
+// cross-feature decoupling (the parent never names the child) and no AnyView (@ViewBuilder switch).
+
+// A leaf "module" with a NON-Void environment — so building its view demonstrably needs env.
+@Feature(type: .internalOnly, strategy: .observationSimple)
+enum RDetail {
+    struct State: Sendable, Equatable { var text = "detail" }
+    enum Action: Sendable, Equatable { case tap }
+    struct Environment: Sendable { var greet: @Sendable () -> String }
+    static func behavior() -> Behavior<Action, State, Environment> {
+        .reduce { action, state in
+            switch action {
+            case .tap: state.text = "tapped"
+            }
+        }
+    }
+    typealias Content = RDetailView
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@BoundTo(RDetail.self, strategy: .observationSimple)
+struct RDetailView: View {
+    var body: some View { Text(viewStore.state.text) }
+}
+
+// @Prisms requires >= fileprivate.
+// swiftlint:disable private_over_fileprivate
+@Prisms
+fileprivate enum RAppAction: Sendable {
+    case detail(RDetail.Action)
+    case dismiss
+}
+
+@Lenses
+fileprivate struct RAppState: Sendable {
+    var detail = RDetail.State() // sibling slice; the route is just a trigger token
+    var route: RAppRoute?
+}
+
+fileprivate enum RAppRoute: Hashable, Sendable { case detail }
+
+fileprivate struct RWorld: Sendable { var greet: @Sendable () -> String = { "hi" } }
+
+// The router: one concrete type that knows the whole tree. Its @ViewBuilder switch resolves a route
+// to a child view, supplying that child's env — the crux — and keeping `some View` (no AnyView).
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@MainActor
+fileprivate struct RAppRouter {
+    let store: Store<RAppAction, RAppState, RWorld>
+    let world: RWorld
+
+    @ViewBuilder
+    func view(for route: RAppRoute) -> some View {
+        switch route {
+        case .detail:
+            RDetail.view(
+                store: store.projection(action: \.detail, state: \.detail), // prism + key-path sugar
+                environment: RDetail.Environment(greet: world.greet) // env supplied HERE
+            )
+        }
+    }
+}
+
+// The parent view: it holds only a `viewStore` and a `router` — NO environment. It presents the
+// detail through the router and never names `RDetail`. Cross-feature decoupling + crux resolution.
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+fileprivate struct RHomeView: View, Routable {
+    let viewStore: ViewStore<RAppState, RAppAction>
+    let router: RAppRouter
+
+    var body: some View {
+        Text("home")
+            .sheet(isPresented: viewStore.presence(\.route, dismiss: .dismiss)) {
+                router.view(for: .detail) // env-free body; the router supplied env — crux resolved
+            }
+    }
+}
+// swiftlint:enable private_over_fileprivate
+
+@Suite("Router — crux resolution")
+@MainActor
+struct RouterCruxTests {
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    private func makeStore() -> Store<RAppAction, RAppState, RWorld> {
+        Store(
+            initial: RAppState(),
+            behavior: RDetail.behavior().lift(
+                action: \.detail,
+                state: \RAppState.detail,
+                environment: { (world: RWorld) in RDetail.Environment(greet: world.greet) }
+            ),
+            environment: RWorld()
+        )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func envFreeParentPresentsChildBuiltWithEnv() {
+        // Compiles ⇒ the router resolves a route to a child view WITH env, from an env-free parent.
+        let store = makeStore()
+        let router = RAppRouter(store: store, world: RWorld())
+        let home = RHomeView(viewStore: ViewStore(store), router: router)
+        _ = home.router.view(for: .detail)
+        _ = home.body
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func routedChildSharesTheOneStore() {
+        // The child dispatches into the same single store; its behavior (lifted) runs.
+        let store = makeStore()
+        store.dispatch(.detail(.tap))
+        #expect(store.state.detail.text == "tapped")
+    }
+}
+#endif


### PR DESCRIPTION
## What
The **WHAT** side of navigation — a router that resolves a route to a child view, **supplying the child's environment** that the env-free view body cannot. Proven end-to-end, **no macro changes, no AnyView**. Stacked on #186.

## The crux
The façade redesign made `Feature.view(store:environment:)` need env, but a navigation destination runs inside the *env-free* view body. Resolution: a router (which holds `store` + `world`) builds the child via a `@ViewBuilder` switch, supplying env there.

## Changes
- `StoreType.projection(action: PrismKeyPath, state: KeyPath)` — ergonomic child-store projection for router switches (core; sugar over the closure form).
- `Routable` protocol (SwiftRexSwiftUI) — the opt-in seam: a navigating view holds its router as a `let`, handed in at construction (deterministic across modal boundaries, unlike `@Environment`).
- `RouterCruxTests` — a **compile-proven harness**: a concrete `AppRouter` with `@ViewBuilder view(for:)` builds a child WITH env; an env-free parent view presents it via `router.view(for:)`; the parent never names the child; `some View` throughout.

## Decisions (for review)
- **No macro changes.** The `@Feature(...routing:)` / `@BoundTo(...routing:)` sugar to synthesize `let router` is **deferred** — the mechanism works with a hand-written `let router` today (as PookiePayslip/Caixinhas do), de-risking the Swift-version-sensitive macro work.
- **Parent ⊥ child** decoupling delivered (parent never names the child; the router does). Full **parent ⊥ router** decoupling via a per-feature `Routable<XRouting>` protocol needs a generic view param or a nameable erased `Destination` (the erasure fork the design left open) — documented, not forced.

Green: 516 tests + swiftlint `--strict`.

## Stack
#184 S1 → #185 S2 → #186 S3 → **S4 (this)** → S5 multi-scene → S6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)