### PR TITLE
Nav S5: multi-scene from a single store

### DIFF
--- a/Sources/SwiftRexArchitecture/MultiScene.swift
+++ b/Sources/SwiftRexArchitecture/MultiScene.swift
@@ -1,0 +1,40 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import SwiftRex
+import SwiftUI
+
+// MARK: - Multi-scene from a single store
+//
+// Multiple windows/scenes are still ONE store. Model open scenes as state (a dictionary or
+// identifiable collection of per-scene sub-states); each window projects its own slice by id with
+// the existing element/dictionary projection; open/close are ordinary actions. No new machinery.
+//
+//     @main struct MyApp: App {
+//         let store = Store(initial: AppState(), behavior: appBehavior, environment: world)
+//         var body: some Scene {
+//             WindowGroup { RootView(store: store, world: world) }          // main window
+//             WindowGroup(for: DocID.self) { $id in                          // document windows
+//                 if let id { DocumentScene(store: store, world: world, id: id) }
+//             }
+//         }
+//     }
+//
+// `DocumentScene` projects `store.projection(key: id, actionReview:, stateDictionary:)` for that
+// window's slice and builds its feature view — the same router/scope wiring as in-window navigation,
+// one level up. `openWindow(value:)` / `dismissWindow` are driven by dispatching actions that add or
+// remove a scene's sub-state; the window set is a function of state.
+
+/// A convenience that reads whether a scene id currently has state — for a window body to decide
+/// between rendering its content and dismissing itself (e.g. `if store.hasScene(id, in: \.documents)`).
+@available(iOS 16.1, macOS 13, tvOS 16.1, watchOS 9.1, *)
+extension StoreType {
+    /// `true` while a scene with `id` exists in the keyed sub-state collection — i.e. the window
+    /// should still render. Pair with `dismissWindow` when it becomes `false`.
+    @MainActor
+    public func hasScene<Key: Hashable & Sendable, Value>(
+        _ id: Key,
+        in dictionary: KeyPath<State, [Key: Value]>
+    ) -> Bool {
+        state[keyPath: dictionary][id] != nil
+    }
+}
+#endif

--- a/Tests/SwiftRexArchitectureTests/MultiSceneTests.swift
+++ b/Tests/SwiftRexArchitectureTests/MultiSceneTests.swift
@@ -1,0 +1,94 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+@testable import SwiftRex
+@testable import SwiftRexArchitecture
+import SwiftUI
+import Testing
+
+// Proves multi-scene is single-store: open scenes are STATE (a dictionary of per-scene sub-states),
+// each window projects its slice by id, and a `some Scene` body wires WindowGroup(for:) to the one
+// store. No new projection machinery — the existing dictionary projection carries the per-scene slice.
+
+private struct DocState: Sendable, Equatable { var title: String; var edits = 0 }
+private enum DocAction: Sendable, Equatable { case bumpEdits }
+
+// @Prisms requires >= fileprivate.
+// swiftlint:disable private_over_fileprivate
+@Prisms
+fileprivate enum SceneAppAction: Sendable {
+    case open(Int, String)
+    case close(Int)
+    case document(ElementAction<Int, DocAction>)
+}
+
+@Lenses
+fileprivate struct SceneAppState: Sendable {
+    var documents: [Int: DocState] = [:]   // open windows, keyed by id
+}
+// swiftlint:enable private_over_fileprivate
+
+@Suite("Multi-scene single store")
+@MainActor
+struct MultiSceneTests {
+    private func makeStore() -> Store<SceneAppAction, SceneAppState, Void> {
+        Store(
+            initial: SceneAppState(),
+            behavior: Reducer.reduce { (action: SceneAppAction, state: inout SceneAppState) in
+                switch action {
+                case let .open(id, title): state.documents[id] = DocState(title: title)
+                case .close(let id):           state.documents[id] = nil
+                case .document(let elem):
+                    switch elem.action {
+                    case .bumpEdits: state.documents[elem.id]?.edits += 1
+                    }
+                }
+            }.asBehavior(),
+            environment: ()
+        )
+    }
+
+    @Test func openAndCloseScenesAreStateInTheOneStore() {
+        let store = makeStore()
+        store.dispatch(.open(1, "A"))
+        store.dispatch(.open(2, "B"))
+        #expect(store.state.documents.count == 2)
+        store.dispatch(.close(1))
+        #expect(store.state.documents[1] == nil)
+        #expect(store.state.documents[2]?.title == "B")
+    }
+
+    @available(iOS 16.1, macOS 13, tvOS 16.1, watchOS 9.1, *)
+    @Test func hasSceneReflectsOpenWindows() {
+        let store = makeStore()
+        store.dispatch(.open(7, "Doc"))
+        #expect(store.hasScene(7, in: \.documents))
+        #expect(!store.hasScene(9, in: \.documents))
+    }
+
+    @Test func perSceneProjectionCarriesTheSlice() {
+        let store = makeStore()
+        store.dispatch(.open(3, "C"))
+        // Each window projects its own slice by id — the existing dictionary projection.
+        let window = store.projection(
+            key: 3,
+            actionReview: SceneAppAction.document,
+            stateDictionary: \.documents
+        )
+        #expect(window.state?.title == "C")
+        window.dispatch(.bumpEdits)             // dispatches into the ONE store, scoped to id 3
+        #expect(store.state.documents[3]?.edits == 1)
+    }
+}
+
+// Compile-proof: a `some Scene` body wires WindowGroup(for:) to the single store, projecting each
+// window's slice by id. Not runtime-tested (Scenes are app-level), but compiling proves the pattern.
+@available(iOS 16.1, macOS 13, tvOS 16.1, watchOS 9.1, *)
+@MainActor
+private func multiSceneBody(store: Store<SceneAppAction, SceneAppState, Void>) -> some Scene {
+    WindowGroup(for: Int.self) { $id in
+        if let id, let doc = store.state.documents[id] {
+            Text(doc.title)                     // real apps build the scene's feature view here
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## What
Multiple windows/scenes from **one** store (no multi-store). Stacked on #187.

## Why
The design (and the user's correction to my earlier "multi-store" assumption) is that scenes are single-store: open scenes are *state*, each window projects its own slice, open/close are actions.

## Changes
- `MultiScene.swift` — documents the pattern + `StoreType.hasScene(_:in:)` (whether a scene id still has state, so a window body renders vs dismisses).
- Tests: open/close scenes as store state; the existing `projection(key:actionReview:stateDictionary:)` carries a per-scene slice and dispatches (ElementAction-scoped) back into the one store; a compile-proof `some Scene` wiring `WindowGroup(for:)` to the single store.

**Decision:** **no new projection machinery** — multi-scene reuses the shipped dictionary/element projection. This PR is the pattern + a small `hasScene` helper + proofs, not a new subsystem.

Green: 519 tests + swiftlint `--strict`.

## Stack
#184 → #185 → #186 → #187 → **S5 (this)** → S6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)