### PR TITLE
Nav S7: single Feature protocol + Scope drives both behavior & view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1737,6 +1737,19 @@ Library.view(
 
 On a `.moduleEntryPoint`, only `State`/`Action`/`Environment`/`Input` and the opaque `view()` cross the module boundary; the whole view layer stays `internal`.
 
+## Navigation
+
+Navigation is a **function of state** — one store, routes in state, native SwiftUI containers driven by store-backed bindings that *dispatch* on change. Every container maps to one of four shapes:
+
+| Shape | State | Binding | Reducer | Containers |
+|---|---|---|---|---|
+| **Optional / modal** | `Item?` / `Bool` | `item(_:dismiss:)` / `presence(_:dismiss:)` | `navigationItem` | sheet, cover, popover, bottom sheet (detents), alert, confirmationDialog, inspector, `navigationDestination(isPresented:)` |
+| **Stack** | `[Route]` | `path(_:set:)` | `navigationStack` | `NavigationStack(path:)` |
+| **Selection** (1-of-N, all alive) | `Sel` | `selection(_:set:)` | `navigationSelection` | `TabView`, `.page`/carousel, `NavigationSplitView` |
+| **Scene set** | keyed sub-states | `hasScene(_:in:)` + projection | open/close actions | `WindowGroup(for:)`, multi-window (one store) |
+
+A **`Scope`** declares a child feature's wiring once and drives **both** its `behavior` and its `view` (`Scope(Detail.self, action: \.detail, state: \.detail, environment: \.detailEnv)`). A hand-written **router** (`@ViewBuilder view(for:)`, no `AnyView`) resolves a route to the child view, supplying the environment the env-free view body can't — the navigation crux. Effect lifecycle is state-driven: a supervisor reacting to route state cancels a screen's effects when it leaves. Full walkthrough: the **State-Driven Navigation** DocC article.
+
 # Testing
 
 The **`SwiftRex.Testing`** product ships `TestStore` — a deterministic, exhaustive harness for a feature's `behavior()`. Add it to your **test** target only, so production targets that depend on `SwiftRex` never link it:

--- a/Sources/SwiftRex/Behavior/Behavior+Combine.swift
+++ b/Sources/SwiftRex/Behavior/Behavior+Combine.swift
@@ -1,0 +1,25 @@
+extension Behavior {
+    /// Folds an array of behaviors into one, in order, using the ``Behavior`` monoid
+    /// (``identity`` as the empty element, ``combine(_:_:)`` as the binary operation).
+    ///
+    /// This is the variadic-collection companion to ``combine(_:_:)`` — handy when composing a
+    /// whole app's behaviors from a list (e.g. one lifted child behavior per feature, plus a
+    /// navigation reducer and cross-cutting behaviors like logging):
+    ///
+    /// ```swift
+    /// let appBehavior = Behavior.combine([
+    ///     homeScope.lifted,
+    ///     detailScope.lifted,
+    ///     navigationReducer,
+    ///     loggingBehavior,
+    /// ])
+    /// ```
+    ///
+    /// An empty array yields ``identity`` (the no-op behavior).
+    ///
+    /// - Parameter behaviors: The behaviors to fold, applied left-to-right.
+    /// - Returns: A single behavior equivalent to `behaviors[0] <> behaviors[1] <> …`.
+    public static func combine(_ behaviors: [Behavior]) -> Behavior {
+        behaviors.reduce(.identity, Behavior.combine)
+    }
+}

--- a/Sources/SwiftRex/Store/StoreType+ScopedProjection.swift
+++ b/Sources/SwiftRex/Store/StoreType+ScopedProjection.swift
@@ -1,0 +1,27 @@
+import CoreFP
+
+extension StoreType where Action: Prismatic {
+    /// Projects this store to a child feature using a **prism key path** for the action and a
+    /// read key path for the state — the ergonomic form for a router that resolves a route to a
+    /// child view.
+    ///
+    /// The prism's `review` embeds the child action back into this store's action; the key path
+    /// reads the child's state slice. Equivalent to the closure-based
+    /// ``projection(action:state:)`` with `action: prism.review` and `state: { $0[keyPath:] }`.
+    ///
+    /// ```swift
+    /// // in a router's @ViewBuilder switch:
+    /// Detail.view(
+    ///     store: store.projection(action: \.detail, state: \.detail),
+    ///     environment: world.detailEnvironment
+    /// )
+    /// ```
+    @MainActor
+    public func projection<LocalAction: Sendable, LocalState: Sendable>(
+        action prism: PrismKeyPath<Action, LocalAction>,
+        state keyPath: KeyPath<State, LocalState>
+    ) -> StoreProjection<LocalAction, LocalState> {
+        let review = Prism(prism).review
+        return projection(action: review, state: { $0[keyPath: keyPath] })
+    }
+}

--- a/Sources/SwiftRex/SwiftRex.docc/Navigation.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Navigation.md
@@ -4,114 +4,174 @@ Model navigation as a function of state: routes live in state, SwiftUI bindings 
 
 ## Overview
 
-Navigation in SwiftRex is **pure SwiftUI Views reacting to state**. There is one store for the whole app; a view holds only a projection. Behavior mutates the navigation *state* (a route, an optional, a path, a selection); it never touches the view or the router. Standard SwiftUI containers (`sheet`, `NavigationStack`, `TabView`, windows) are pluggable renderings of a few state *shapes*.
+Navigation in SwiftRex is **pure SwiftUI Views reacting to state**. There is one store for the whole app; a view holds only a projection. Behavior mutates the navigation *state* (a route, an optional, a path, a selection); it never touches the view or the router. Every SwiftUI navigation container — sheet, cover, popover, alert, dialog, inspector, `NavigationStack`, `NavigationSplitView`, `TabView`, pages, windows — is just a pluggable *rendering* of one of four state **shapes**:
 
-Four shapes cover it:
-
-| Shape | State | Lift | SwiftUI binding | Container |
+| Shape | State | Lift | Binding | Reducer |
 | --- | --- | --- | --- | --- |
-| Optional / modal | `Item?` (or `Bool`) | `liftOptional` | `item(_:dismiss:)` / `presence(_:dismiss:)` | sheet, cover, popover |
-| Stack | `[Route]` | `liftCollection` | `path(_:set:)` | `NavigationStack(path:)` |
-| Selection (1-of-N) | `Sel` | plain `lift` ×N | `selection(_:set:)` | `TabView`, split view |
-| Scene set | keyed sub-states | element projection | `WindowGroup(for:)` | windows |
+| **Optional / modal** — 0-or-1, child created on present | `Item?` (or `Bool`) | `liftOptional` | ``StoreType/item(_:dismiss:)`` / ``StoreType/presence(_:dismiss:)`` | ``Behavior/navigationItem(_:action:allow:)`` |
+| **Stack** — 0-to-N ordered | `[Route]` | `liftCollection` | ``StoreType/path(_:set:)`` | ``Behavior/navigationStack(_:action:allow:)`` |
+| **Selection** — exactly 1-of-N, all alive | `Sel` (enum/id) | plain `lift` ×N | ``StoreType/selection(_:set:)`` | ``Behavior/navigationSelection(_:action:allow:)`` |
+| **Scene set** — 0-to-N windows | keyed sub-states | element/dictionary projection | ``StoreType/hasScene(_:in:)`` + `WindowGroup(for:)` | ordinary open/close actions |
 
-## Scope — declare the wiring once
+The rest is: pick the shape, drive its binding, resolve the destination through a router. No new dialect — the bindings feed *native* SwiftUI modifiers.
 
-A ``Scope`` captures how a child feature embeds into the app store — action prism, state key path, environment narrowing — and derives its `lifted` behavior. Constructing one is a **compile-time proof** the feature is wired; a missing state slot, action case, or env mapping is a compile error at the literal.
+## Every container, by shape
 
-```swift
-let detailScope = Scope(
-    behavior:    Detail.behavior(),
-    action:      \.detail,      // PrismKeyPath<AppAction, Detail.Action>
-    state:       \.detail,      // WritableKeyPath<AppState, Detail.State>
-    environment: \.detailEnv    // KeyPath<World, Detail.Environment>
-)
-```
+### Optional / modal — `Item?` or `Bool`
 
-Register every scope in one place with ``Scopes`` so you can't forget to compose a behavior:
+Presentation and child lifetime are one fact: set the optional and the child exists and shows; clear it and it tears down. Use ``StoreType/item(_:dismiss:)`` when the presented content needs state (an `Identifiable` value), ``StoreType/presence(_:dismiss:)`` when a `Bool` suffices. Both only ever dispatch the *dismiss* action — presentation is driven by state, never by the binding.
 
 ```swift
-let features = Scopes(homeScope, detailScope, settingsScope)
-let appBehavior = Behavior.combine([features.behavior, navigationReducer])
-let store = Store(initial: .init(), behavior: appBehavior, environment: world)
-```
+// Sheet, full-screen cover, popover — item- or isPresented-driven, interchangeably:
+.sheet(item: store.item(\.editing, dismiss: .dismissEditor)) { item in router.view(for: .editor(item.id)) }
+.fullScreenCover(isPresented: store.presence(\.onboarding, dismiss: .finishOnboarding)) { router.view(for: .onboarding) }
+.popover(item: store.item(\.tip, dismiss: .dismissTip)) { tip in TipView(tip) }
 
-## Bindings — the WHEN
+// Bottom sheet — a sheet whose content carries detents:
+.sheet(isPresented: store.presence(\.filters, dismiss: .closeFilters)) {
+    router.view(for: .filters).presentationDetents([.medium, .large])
+}
 
-Store-backed bindings drive native SwiftUI containers; a write dispatches an action, so presentation stays a function of state.
+// Inspector (iOS 17+) — Bool-driven:
+.inspector(isPresented: store.presence(\.inspector, dismiss: .hideInspector)) { router.view(for: .inspector) }
 
-```swift
-.sheet(item: store.item(\.selected, dismiss: .deselect)) { item in … }
-NavigationStack(path: store.path(\.path, set: NavAction.setPath)) { root }
-TabView(selection: store.selection(\.tab, set: AppAction.selectTab)) { … }
-```
+// Single push via NavigationStack, without a path:
+.navigationDestination(isPresented: store.presence(\.detail, dismiss: .popDetail)) { router.view(for: .detail) }
 
-## Navigation reducers — apply, or veto
-
-Fold a navigation reducer into the app behavior to handle the standard operations. Default applies every op; pass `allow` to veto or gate one (return `false` to block) — a vetoed op leaves state unchanged and the binding re-presents.
-
-```swift
-Behavior.navigationStack(\.path, action: \.nav)                         // push/pop/setPath
-Behavior.navigationItem(\.sheet, action: \.modal) { op, s in !s.isDirty } // block dismiss while dirty
-Behavior.navigationSelection(\.tab, action: \.select)
-```
-
-## Router — the WHAT (and the environment crux)
-
-`Feature.view(store:environment:)` needs an environment, but a navigation destination runs inside the *environment-free* view body. A **router** — a value holding the store and the world — resolves that: its `@ViewBuilder view(for:)` switch builds each child, supplying the child's environment there. `some View` throughout — no `AnyView`.
-
-```swift
-@MainActor struct AppRouter {
-    let store: MainStore
-    let world: World
-
-    @ViewBuilder func view(for route: AppRoute) -> some View {
-        switch route {
-        case .detail:
-            Detail.view(
-                store: store.projection(action: \.detail, state: \.detail),
-                environment: world.detailEnv                 // env supplied here
-            )
-        }
-    }
+// Alert / confirmation dialog — present with `presence`/`item`; the BUTTONS dispatch their own actions:
+.alert("Delete?", isPresented: store.presence(\.deleteConfirm, dismiss: .cancelDelete), presenting: store.state.deleteConfirm) { item in
+    Button("Delete", role: .destructive) { store.dispatch(.confirmDelete(item.id)) }
+    Button("Cancel", role: .cancel) { store.dispatch(.cancelDelete) }
+}
+.confirmationDialog("Sort", isPresented: store.presence(\.sortDialog, dismiss: .closeSort)) {
+    Button("Newest") { store.dispatch(.sort(.newest)) }
+    Button("Oldest") { store.dispatch(.sort(.oldest)) }
 }
 ```
 
-A navigating view conforms to ``Routable`` and holds its router as a `let`, handed in at construction. Because the router builds every view, it re-hands itself at each construction — deterministic across the sheet/modal boundaries where SwiftUI's `@Environment` propagation is unreliable. The view's body stays environment-free:
+Behavior side: `liftOptional` (the child runs only while `.some`) or ``Behavior/navigationItem(_:action:allow:)`` for standard present/dismiss with an optional veto.
+
+### Stack — `[Route]`
+
+`NavigationStack(path:)` reflects the whole path; SwiftUI hands the binding the new path on any change, so one `setPath` action covers push, back-swipe, and pop-to-root. Destinations resolve through the router.
 
 ```swift
-struct HomeView: View, Routable {
-    let viewStore: ViewStore<Home.State, Home.Action>
-    let router: AppRouter                                     // trapped at construction
-
-    var body: some View {
-        List { … }
-            .sheet(isPresented: viewStore.presence(\.route, dismiss: .dismiss)) {
-                router.view(for: .detail)                     // router supplies env — crux resolved
-            }
-    }
+NavigationStack(path: store.path(\.path, set: NavAction.setPath)) {
+    RootView(...)
+        .navigationDestination(for: AppRoute.self) { route in router.view(for: route) }
 }
 ```
 
-The view never names `Detail` — the router does. A route may resolve to a completely separate module (its own store slice / dependencies) without the presenting feature importing it.
+Behavior side: `liftCollection` per element, plus ``Behavior/navigationStack(_:action:allow:)`` for `push`/`pop`/`popToRoot`/`setPath` (veto e.g. a pop while a form is dirty).
 
-## Multi-scene is single-store
+### Selection — 1-of-N, all children alive
 
-Multiple windows are still one store. Model open scenes as state (a dictionary of per-scene sub-states); each window projects its slice by id; open/close are ordinary actions.
+Tabs, split view, and paged/carousel views keep every child mounted; only the selection changes. All children are lifted **unconditionally** (siblings in state). Unlike modal dismiss, selecting is a normal state change, so ``StoreType/selection(_:set:)`` dispatches on every change.
+
+```swift
+// Tabs:
+TabView(selection: store.selection(\.tab, set: AppAction.selectTab)) {
+    router.view(for: .home).tag(Tab.home)
+    router.view(for: .search).tag(Tab.search)
+}
+
+// Paged / carousel — same selection, page style:
+TabView(selection: store.selection(\.page, set: AppAction.selectPage)) { … }
+    .tabViewStyle(.page)
+
+// Split view — selection + column visibility (the latter is just a plain `binding`):
+NavigationSplitView(columnVisibility: store.binding(\.columns, set: AppAction.setColumns)) {
+    Sidebar(selection: store.selection(\.selectedItem, set: AppAction.select))   // optional selection
+} detail: {
+    router.view(for: .detail)
+}
+```
+
+> A background/unselected child keeps running by default (that's the point of tabs). To pause one, add a supervisor keyed on the selection — it's your policy, not a framework default.
+
+### Scene set — windows, one store
+
+Multiple windows are still one store. Model open scenes as state (a dictionary of per-scene sub-states); each window projects its slice by id; open/close are ordinary actions; ``StoreType/hasScene(_:in:)`` tells a window body whether to render or dismiss.
 
 ```swift
 var body: some Scene {
     WindowGroup { RootView(store: store, router: router) }
     WindowGroup(for: DocID.self) { $id in
         if let id, store.hasScene(id, in: \.documents) {
-            Document.view(store: store.projection(key: id, actionReview: AppAction.document, stateDictionary: \.documents), environment: world.docEnv)
+            Document.view(
+                store: store.projection(key: id, actionReview: AppAction.document, stateDictionary: \.documents),
+                environment: world.docEnv
+            )
+        }
+    }
+    // `Settings`, `MenuBarExtra`, `Window` follow the same single-store pattern.
+}
+```
+
+`openWindow(value: DocID(…))` / `dismissWindow` are triggered by dispatching actions that add or remove a scene's sub-state — the window set is a function of state.
+
+## Scope — declare the wiring once, drive both sides
+
+A ``Scope`` captures how a child ``Feature`` embeds into the app store — action prism, state key path, environment narrowing — and derives **both** its lifted ``Scope/behavior`` and its ``Scope/view(from:world:)``. Constructing one is a **compile-time proof** the feature is wired; a missing state slot, action case, or env mapping is a compile error at the literal.
+
+```swift
+let detailScope = Scope(Detail.self, action: \.detail, state: \.detail, environment: \.detailEnv)
+detailScope.behavior                          // Behavior<AppAction, AppState, World> — register it
+detailScope.view(from: store, world: world)   // Detail's view, env supplied — call from the router
+```
+
+Register every scope's behavior in one place with ``Scopes`` so you can't forget to compose one:
+
+```swift
+let appBehavior = Scopes(
+    homeScope.behavior,
+    detailScope.behavior,
+    Behavior.navigationStack(\.path, action: \.nav)   // + navigation reducers, logging, …
+).behavior
+let store = Store(initial: .init(), behavior: appBehavior, environment: world)
+```
+
+A child feature conforms with one line — `extension Detail: Feature {}` — where Swift infers the associated types from the members `@Feature` generates.
+
+## Router — the WHAT (and the environment crux)
+
+`Feature.view(store:environment:)` needs an environment, but a navigation destination runs inside the *environment-free* view body. A **router** — a value holding the store and the world — resolves that: its `@ViewBuilder view(for:)` switch builds each child (via ``Scope/view(from:world:)`` or directly), supplying the child's environment there. `some View` throughout — no `AnyView`.
+
+```swift
+@MainActor struct AppRouter {
+    let store: MainStore
+    let world: World
+    let detailScope = Scope(Detail.self, action: \.detail, state: \.detail, environment: \.detailEnv)
+
+    @ViewBuilder func view(for route: AppRoute) -> some View {
+        switch route {
+        case .detail: detailScope.view(from: store, world: world)   // env supplied here — crux resolved
         }
     }
 }
 ```
 
+A navigating view conforms to ``Routable`` and holds its router as a `let`, handed in at construction. Because the router builds every view, it re-hands itself at each construction — deterministic across the sheet/modal boundaries where SwiftUI's `@Environment` propagation is unreliable. The view body stays environment-free, and never names the child — the router does, so a route may resolve to a completely separate module (its own store slice and dependencies) without the presenting feature importing it.
+
+```swift
+struct HomeView: View, Routable {
+    let viewStore: ViewStore<Home.State, Home.Action>
+    let router: AppRouter
+    var body: some View {
+        List { … }.sheet(isPresented: viewStore.presence(\.route, dismiss: .dismiss)) {
+            router.view(for: .detail)   // router supplies env — crux resolved
+        }
+    }
+}
+```
+
+## Communication between features
+
+A presented child talks back through the core ``Behavior/on(_:dispatch:reduce:)`` bridge: the child emits an action, a bridge routes it to the presenter (clearing the route, seeding state). It works identically for same-store and separate-store children — no direct coupling.
+
 ## Topics
 
 - ``Scope``
 - ``Scopes``
+- ``Feature``
 - ``Routable``

--- a/Sources/SwiftRex/SwiftRex.docc/Navigation.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Navigation.md
@@ -1,0 +1,117 @@
+# State-Driven Navigation
+
+Model navigation as a function of state: routes live in state, SwiftUI bindings dispatch, and a router builds destination views — resolving the environment that an env-free view body can't.
+
+## Overview
+
+Navigation in SwiftRex is **pure SwiftUI Views reacting to state**. There is one store for the whole app; a view holds only a projection. Behavior mutates the navigation *state* (a route, an optional, a path, a selection); it never touches the view or the router. Standard SwiftUI containers (`sheet`, `NavigationStack`, `TabView`, windows) are pluggable renderings of a few state *shapes*.
+
+Four shapes cover it:
+
+| Shape | State | Lift | SwiftUI binding | Container |
+| --- | --- | --- | --- | --- |
+| Optional / modal | `Item?` (or `Bool`) | `liftOptional` | `item(_:dismiss:)` / `presence(_:dismiss:)` | sheet, cover, popover |
+| Stack | `[Route]` | `liftCollection` | `path(_:set:)` | `NavigationStack(path:)` |
+| Selection (1-of-N) | `Sel` | plain `lift` ×N | `selection(_:set:)` | `TabView`, split view |
+| Scene set | keyed sub-states | element projection | `WindowGroup(for:)` | windows |
+
+## Scope — declare the wiring once
+
+A ``Scope`` captures how a child feature embeds into the app store — action prism, state key path, environment narrowing — and derives its `lifted` behavior. Constructing one is a **compile-time proof** the feature is wired; a missing state slot, action case, or env mapping is a compile error at the literal.
+
+```swift
+let detailScope = Scope(
+    behavior:    Detail.behavior(),
+    action:      \.detail,      // PrismKeyPath<AppAction, Detail.Action>
+    state:       \.detail,      // WritableKeyPath<AppState, Detail.State>
+    environment: \.detailEnv    // KeyPath<World, Detail.Environment>
+)
+```
+
+Register every scope in one place with ``Scopes`` so you can't forget to compose a behavior:
+
+```swift
+let features = Scopes(homeScope, detailScope, settingsScope)
+let appBehavior = Behavior.combine([features.behavior, navigationReducer])
+let store = Store(initial: .init(), behavior: appBehavior, environment: world)
+```
+
+## Bindings — the WHEN
+
+Store-backed bindings drive native SwiftUI containers; a write dispatches an action, so presentation stays a function of state.
+
+```swift
+.sheet(item: store.item(\.selected, dismiss: .deselect)) { item in … }
+NavigationStack(path: store.path(\.path, set: NavAction.setPath)) { root }
+TabView(selection: store.selection(\.tab, set: AppAction.selectTab)) { … }
+```
+
+## Navigation reducers — apply, or veto
+
+Fold a navigation reducer into the app behavior to handle the standard operations. Default applies every op; pass `allow` to veto or gate one (return `false` to block) — a vetoed op leaves state unchanged and the binding re-presents.
+
+```swift
+Behavior.navigationStack(\.path, action: \.nav)                         // push/pop/setPath
+Behavior.navigationItem(\.sheet, action: \.modal) { op, s in !s.isDirty } // block dismiss while dirty
+Behavior.navigationSelection(\.tab, action: \.select)
+```
+
+## Router — the WHAT (and the environment crux)
+
+`Feature.view(store:environment:)` needs an environment, but a navigation destination runs inside the *environment-free* view body. A **router** — a value holding the store and the world — resolves that: its `@ViewBuilder view(for:)` switch builds each child, supplying the child's environment there. `some View` throughout — no `AnyView`.
+
+```swift
+@MainActor struct AppRouter {
+    let store: MainStore
+    let world: World
+
+    @ViewBuilder func view(for route: AppRoute) -> some View {
+        switch route {
+        case .detail:
+            Detail.view(
+                store: store.projection(action: \.detail, state: \.detail),
+                environment: world.detailEnv                 // env supplied here
+            )
+        }
+    }
+}
+```
+
+A navigating view conforms to ``Routable`` and holds its router as a `let`, handed in at construction. Because the router builds every view, it re-hands itself at each construction — deterministic across the sheet/modal boundaries where SwiftUI's `@Environment` propagation is unreliable. The view's body stays environment-free:
+
+```swift
+struct HomeView: View, Routable {
+    let viewStore: ViewStore<Home.State, Home.Action>
+    let router: AppRouter                                     // trapped at construction
+
+    var body: some View {
+        List { … }
+            .sheet(isPresented: viewStore.presence(\.route, dismiss: .dismiss)) {
+                router.view(for: .detail)                     // router supplies env — crux resolved
+            }
+    }
+}
+```
+
+The view never names `Detail` — the router does. A route may resolve to a completely separate module (its own store slice / dependencies) without the presenting feature importing it.
+
+## Multi-scene is single-store
+
+Multiple windows are still one store. Model open scenes as state (a dictionary of per-scene sub-states); each window projects its slice by id; open/close are ordinary actions.
+
+```swift
+var body: some Scene {
+    WindowGroup { RootView(store: store, router: router) }
+    WindowGroup(for: DocID.self) { $id in
+        if let id, store.hasScene(id, in: \.documents) {
+            Document.view(store: store.projection(key: id, actionReview: AppAction.document, stateDictionary: \.documents), environment: world.docEnv)
+        }
+    }
+}
+```
+
+## Topics
+
+- ``Scope``
+- ``Scopes``
+- ``Routable``

--- a/Sources/SwiftRex/SwiftRex.docc/SwiftRex.md
+++ b/Sources/SwiftRex/SwiftRex.docc/SwiftRex.md
@@ -35,6 +35,7 @@ Everything except the `Store` is inert and composable. Two `Reducer`s combine in
 - <doc:BuildYourFirstFeature>
 - <doc:AddingEffects>
 - <doc:Features>
+- <doc:Navigation>
 
 ### Concepts
 

--- a/Sources/SwiftRexArchitecture/FeatureProtocol.swift
+++ b/Sources/SwiftRexArchitecture/FeatureProtocol.swift
@@ -1,0 +1,35 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import SwiftRex
+import SwiftUI
+
+/// A feature: it produces a ``Behavior`` and builds its SwiftUI view. One protocol so a ``Scope`` can
+/// abstract over a feature — driving **both** its behavior and its view — without naming it.
+///
+/// It exposes only the liftable/viewable surface (`Action`/`State`/`Environment` + `behavior`/`view`),
+/// never `ViewState`/`ViewAction` — the reason the earlier view-model-exposing protocol was retired.
+///
+/// `view` takes `any StoreType<Action, State>` (a concrete existential) rather than a generic
+/// `some StoreType`, so its `some View` result can bind ``Body``; a generic method could not. A
+/// `Store` or a `StoreProjection` boxes into the existential, so callers are unaffected.
+///
+/// Conformance is one line — `extension MyFeature: Feature {}` — where Swift infers the associated
+/// types from the members `@Feature` already generates. (The macro can't add it automatically: an
+/// extension macro can't infer `Body` from a member-macro-generated `some View` method.)
+public protocol Feature {
+    /// The feature's action type.
+    associatedtype Action: Sendable
+    /// The feature's state type.
+    associatedtype State: Sendable
+    /// The feature's environment (dependencies) type.
+    associatedtype Environment: Sendable
+    /// The concrete view type produced — inferred from `view`'s `some View` result.
+    associatedtype Body: View
+
+    /// The feature's behavior — its reducer/effects/supervisor, composed once.
+    static func behavior() -> Behavior<Action, State, Environment>
+
+    /// Builds the feature's view from the (already scoped) store and environment — the caller
+    /// supplies both, resolving the navigation crux (an environment-free view body never builds this).
+    @MainActor static func view(store: any StoreType<Action, State>, environment: Environment) -> Body
+}
+#endif

--- a/Sources/SwiftRexArchitecture/FeatureProtocol.swift
+++ b/Sources/SwiftRexArchitecture/FeatureProtocol.swift
@@ -2,20 +2,26 @@
 import SwiftRex
 import SwiftUI
 
-/// A feature: it produces a ``Behavior`` and builds its SwiftUI view. One protocol so a ``Scope`` can
-/// abstract over a feature — driving **both** its behavior and its view — without naming it.
+/// A feature that produces a ``Behavior`` — the composable, liftable capability. A logic-only
+/// feature (no view) can conform to just this.
+public protocol HasBehavior {
+    /// The feature's action type.
+    associatedtype Action: Sendable
+    /// The feature's state type.
+    associatedtype State: Sendable
+    /// The feature's environment (dependencies) type.
+    associatedtype Environment: Sendable
+
+    /// The feature's behavior — its reducer/effects/supervisor, composed once.
+    static func behavior() -> Behavior<Action, State, Environment>
+}
+
+/// A feature that builds its SwiftUI view — the view capability.
 ///
-/// It exposes only the liftable/viewable surface (`Action`/`State`/`Environment` + `behavior`/`view`),
-/// never `ViewState`/`ViewAction` — the reason the earlier view-model-exposing protocol was retired.
-///
-/// `view` takes `any StoreType<Action, State>` (a concrete existential) rather than a generic
-/// `some StoreType`, so its `some View` result can bind ``Body``; a generic method could not. A
-/// `Store` or a `StoreProjection` boxes into the existential, so callers are unaffected.
-///
-/// Conformance is one line — `extension MyFeature: Feature {}` — where Swift infers the associated
-/// types from the members `@Feature` already generates. (The macro can't add it automatically: an
-/// extension macro can't infer `Body` from a member-macro-generated `some View` method.)
-public protocol Feature {
+/// `view` takes `any StoreType<Action, State>` (a concrete existential), **not** a generic
+/// `some StoreType`: a generic method returning `some View` cannot bind the ``Body`` associated
+/// type; the existential can. A `Store` or `StoreProjection` boxes into it, so callers are unaffected.
+public protocol ViewFactory {
     /// The feature's action type.
     associatedtype Action: Sendable
     /// The feature's state type.
@@ -25,11 +31,19 @@ public protocol Feature {
     /// The concrete view type produced — inferred from `view`'s `some View` result.
     associatedtype Body: View
 
-    /// The feature's behavior — its reducer/effects/supervisor, composed once.
-    static func behavior() -> Behavior<Action, State, Environment>
-
     /// Builds the feature's view from the (already scoped) store and environment — the caller
     /// supplies both, resolving the navigation crux (an environment-free view body never builds this).
+    @MainActor static func view(store: any StoreType<Action, State>, environment: Environment) -> Body
+}
+
+/// A full feature: it both produces a ``Behavior`` and builds a view — what a ``Scope`` needs to
+/// drive **both** behavior composition and navigation from one declaration.
+///
+/// It **re-declares** both requirements (rather than only inheriting them). That is what lets a
+/// conformer's associated types infer through the combined protocol — inheriting alone does not.
+/// It exposes only the liftable/viewable surface, never `ViewState`/`ViewAction`.
+public protocol Feature: HasBehavior, ViewFactory {
+    static func behavior() -> Behavior<Action, State, Environment>
     @MainActor static func view(store: any StoreType<Action, State>, environment: Environment) -> Body
 }
 #endif

--- a/Sources/SwiftRexArchitecture/MultiScene.swift
+++ b/Sources/SwiftRexArchitecture/MultiScene.swift
@@ -1,0 +1,40 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import SwiftRex
+import SwiftUI
+
+// MARK: - Multi-scene from a single store
+//
+// Multiple windows/scenes are still ONE store. Model open scenes as state (a dictionary or
+// identifiable collection of per-scene sub-states); each window projects its own slice by id with
+// the existing element/dictionary projection; open/close are ordinary actions. No new machinery.
+//
+//     @main struct MyApp: App {
+//         let store = Store(initial: AppState(), behavior: appBehavior, environment: world)
+//         var body: some Scene {
+//             WindowGroup { RootView(store: store, world: world) }          // main window
+//             WindowGroup(for: DocID.self) { $id in                          // document windows
+//                 if let id { DocumentScene(store: store, world: world, id: id) }
+//             }
+//         }
+//     }
+//
+// `DocumentScene` projects `store.projection(key: id, actionReview:, stateDictionary:)` for that
+// window's slice and builds its feature view — the same router/scope wiring as in-window navigation,
+// one level up. `openWindow(value:)` / `dismissWindow` are driven by dispatching actions that add or
+// remove a scene's sub-state; the window set is a function of state.
+
+/// A convenience that reads whether a scene id currently has state — for a window body to decide
+/// between rendering its content and dismissing itself (e.g. `if store.hasScene(id, in: \.documents)`).
+@available(iOS 16.1, macOS 13, tvOS 16.1, watchOS 9.1, *)
+extension StoreType {
+    /// `true` while a scene with `id` exists in the keyed sub-state collection — i.e. the window
+    /// should still render. Pair with `dismissWindow` when it becomes `false`.
+    @MainActor
+    public func hasScene<Key: Hashable & Sendable, Value>(
+        _ id: Key,
+        in dictionary: KeyPath<State, [Key: Value]>
+    ) -> Bool {
+        state[keyPath: dictionary][id] != nil
+    }
+}
+#endif

--- a/Sources/SwiftRexArchitecture/NavigationReducer.swift
+++ b/Sources/SwiftRexArchitecture/NavigationReducer.swift
@@ -1,0 +1,98 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+import SwiftRex
+
+// MARK: - Navigation action vocabulary
+
+/// The standard operations on a **stack** (`[Route]`) navigation slice. Embed one case of this in
+/// your feature's `Action` (e.g. `case nav(StackNavigation<AppRoute>)`) and reduce it with
+/// ``Behavior/navigationStack(_:action:allow:)``.
+public enum StackNavigation<Route: Hashable & Sendable>: Sendable {
+    case push(Route)
+    case pop
+    case popToRoot
+    /// Replace the whole path — what `NavigationStack(path:)`'s binding delivers on any change
+    /// (push, back-swipe, pop-to-root), so a single case covers interactive navigation.
+    case setPath([Route])
+}
+
+/// The standard operations on a **modal / optional** (`Item?`) navigation slice — present sets the
+/// slice to `.some`, dismiss clears it. Reduce with ``Behavior/navigationItem(_:action:allow:)``.
+public enum ModalNavigation<Item: Sendable>: Sendable {
+    case present(Item)
+    case dismiss
+}
+
+/// The operation on a **selection** (1-of-N) navigation slice. Reduce with
+/// ``Behavior/navigationSelection(_:action:allow:)``.
+public enum SelectionNavigation<Selection: Sendable>: Sendable {
+    case select(Selection)
+}
+
+// MARK: - Navigation reducers
+
+extension Behavior {
+    /// A behavior that reduces ``StackNavigation`` operations into a `[Route]` slice of state.
+    ///
+    /// Add it to your app's behavior list (`Behavior.combine([…, navigationStack(…)])`). The default
+    /// is to **apply** every operation; pass `allow` to veto or gate one (return `false` to block —
+    /// e.g. refuse to pop while a form is dirty). Navigation stays a function of state: a blocked
+    /// operation simply leaves the path unchanged, and the `NavigationStack` binding re-presents it.
+    ///
+    /// ```swift
+    /// Behavior.navigationStack(\.path, action: \.nav)                         // always apply
+    /// Behavior.navigationStack(\.path, action: \.nav) { op, s in !s.isDirty } // veto pop while dirty
+    /// ```
+    public static func navigationStack<Route: Hashable & Sendable>(
+        _ path: WritableKeyPath<State, [Route]>,
+        action navigation: PrismKeyPath<Action, StackNavigation<Route>>,
+        allow: (@Sendable (StackNavigation<Route>, State) -> Bool)? = nil
+    ) -> Behavior where Action: Prismatic {
+        let preview = Prism(navigation).preview
+        return .reduce { action, state in
+            guard let op = preview(action), allow?(op, state) != false else { return }
+            switch op {
+            case .push(let route):  state[keyPath: path].append(route)
+            case .pop:              if !state[keyPath: path].isEmpty { state[keyPath: path].removeLast() }
+            case .popToRoot:        state[keyPath: path].removeAll()
+            case .setPath(let new): state[keyPath: path] = new
+            }
+        }
+    }
+
+    /// A behavior that reduces ``ModalNavigation`` into an optional (`Item?`) slice — present sets
+    /// `.some`, dismiss clears. `allow` gates an operation (return `false` to block, e.g. refuse to
+    /// dismiss with unsaved edits). For sheets/covers/popovers driven by ``StoreType/item(_:dismiss:)``.
+    public static func navigationItem<Item: Sendable>(
+        _ item: WritableKeyPath<State, Item?>,
+        action navigation: PrismKeyPath<Action, ModalNavigation<Item>>,
+        allow: (@Sendable (ModalNavigation<Item>, State) -> Bool)? = nil
+    ) -> Behavior where Action: Prismatic {
+        let preview = Prism(navigation).preview
+        return .reduce { action, state in
+            guard let op = preview(action), allow?(op, state) != false else { return }
+            switch op {
+            case .present(let value): state[keyPath: item] = value
+            case .dismiss:            state[keyPath: item] = nil
+            }
+        }
+    }
+
+    /// A behavior that reduces ``SelectionNavigation`` into a selection slice — for
+    /// `TabView(selection:)` / split view. `allow` gates a change (return `false` to block, e.g.
+    /// refuse to leave a tab mid-task). Unlike modal dismiss, selecting is a normal state change.
+    public static func navigationSelection<Selection: Sendable>(
+        _ selection: WritableKeyPath<State, Selection>,
+        action navigation: PrismKeyPath<Action, SelectionNavigation<Selection>>,
+        allow: (@Sendable (SelectionNavigation<Selection>, State) -> Bool)? = nil
+    ) -> Behavior where Action: Prismatic {
+        let preview = Prism(navigation).preview
+        return .reduce { action, state in
+            guard let op = preview(action), allow?(op, state) != false else { return }
+            switch op {
+            case .select(let value): state[keyPath: selection] = value
+            }
+        }
+    }
+}
+#endif

--- a/Sources/SwiftRexArchitecture/Scope.swift
+++ b/Sources/SwiftRexArchitecture/Scope.swift
@@ -2,91 +2,76 @@
 import CoreFP
 import SwiftRex
 
-/// The wiring that scopes a child feature into a parent (app) store — declared **once** and reused
-/// by both behavior composition and (in a later stage) navigation.
+/// The wiring that scopes a child ``Feature`` into a parent (app) store — declared **once** and used
+/// for both behavior composition **and** navigation.
 ///
-/// A `Scope` captures how a child feature's `(Action, State, Environment)` embeds into the parent's
-/// `(GlobalAction, GlobalState, GlobalEnvironment)`: the action prism, the state key path, and the
-/// environment-narrowing closure. From those it derives the child's **lifted behavior**
-/// (``lifted``), typed at the global types so a whole app's behaviors are homogeneous and fold with
-/// the ``Behavior`` monoid.
+/// A `Scope` captures how a child embeds into the parent's `(GlobalAction, GlobalState,
+/// GlobalEnvironment)`: the action prism, the state key path, and the environment-narrowing. From the
+/// child feature it derives:
+/// - ``behavior`` — the child's behavior lifted to the global types (register it in the app behavior);
+/// - ``view(from:world:)`` — the child's view, built with the scoped store and narrowed environment.
+///   This resolves the navigation crux: an environment-free view body never builds a child itself; a
+///   router calls this.
 ///
 /// ## Compile-time proof of wiring
 ///
-/// Constructing a `Scope` *is* the proof the feature is wired: the initializer will not type-check
-/// unless the global state slot, global action case (prism), environment-narrowing, and the child's
-/// own `(Action, State, Environment)` all exist and line up. Forget the slot, the case, or the
-/// env-narrowing and you get a **compile error at the `Scope` literal** — not a silent missing
-/// screen at runtime.
+/// Constructing a `Scope` is the proof the feature is wired: it won't type-check unless the global
+/// state slot, action case, and env-narrowing line up with the child feature's own `(Action, State,
+/// Environment)`. Forget one and you get a compile error at the literal.
 ///
 /// ```swift
-/// let homeScope = Scope(
-///     behavior:    HomeFeature.behavior(),
-///     action:      \.home,          // PrismKeyPath<AppAction, HomeFeature.Action>
-///     state:       \.home,          // WritableKeyPath<AppState, HomeFeature.State>
-///     environment: \.homeEnv        // KeyPath<World, HomeFeature.Environment>
-/// )
-/// // homeScope.lifted : Behavior<AppAction, AppState, World>
+/// let detailScope = Scope(Detail.self, action: \.detail, state: \.detail, environment: \.detailEnv)
+/// detailScope.behavior                          // Behavior<AppAction, AppState, World>
+/// detailScope.view(from: store, world: world)   // Detail's view, env supplied — for a router switch
 /// ```
 ///
-/// Register every scope's ``lifted`` behavior in one homogeneous list so you can't forget to
-/// compose one:
-///
-/// ```swift
-/// let appBehavior = Behavior.combine([homeScope.lifted, detailScope.lifted, navigationReducer])
-/// ```
-///
-/// A scope over an **optional** child state (`ChildState?`) lifts with `liftOptional`, so the child
-/// behavior runs only while its slice is `.some` — the shape a presented/pushed screen uses.
-public struct Scope<GlobalAction: Sendable, GlobalState: Sendable, GlobalEnvironment: Sendable>: Sendable {
+/// This `Scope` is for **present-state** children (a sibling slice always in state — the shape a tab,
+/// split pane, or a route whose state lives alongside uses). An **optional/modal** child (`State?`)
+/// registers its behavior with `liftOptional` (see the navigation reducers) and has its view
+/// hand-wired in the router via a store `item` projection.
+public struct Scope<
+    GlobalAction: Sendable & Prismatic,
+    GlobalState: Sendable,
+    GlobalEnvironment: Sendable,
+    F: Feature
+>: Sendable {
     /// The child behavior lifted to the global `(Action, State, Environment)` — homogeneous across
     /// every scope, so a whole app's behaviors fold with ``Behavior/combine(_:)-(Array)``.
-    public let lifted: Behavior<GlobalAction, GlobalState, GlobalEnvironment>
+    public let behavior: Behavior<GlobalAction, GlobalState, GlobalEnvironment>
 
-    // MARK: - Always-present child state (env as closure)
+    private let action: PrismKeyPath<GlobalAction, F.Action>
+    private let state: KeyPath<GlobalState, F.State>
+    private let narrowEnvironment: @Sendable (GlobalEnvironment) -> F.Environment
 
-    /// Scopes a child whose state is always present in the parent (a sibling slice — the shape used
-    /// for tabs/split children that all stay alive).
-    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
-        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
-        action: PrismKeyPath<GlobalAction, ChildAction>,
-        state: WritableKeyPath<GlobalState, ChildState>,
-        environment: @escaping @Sendable (GlobalEnvironment) -> ChildEnvironment
-    ) where GlobalAction: Prismatic {
-        lifted = behavior.lift(action: action, state: state, environment: environment)
+    /// Scopes a child feature whose state is a present sibling slice.
+    public init(
+        _ feature: F.Type,
+        action: PrismKeyPath<GlobalAction, F.Action>,
+        state: WritableKeyPath<GlobalState, F.State>,
+        environment: @escaping @Sendable (GlobalEnvironment) -> F.Environment
+    ) {
+        self.action = action
+        self.state = state
+        self.narrowEnvironment = environment
+        self.behavior = F.behavior().lift(action: action, state: state, environment: environment)
     }
 
-    /// Env-as-key-path convenience for an always-present child.
-    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
-        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
-        action: PrismKeyPath<GlobalAction, ChildAction>,
-        state: WritableKeyPath<GlobalState, ChildState>,
-        environment: KeyPath<GlobalEnvironment, ChildEnvironment> & Sendable
-    ) where GlobalAction: Prismatic {
-        self.init(behavior: behavior, action: action, state: state, environment: { $0[keyPath: environment] })
+    /// Env-as-key-path convenience.
+    public init(
+        _ feature: F.Type,
+        action: PrismKeyPath<GlobalAction, F.Action>,
+        state: WritableKeyPath<GlobalState, F.State>,
+        environment: KeyPath<GlobalEnvironment, F.Environment> & Sendable
+    ) {
+        self.init(feature, action: action, state: state, environment: { $0[keyPath: environment] })
     }
 
-    // MARK: - Optional child state (present-while-.some)
-
-    /// Scopes a child whose state is **optional** — the child behavior runs only while the slice is
-    /// `.some` (the shape a presented sheet / pushed screen uses). Lifts with `liftOptional`.
-    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
-        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
-        action: PrismKeyPath<GlobalAction, ChildAction>,
-        state: WritableKeyPath<GlobalState, ChildState?>,
-        environment: @escaping @Sendable (GlobalEnvironment) -> ChildEnvironment
-    ) where GlobalAction: Prismatic {
-        lifted = behavior.liftOptional(action: action, state: state, environment: environment)
-    }
-
-    /// Env-as-key-path convenience for an optional child.
-    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
-        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
-        action: PrismKeyPath<GlobalAction, ChildAction>,
-        state: WritableKeyPath<GlobalState, ChildState?>,
-        environment: KeyPath<GlobalEnvironment, ChildEnvironment> & Sendable
-    ) where GlobalAction: Prismatic {
-        self.init(behavior: behavior, action: action, state: state, environment: { $0[keyPath: environment] })
+    /// Builds the child feature's view from the scoped store and narrowed environment — the WHAT of
+    /// navigation. Call it from a router's `@ViewBuilder view(for:)` switch; the environment comes
+    /// from the world the router holds, never from the (environment-free) presenting view body.
+    @MainActor
+    public func view(from store: any StoreType<GlobalAction, GlobalState>, world: GlobalEnvironment) -> F.Body {
+        F.view(store: store.projection(action: action, state: state), environment: narrowEnvironment(world))
     }
 }
 #endif

--- a/Sources/SwiftRexArchitecture/Scope.swift
+++ b/Sources/SwiftRexArchitecture/Scope.swift
@@ -1,0 +1,92 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+import SwiftRex
+
+/// The wiring that scopes a child feature into a parent (app) store — declared **once** and reused
+/// by both behavior composition and (in a later stage) navigation.
+///
+/// A `Scope` captures how a child feature's `(Action, State, Environment)` embeds into the parent's
+/// `(GlobalAction, GlobalState, GlobalEnvironment)`: the action prism, the state key path, and the
+/// environment-narrowing closure. From those it derives the child's **lifted behavior**
+/// (``lifted``), typed at the global types so a whole app's behaviors are homogeneous and fold with
+/// the ``Behavior`` monoid.
+///
+/// ## Compile-time proof of wiring
+///
+/// Constructing a `Scope` *is* the proof the feature is wired: the initializer will not type-check
+/// unless the global state slot, global action case (prism), environment-narrowing, and the child's
+/// own `(Action, State, Environment)` all exist and line up. Forget the slot, the case, or the
+/// env-narrowing and you get a **compile error at the `Scope` literal** — not a silent missing
+/// screen at runtime.
+///
+/// ```swift
+/// let homeScope = Scope(
+///     behavior:    HomeFeature.behavior(),
+///     action:      \.home,          // PrismKeyPath<AppAction, HomeFeature.Action>
+///     state:       \.home,          // WritableKeyPath<AppState, HomeFeature.State>
+///     environment: \.homeEnv        // KeyPath<World, HomeFeature.Environment>
+/// )
+/// // homeScope.lifted : Behavior<AppAction, AppState, World>
+/// ```
+///
+/// Register every scope's ``lifted`` behavior in one homogeneous list so you can't forget to
+/// compose one:
+///
+/// ```swift
+/// let appBehavior = Behavior.combine([homeScope.lifted, detailScope.lifted, navigationReducer])
+/// ```
+///
+/// A scope over an **optional** child state (`ChildState?`) lifts with `liftOptional`, so the child
+/// behavior runs only while its slice is `.some` — the shape a presented/pushed screen uses.
+public struct Scope<GlobalAction: Sendable, GlobalState: Sendable, GlobalEnvironment: Sendable>: Sendable {
+    /// The child behavior lifted to the global `(Action, State, Environment)` — homogeneous across
+    /// every scope, so a whole app's behaviors fold with ``Behavior/combine(_:)-(Array)``.
+    public let lifted: Behavior<GlobalAction, GlobalState, GlobalEnvironment>
+
+    // MARK: - Always-present child state (env as closure)
+
+    /// Scopes a child whose state is always present in the parent (a sibling slice — the shape used
+    /// for tabs/split children that all stay alive).
+    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
+        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
+        action: PrismKeyPath<GlobalAction, ChildAction>,
+        state: WritableKeyPath<GlobalState, ChildState>,
+        environment: @escaping @Sendable (GlobalEnvironment) -> ChildEnvironment
+    ) where GlobalAction: Prismatic {
+        lifted = behavior.lift(action: action, state: state, environment: environment)
+    }
+
+    /// Env-as-key-path convenience for an always-present child.
+    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
+        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
+        action: PrismKeyPath<GlobalAction, ChildAction>,
+        state: WritableKeyPath<GlobalState, ChildState>,
+        environment: KeyPath<GlobalEnvironment, ChildEnvironment> & Sendable
+    ) where GlobalAction: Prismatic {
+        self.init(behavior: behavior, action: action, state: state, environment: { $0[keyPath: environment] })
+    }
+
+    // MARK: - Optional child state (present-while-.some)
+
+    /// Scopes a child whose state is **optional** — the child behavior runs only while the slice is
+    /// `.some` (the shape a presented sheet / pushed screen uses). Lifts with `liftOptional`.
+    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
+        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
+        action: PrismKeyPath<GlobalAction, ChildAction>,
+        state: WritableKeyPath<GlobalState, ChildState?>,
+        environment: @escaping @Sendable (GlobalEnvironment) -> ChildEnvironment
+    ) where GlobalAction: Prismatic {
+        lifted = behavior.liftOptional(action: action, state: state, environment: environment)
+    }
+
+    /// Env-as-key-path convenience for an optional child.
+    public init<ChildAction: Sendable, ChildState: Sendable, ChildEnvironment: Sendable>(
+        behavior: Behavior<ChildAction, ChildState, ChildEnvironment>,
+        action: PrismKeyPath<GlobalAction, ChildAction>,
+        state: WritableKeyPath<GlobalState, ChildState?>,
+        environment: KeyPath<GlobalEnvironment, ChildEnvironment> & Sendable
+    ) where GlobalAction: Prismatic {
+        self.init(behavior: behavior, action: action, state: state, environment: { $0[keyPath: environment] })
+    }
+}
+#endif

--- a/Sources/SwiftRexArchitecture/Scopes.swift
+++ b/Sources/SwiftRexArchitecture/Scopes.swift
@@ -3,36 +3,31 @@ import SwiftRex
 
 /// A single registration point for an app's scoped feature behaviors.
 ///
-/// List every feature's ``Scope`` once; ``behavior`` folds their `lifted` behaviors into one. This
-/// is the app-composition companion to ``Scope`` — declaring a scope registers its behavior, so you
-/// can't wire a feature into state/action without also composing its behavior:
+/// Each ``Scope`` is generic over its child feature, so scopes are heterogeneous and can't share one
+/// array — but their ``Scope/behavior`` is homogeneous (`Behavior<GlobalAction, GlobalState,
+/// GlobalEnvironment>`). List those; ``behavior`` folds them into one. Declaring a scope and passing
+/// its `.behavior` here is the single place a feature's behavior is registered:
 ///
 /// ```swift
-/// let features = Scopes(homeScope, detailScope, settingsScope)
-/// let appBehavior = Behavior.combine([features.behavior, navigationReducer, loggingBehavior])
+/// let appBehavior = Scopes(homeScope.behavior, detailScope.behavior, navigationReducer).behavior
 /// let store = Store(initial: .init(), behavior: appBehavior, environment: world)
 /// ```
 ///
-/// The same scope values feed a hand-written router's `@ViewBuilder view(for:)` switch, so behavior
-/// registration and navigation share one source of truth. (A future collecting macro could derive
-/// this list from the route enum; today it is one explicit array — the single place to add a
-/// feature.)
+/// The same scope values feed a hand-written router's `@ViewBuilder view(for:)` switch (via
+/// ``Scope/view(from:world:)``), so behavior registration and navigation share one source of truth.
 public struct Scopes<GlobalAction: Sendable, GlobalState: Sendable, GlobalEnvironment: Sendable>: Sendable {
-    private let scopes: [Scope<GlobalAction, GlobalState, GlobalEnvironment>]
+    /// The combined behavior of every registered scope (plus any extra behaviors passed in) — fold
+    /// this into the store.
+    public let behavior: Behavior<GlobalAction, GlobalState, GlobalEnvironment>
 
-    /// Registers a list of feature scopes.
-    public init(_ scopes: Scope<GlobalAction, GlobalState, GlobalEnvironment>...) {
-        self.scopes = scopes
+    /// Registers scope behaviors (and any extra behaviors, e.g. a navigation reducer or logging).
+    public init(_ behaviors: Behavior<GlobalAction, GlobalState, GlobalEnvironment>...) {
+        self.behavior = .combine(behaviors)
     }
 
-    /// Registers a list of feature scopes (array form).
-    public init(_ scopes: [Scope<GlobalAction, GlobalState, GlobalEnvironment>]) {
-        self.scopes = scopes
-    }
-
-    /// The combined behavior of every registered scope — fold this into the app behavior.
-    public var behavior: Behavior<GlobalAction, GlobalState, GlobalEnvironment> {
-        .combine(scopes.map(\.lifted))
+    /// Registers scope behaviors (array form).
+    public init(_ behaviors: [Behavior<GlobalAction, GlobalState, GlobalEnvironment>]) {
+        self.behavior = .combine(behaviors)
     }
 }
 #endif

--- a/Sources/SwiftRexArchitecture/Scopes.swift
+++ b/Sources/SwiftRexArchitecture/Scopes.swift
@@ -1,0 +1,38 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import SwiftRex
+
+/// A single registration point for an app's scoped feature behaviors.
+///
+/// List every feature's ``Scope`` once; ``behavior`` folds their `lifted` behaviors into one. This
+/// is the app-composition companion to ``Scope`` — declaring a scope registers its behavior, so you
+/// can't wire a feature into state/action without also composing its behavior:
+///
+/// ```swift
+/// let features = Scopes(homeScope, detailScope, settingsScope)
+/// let appBehavior = Behavior.combine([features.behavior, navigationReducer, loggingBehavior])
+/// let store = Store(initial: .init(), behavior: appBehavior, environment: world)
+/// ```
+///
+/// The same scope values feed a hand-written router's `@ViewBuilder view(for:)` switch, so behavior
+/// registration and navigation share one source of truth. (A future collecting macro could derive
+/// this list from the route enum; today it is one explicit array — the single place to add a
+/// feature.)
+public struct Scopes<GlobalAction: Sendable, GlobalState: Sendable, GlobalEnvironment: Sendable>: Sendable {
+    private let scopes: [Scope<GlobalAction, GlobalState, GlobalEnvironment>]
+
+    /// Registers a list of feature scopes.
+    public init(_ scopes: Scope<GlobalAction, GlobalState, GlobalEnvironment>...) {
+        self.scopes = scopes
+    }
+
+    /// Registers a list of feature scopes (array form).
+    public init(_ scopes: [Scope<GlobalAction, GlobalState, GlobalEnvironment>]) {
+        self.scopes = scopes
+    }
+
+    /// The combined behavior of every registered scope — fold this into the app behavior.
+    public var behavior: Behavior<GlobalAction, GlobalState, GlobalEnvironment> {
+        .combine(scopes.map(\.lifted))
+    }
+}
+#endif

--- a/Sources/SwiftRexMacros/FeatureMacro.swift
+++ b/Sources/SwiftRexMacros/FeatureMacro.swift
@@ -94,9 +94,13 @@ public struct FeatureMacro: MemberAttributeMacro, MemberMacro {
         } else {
             source = "store"   // no view layer — wrap the store directly (ViewState == State)
         }
+        // The store parameter is `any StoreType<Action, State>` (an existential — a CONCRETE type),
+        // not `some StoreType<…>` (a generic parameter). A generic method returning `some View`
+        // cannot bind the `ViewFactory.Body` associated type, so the feature couldn't conform to
+        // `Feature`; the existential can. Callers are unaffected — a `Store` boxes into it.
         return """
             \(raw: availability)@MainActor \(raw: access)static func view(
-                store: some StoreType<Action, State>,
+                store: any StoreType<Action, State>,
                 environment: Environment
             ) -> some View {
                 Content(viewStore: \(raw: storeType)(\(raw: source)))

--- a/Sources/SwiftRexSwiftUI/Routable.swift
+++ b/Sources/SwiftRexSwiftUI/Routable.swift
@@ -1,0 +1,40 @@
+#if canImport(SwiftUI)
+/// A view that navigates — it holds a **router** it was handed at construction and asks it to build
+/// destination views on demand.
+///
+/// This is the opt-in seam for navigation. A view that presents/pushes other features conforms to
+/// `Routable`, stores its router as a `let`, and calls it from destination closures:
+///
+/// ```swift
+/// struct HomeView: View, Routable {
+///     let viewStore: ViewStore<Home.State, Home.Action>
+///     let router: AppRouter                        // handed in at construction, traps store + world
+///
+///     var body: some View {
+///         List { … }
+///             .sheet(isPresented: viewStore.presence(\.route, dismiss: .dismiss)) {
+///                 router.view(for: .detail)        // env-free body; the router supplies env
+///             }
+///     }
+/// }
+/// ```
+///
+/// ## Why hold the router, not read it ambiently
+///
+/// A router injected at construction is deterministic across sheet/modal boundaries — the exact
+/// place SwiftUI's `@Environment` propagation is unreliable. Because the router builds every view,
+/// it re-hands itself at each construction, so nested flows (a sheet that itself navigates) always
+/// have their router. See ``Router`` for the destination-building side.
+///
+/// A view conforms manually today; a future `routing:` argument on the feature macros can synthesize
+/// the `router` property and this conformance.
+public protocol Routable {
+    /// The router type this view navigates through — a concrete app router, or a narrow per-feature
+    /// routing protocol it conforms to (so the view sees only the destinations it needs).
+    associatedtype Routing
+
+    /// The router, trapped at construction. Building a destination (`router.view(for:)`) supplies
+    /// the child's store projection and environment — the view body never touches `Environment`.
+    var router: Routing { get }
+}
+#endif

--- a/Sources/SwiftRexSwiftUI/StoreType+Bindings.swift
+++ b/Sources/SwiftRexSwiftUI/StoreType+Bindings.swift
@@ -75,5 +75,61 @@ extension StoreType {
             }
         )
     }
+
+    /// A `Binding<[Element]>` for `NavigationStack(path:)` — the **stack** navigation shape.
+    ///
+    /// SwiftUI hands the binding the *whole* new path on every structural change, so a single
+    /// `set` action carries push (append), pop / back-swipe (truncate), and pop-to-root (empty)
+    /// uniformly. The stack is a function of state; the reducer decides what a new path means
+    /// (see the navigation reducer for standard `push`/`pop`/`setPath` handling).
+    ///
+    /// ```swift
+    /// NavigationStack(path: store.path(\.path, set: NavAction.setPath)) { root }
+    ///     .navigationDestination(for: Route.self) { route in router.view(for: route) }
+    /// ```
+    @MainActor
+    public func path<Element>(
+        _ keyPath: KeyPath<State, [Element]>,
+        set: @escaping @Sendable ([Element]) -> Action,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Binding<[Element]> {
+        binding(keyPath, set: set, file: file, function: function, line: line)
+    }
+
+    /// A `Binding<Value>` for `TabView(selection:)` / `TabView(.page)` / carousels — the **selection**
+    /// shape (exactly one of N, all children alive).
+    ///
+    /// Unlike ``presence(_:dismiss:)`` / ``item(_:dismiss:)`` (which only dispatch on *dismiss*),
+    /// selection dispatches on **every** change — picking a tab is a real state transition the
+    /// reducer honors (and may veto/redirect).
+    ///
+    /// ```swift
+    /// TabView(selection: store.selection(\.tab, set: AppAction.selectTab)) { … }
+    /// ```
+    @MainActor
+    public func selection<Value>(
+        _ keyPath: KeyPath<State, Value>,
+        set: @escaping @Sendable (Value) -> Action,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Binding<Value> {
+        binding(keyPath, set: set, file: file, function: function, line: line)
+    }
+
+    /// A `Binding<Value?>` for `NavigationSplitView`-style **optional** selection (nothing selected
+    /// yet, or a cleared sidebar). Dispatches on every change, including selecting `nil`.
+    @MainActor
+    public func selection<Value>(
+        _ keyPath: KeyPath<State, Value?>,
+        set: @escaping @Sendable (Value?) -> Action,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) -> Binding<Value?> {
+        binding(keyPath, set: set, file: file, function: function, line: line)
+    }
 }
 #endif

--- a/Tests/SwiftRexArchitectureTests/FeatureProtocolTests.swift
+++ b/Tests/SwiftRexArchitectureTests/FeatureProtocolTests.swift
@@ -51,9 +51,10 @@ struct FeatureProtocolTests {
         _ = drive(FPLeaf.self, store: store, environment: FPLeaf.Environment(step: 1))
     }
 
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    @Test func behaviorRunsThroughTheProtocol() {
-        func featureBehavior<F: Feature>(_ f: F.Type) -> Behavior<F.Action, F.State, F.Environment> { F.behavior() }
+    @Test func behaviorRunsThroughHasBehavior() {
+        // The behavior half alone (HasBehavior) abstracts a feature's behavior — reusable for
+        // logic-only features that have no view.
+        func featureBehavior<F: HasBehavior>(_ f: F.Type) -> Behavior<F.Action, F.State, F.Environment> { F.behavior() }
         let store = Store(initial: FPLeaf.State(), behavior: featureBehavior(FPLeaf.self), environment: FPLeaf.Environment(step: 1))
         store.dispatch(.bump)
         #expect(store.state.n == 1)

--- a/Tests/SwiftRexArchitectureTests/FeatureProtocolTests.swift
+++ b/Tests/SwiftRexArchitectureTests/FeatureProtocolTests.swift
@@ -1,0 +1,62 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+@testable import SwiftRex
+@testable import SwiftRexArchitecture
+import SwiftUI
+import Testing
+
+// Proves the Feature protocol lets you abstract over a feature generically — driving BOTH its
+// behavior and its view without naming the concrete feature. Conformance is one line (`extension X:
+// Feature {}`), which Swift's associated-type inference fills in from the @Feature-generated members.
+
+@Feature(type: .internalOnly, strategy: .observationSimple)
+enum FPLeaf {
+    struct State: Sendable, Equatable { var n = 0 }
+    enum Action: Sendable, Equatable { case bump }
+    struct Environment: Sendable { var step: Int }
+    static func behavior() -> Behavior<Action, State, Environment> {
+        .reduce { action, state in
+            switch action {
+            case .bump: state.n += 1
+            }
+        }
+    }
+    typealias Content = FPLeafView
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@BoundTo(FPLeaf.self, strategy: .observationSimple)
+struct FPLeafView: View { var body: some View { Text("\(viewStore.state.n)") } }
+
+// One-line conformance — Body/Action/State/Environment inferred from the generated members.
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension FPLeaf: Feature {}
+
+// A generic that abstracts over ANY feature — driving both its behavior and its view through the
+// single Feature protocol, without naming the concrete feature inside.
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@MainActor
+private func drive<F: Feature>(_ feature: F.Type, store: any StoreType<F.Action, F.State>, environment: F.Environment) -> F.Body {
+    _ = F.behavior()
+    return F.view(store: store, environment: environment)
+}
+
+@Suite("Feature protocol")
+@MainActor
+struct FeatureProtocolTests {
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func abstractsFeatureGenerically() {
+        // Compiles ⇒ `drive` used a feature purely through the protocol (no concrete naming inside).
+        let store = Store(initial: FPLeaf.State(), behavior: FPLeaf.behavior(), environment: FPLeaf.Environment(step: 1))
+        _ = drive(FPLeaf.self, store: store, environment: FPLeaf.Environment(step: 1))
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func behaviorRunsThroughTheProtocol() {
+        func featureBehavior<F: Feature>(_ f: F.Type) -> Behavior<F.Action, F.State, F.Environment> { F.behavior() }
+        let store = Store(initial: FPLeaf.State(), behavior: featureBehavior(FPLeaf.self), environment: FPLeaf.Environment(step: 1))
+        store.dispatch(.bump)
+        #expect(store.state.n == 1)
+    }
+}
+#endif

--- a/Tests/SwiftRexArchitectureTests/MultiSceneTests.swift
+++ b/Tests/SwiftRexArchitectureTests/MultiSceneTests.swift
@@ -1,0 +1,94 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+@testable import SwiftRex
+@testable import SwiftRexArchitecture
+import SwiftUI
+import Testing
+
+// Proves multi-scene is single-store: open scenes are STATE (a dictionary of per-scene sub-states),
+// each window projects its slice by id, and a `some Scene` body wires WindowGroup(for:) to the one
+// store. No new projection machinery — the existing dictionary projection carries the per-scene slice.
+
+private struct DocState: Sendable, Equatable { var title: String; var edits = 0 }
+private enum DocAction: Sendable, Equatable { case bumpEdits }
+
+// @Prisms requires >= fileprivate.
+// swiftlint:disable private_over_fileprivate
+@Prisms
+fileprivate enum SceneAppAction: Sendable {
+    case open(Int, String)
+    case close(Int)
+    case document(ElementAction<Int, DocAction>)
+}
+
+@Lenses
+fileprivate struct SceneAppState: Sendable {
+    var documents: [Int: DocState] = [:]   // open windows, keyed by id
+}
+// swiftlint:enable private_over_fileprivate
+
+@Suite("Multi-scene single store")
+@MainActor
+struct MultiSceneTests {
+    private func makeStore() -> Store<SceneAppAction, SceneAppState, Void> {
+        Store(
+            initial: SceneAppState(),
+            behavior: Reducer.reduce { (action: SceneAppAction, state: inout SceneAppState) in
+                switch action {
+                case let .open(id, title): state.documents[id] = DocState(title: title)
+                case .close(let id):           state.documents[id] = nil
+                case .document(let elem):
+                    switch elem.action {
+                    case .bumpEdits: state.documents[elem.id]?.edits += 1
+                    }
+                }
+            }.asBehavior(),
+            environment: ()
+        )
+    }
+
+    @Test func openAndCloseScenesAreStateInTheOneStore() {
+        let store = makeStore()
+        store.dispatch(.open(1, "A"))
+        store.dispatch(.open(2, "B"))
+        #expect(store.state.documents.count == 2)
+        store.dispatch(.close(1))
+        #expect(store.state.documents[1] == nil)
+        #expect(store.state.documents[2]?.title == "B")
+    }
+
+    @available(iOS 16.1, macOS 13, tvOS 16.1, watchOS 9.1, *)
+    @Test func hasSceneReflectsOpenWindows() {
+        let store = makeStore()
+        store.dispatch(.open(7, "Doc"))
+        #expect(store.hasScene(7, in: \.documents))
+        #expect(!store.hasScene(9, in: \.documents))
+    }
+
+    @Test func perSceneProjectionCarriesTheSlice() {
+        let store = makeStore()
+        store.dispatch(.open(3, "C"))
+        // Each window projects its own slice by id — the existing dictionary projection.
+        let window = store.projection(
+            key: 3,
+            actionReview: SceneAppAction.document,
+            stateDictionary: \.documents
+        )
+        #expect(window.state?.title == "C")
+        window.dispatch(.bumpEdits)             // dispatches into the ONE store, scoped to id 3
+        #expect(store.state.documents[3]?.edits == 1)
+    }
+}
+
+// Compile-proof: a `some Scene` body wires WindowGroup(for:) to the single store, projecting each
+// window's slice by id. Not runtime-tested (Scenes are app-level), but compiling proves the pattern.
+@available(iOS 16.1, macOS 13, tvOS 16.1, watchOS 9.1, *)
+@MainActor
+private func multiSceneBody(store: Store<SceneAppAction, SceneAppState, Void>) -> some Scene {
+    WindowGroup(for: Int.self) { $id in
+        if let id, let doc = store.state.documents[id] {
+            Text(doc.title)                     // real apps build the scene's feature view here
+        }
+    }
+}
+#endif

--- a/Tests/SwiftRexArchitectureTests/NavigationReducerTests.swift
+++ b/Tests/SwiftRexArchitectureTests/NavigationReducerTests.swift
@@ -1,0 +1,116 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+@testable import SwiftRex
+@testable import SwiftRexArchitecture
+import Testing
+
+private enum NavRoute: Hashable, Sendable { case a, b, c }
+private struct NavItem: Sendable, Equatable { var id: Int }
+private enum NavTab: Hashable, Sendable { case home, search }
+
+// @Prisms requires >= fileprivate.
+// swiftlint:disable private_over_fileprivate
+@Prisms
+fileprivate enum NavAction: Sendable {
+    case stack(StackNavigation<NavRoute>)
+    case modal(ModalNavigation<NavItem>)
+    case select(SelectionNavigation<NavTab>)
+}
+// swiftlint:enable private_over_fileprivate
+
+private struct NavState: Sendable, Equatable {
+    var path: [NavRoute] = []
+    var sheet: NavItem?
+    var tab: NavTab = .home
+    var locked = false
+}
+
+@Suite("Navigation reducer")
+@MainActor
+struct NavigationReducerTests {
+    private func makeStore(_ behavior: Behavior<NavAction, NavState, Void>, _ initial: NavState = .init()) -> Store<NavAction, NavState, Void> {
+        Store(initial: initial, behavior: behavior, environment: ())
+    }
+
+    // MARK: Stack
+
+    @Test func stackPushPopSetPath() {
+        let store = makeStore(.navigationStack(\.path, action: \.stack))
+        store.dispatch(.stack(.push(.a)))
+        store.dispatch(.stack(.push(.b)))
+        #expect(store.state.path == [.a, .b])
+        store.dispatch(.stack(.pop))
+        #expect(store.state.path == [.a])
+        store.dispatch(.stack(.setPath([.a, .b, .c])))
+        #expect(store.state.path == [.a, .b, .c])
+        store.dispatch(.stack(.popToRoot))
+        #expect(store.state.path == [])
+    }
+
+    @Test func stackVetoBlocks() {
+        // block pop while locked
+        let store = makeStore(
+            .navigationStack(\.path, action: \.stack) { op, state in
+                if case .pop = op, state.locked { return false }
+                return true
+            },
+            NavState(path: [.a, .b], locked: true)
+        )
+        store.dispatch(.stack(.pop))
+        #expect(store.state.path == [.a, .b])   // vetoed
+    }
+
+    // MARK: Modal
+
+    @Test func modalPresentDismiss() {
+        let store = makeStore(.navigationItem(\.sheet, action: \.modal))
+        store.dispatch(.modal(.present(.init(id: 7))))
+        #expect(store.state.sheet == NavItem(id: 7))
+        store.dispatch(.modal(.dismiss))
+        #expect(store.state.sheet == nil)
+    }
+
+    @Test func modalVetoBlocksDismiss() {
+        let store = makeStore(
+            .navigationItem(\.sheet, action: \.modal) { op, _ in
+                if case .dismiss = op { return false }
+                return true
+            },
+            NavState(sheet: NavItem(id: 1))
+        )
+        store.dispatch(.modal(.dismiss))
+        #expect(store.state.sheet == NavItem(id: 1))   // vetoed
+    }
+
+    // MARK: Selection
+
+    @Test func selectionSelects() {
+        let store = makeStore(.navigationSelection(\.tab, action: \.select))
+        store.dispatch(.select(.select(.search)))
+        #expect(store.state.tab == .search)
+    }
+
+    @Test func selectionVetoBlocks() {
+        let store = makeStore(
+            .navigationSelection(\.tab, action: \.select) { _, state in !state.locked },
+            NavState(locked: true)
+        )
+        store.dispatch(.select(.select(.search)))
+        #expect(store.state.tab == .home)   // vetoed
+    }
+
+    // MARK: Composition — nav reducers fold with feature behaviors
+
+    @Test func foldsWithOtherBehaviors() {
+        let app = Behavior<NavAction, NavState, Void>.combine([
+            .navigationStack(\.path, action: \.stack),
+            .navigationItem(\.sheet, action: \.modal)
+        ])
+        let store = makeStore(app)
+        store.dispatch(.stack(.push(.a)))
+        store.dispatch(.modal(.present(.init(id: 2))))
+        #expect(store.state.path == [.a])
+        #expect(store.state.sheet == NavItem(id: 2))
+    }
+}
+#endif

--- a/Tests/SwiftRexArchitectureTests/RouterCruxTests.swift
+++ b/Tests/SwiftRexArchitectureTests/RouterCruxTests.swift
@@ -1,0 +1,122 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+@testable import SwiftRex
+@testable import SwiftRexArchitecture
+import SwiftUI
+import Testing
+
+// Proves the navigation crux is resolved: a parent view whose body is ENVIRONMENT-FREE presents a
+// child built WITH its environment — supplied by the router, never by the view body. Also proves
+// cross-feature decoupling (the parent never names the child) and no AnyView (@ViewBuilder switch).
+
+// A leaf "module" with a NON-Void environment — so building its view demonstrably needs env.
+@Feature(type: .internalOnly, strategy: .observationSimple)
+enum RDetail {
+    struct State: Sendable, Equatable { var text = "detail" }
+    enum Action: Sendable, Equatable { case tap }
+    struct Environment: Sendable { var greet: @Sendable () -> String }
+    static func behavior() -> Behavior<Action, State, Environment> {
+        .reduce { action, state in
+            switch action {
+            case .tap: state.text = "tapped"
+            }
+        }
+    }
+    typealias Content = RDetailView
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@BoundTo(RDetail.self, strategy: .observationSimple)
+struct RDetailView: View {
+    var body: some View { Text(viewStore.state.text) }
+}
+
+// @Prisms requires >= fileprivate.
+// swiftlint:disable private_over_fileprivate
+@Prisms
+fileprivate enum RAppAction: Sendable {
+    case detail(RDetail.Action)
+    case dismiss
+}
+
+@Lenses
+fileprivate struct RAppState: Sendable {
+    var detail = RDetail.State() // sibling slice; the route is just a trigger token
+    var route: RAppRoute?
+}
+
+fileprivate enum RAppRoute: Hashable, Sendable { case detail }
+
+fileprivate struct RWorld: Sendable { var greet: @Sendable () -> String = { "hi" } }
+
+// The router: one concrete type that knows the whole tree. Its @ViewBuilder switch resolves a route
+// to a child view, supplying that child's env — the crux — and keeping `some View` (no AnyView).
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@MainActor
+fileprivate struct RAppRouter {
+    let store: Store<RAppAction, RAppState, RWorld>
+    let world: RWorld
+
+    @ViewBuilder
+    func view(for route: RAppRoute) -> some View {
+        switch route {
+        case .detail:
+            RDetail.view(
+                store: store.projection(action: \.detail, state: \.detail), // prism + key-path sugar
+                environment: RDetail.Environment(greet: world.greet) // env supplied HERE
+            )
+        }
+    }
+}
+
+// The parent view: it holds only a `viewStore` and a `router` — NO environment. It presents the
+// detail through the router and never names `RDetail`. Cross-feature decoupling + crux resolution.
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+fileprivate struct RHomeView: View, Routable {
+    let viewStore: ViewStore<RAppState, RAppAction>
+    let router: RAppRouter
+
+    var body: some View {
+        Text("home")
+            .sheet(isPresented: viewStore.presence(\.route, dismiss: .dismiss)) {
+                router.view(for: .detail) // env-free body; the router supplied env — crux resolved
+            }
+    }
+}
+// swiftlint:enable private_over_fileprivate
+
+@Suite("Router — crux resolution")
+@MainActor
+struct RouterCruxTests {
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    private func makeStore() -> Store<RAppAction, RAppState, RWorld> {
+        Store(
+            initial: RAppState(),
+            behavior: RDetail.behavior().lift(
+                action: \.detail,
+                state: \RAppState.detail,
+                environment: { (world: RWorld) in RDetail.Environment(greet: world.greet) }
+            ),
+            environment: RWorld()
+        )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func envFreeParentPresentsChildBuiltWithEnv() {
+        // Compiles ⇒ the router resolves a route to a child view WITH env, from an env-free parent.
+        let store = makeStore()
+        let router = RAppRouter(store: store, world: RWorld())
+        let home = RHomeView(viewStore: ViewStore(store), router: router)
+        _ = home.router.view(for: .detail)
+        _ = home.body
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func routedChildSharesTheOneStore() {
+        // The child dispatches into the same single store; its behavior (lifted) runs.
+        let store = makeStore()
+        store.dispatch(.detail(.tap))
+        #expect(store.state.detail.text == "tapped")
+    }
+}
+#endif

--- a/Tests/SwiftRexArchitectureTests/ScopeTests.swift
+++ b/Tests/SwiftRexArchitectureTests/ScopeTests.swift
@@ -114,5 +114,21 @@ struct ScopeTests {
         store.dispatch(.counter(.inc))
         #expect(store.state.counter.count == 1)
     }
+
+    @Test func scopesRegistryFoldsAllBehaviors() {
+        let sheetScope = Scope<SCAction, SCState, SCWorld>(
+            behavior: SCCounter.behavior(),
+            action: \.sheet,
+            state: \.sheet,
+            environment: { _ in .init(step: 0) }
+        )
+        let registry = Scopes(counterScope(), sheetScope)
+        var initial = SCState(); initial.sheet = SCCounter.State()
+        let store = Store(initial: initial, behavior: registry.behavior, environment: SCWorld())
+        store.dispatch(.counter(.inc))
+        store.dispatch(.sheet(.inc))
+        #expect(store.state.counter.count == 1)   // both registered behaviors run
+        #expect(store.state.sheet?.count == 1)
+    }
 }
 #endif

--- a/Tests/SwiftRexArchitectureTests/ScopeTests.swift
+++ b/Tests/SwiftRexArchitectureTests/ScopeTests.swift
@@ -1,0 +1,118 @@
+#if canImport(Observation) && canImport(SwiftUI)
+import CoreFP
+@testable import SwiftRex
+@testable import SwiftRexArchitecture
+import Testing
+
+// A child feature reduced to the essentials Scope needs: a behavior + (Action, State, Environment).
+// No @Feature required — Scope takes the behavior + optics as values.
+private enum SCCounter {
+    struct State: Sendable, Equatable { var count = 0 }
+    enum Action: Sendable, Equatable { case inc, pull, add(Int) }
+    struct Environment: Sendable { var step: Int }
+
+    static func behavior() -> Behavior<Action, State, Environment> {
+        .handle { action, _ in
+            switch action {
+            case .inc:        .reduce { $0.count += 1 }
+            case .pull:       .produce { ctx in Effect.just(.add(ctx.environment.step)) } // reads env
+            case .add(let n): .reduce { $0.count += n }
+            }
+        }
+    }
+}
+
+// @Prisms/@Lenses require >= fileprivate (they reject `private`).
+// swiftlint:disable private_over_fileprivate
+@Prisms
+fileprivate enum SCAction: Sendable, Equatable {
+    case counter(SCCounter.Action)
+    case sheet(SCCounter.Action)
+}
+
+@Lenses
+fileprivate struct SCState: Sendable, Equatable {
+    var counter = SCCounter.State()
+    var sheet: SCCounter.State?
+}
+// swiftlint:enable private_over_fileprivate
+
+private struct SCWorld: Sendable {
+    var step: Int = 10
+    var counterEnv: SCCounter.Environment { .init(step: step) }
+}
+
+@Suite("Scope")
+@MainActor
+struct ScopeTests {
+    // The Scope literal itself is a compile-time proof of wiring: it would not compile if the
+    // action case, state slot, or env-narrowing didn't line up with SCCounter's own types.
+    private func counterScope() -> Scope<SCAction, SCState, SCWorld> {
+        Scope(behavior: SCCounter.behavior(), action: \.counter, state: \.counter, environment: { _ in .init(step: 0) })
+    }
+
+    @Test func presentScopeLiftsActionAndState() {
+        let store = Store(initial: SCState(), behavior: counterScope().lifted, environment: SCWorld())
+        store.dispatch(.counter(.inc))
+        #expect(store.state.counter.count == 1) // action prism + state key path both applied
+    }
+
+    @Test func envIsNarrowedFromWorld() async {
+        let scope = Scope<SCAction, SCState, SCWorld>(
+            behavior: SCCounter.behavior(),
+            action: \.counter,
+            state: \.counter,
+            environment: { SCCounter.Environment(step: $0.step) } // narrow SCWorld.step
+        )
+        let store = Store(initial: SCState(), behavior: scope.lifted, environment: SCWorld(step: 7))
+        store.dispatch(.counter(.pull)) // effect reads env.step=7 → .add(7)
+        await Task.yield()
+        #expect(store.state.counter.count == 7)
+    }
+
+    @Test func envAsKeyPathConvenience() async {
+        let scope = Scope<SCAction, SCState, SCWorld>(
+            behavior: SCCounter.behavior(),
+            action: \.counter,
+            state: \.counter,
+            environment: \.counterEnv // KeyPath<SCWorld, SCCounter.Environment>
+        )
+        let store = Store(initial: SCState(), behavior: scope.lifted, environment: SCWorld(step: 3))
+        store.dispatch(.counter(.pull))
+        await Task.yield()
+        #expect(store.state.counter.count == 3) // env-narrow via key path reached the effect
+    }
+
+    @Test func optionalScopeRunsWhenSome() {
+        let scope = Scope<SCAction, SCState, SCWorld>(
+            behavior: SCCounter.behavior(),
+            action: \.sheet,
+            state: \.sheet, // WritableKeyPath<SCState, SCCounter.State?>
+            environment: { _ in .init(step: 0) }
+        )
+        var initial = SCState(); initial.sheet = SCCounter.State(count: 5)
+        let store = Store(initial: initial, behavior: scope.lifted, environment: SCWorld())
+        store.dispatch(.sheet(.inc))
+        #expect(store.state.sheet?.count == 6)
+    }
+
+    @Test func optionalScopeSkipsWhenNil() {
+        let scope = Scope<SCAction, SCState, SCWorld>(
+            behavior: SCCounter.behavior(),
+            action: \.sheet,
+            state: \.sheet,
+            environment: { _ in .init(step: 0) }
+        )
+        let store = Store(initial: SCState(), behavior: scope.lifted, environment: SCWorld()) // sheet nil
+        store.dispatch(.sheet(.inc))
+        #expect(store.state.sheet == nil) // child behavior never runs while slice is nil
+    }
+
+    @Test func scopesFoldIntoOneAppBehavior() {
+        let app = Behavior.combine([counterScope().lifted])
+        let store = Store(initial: SCState(), behavior: app, environment: SCWorld())
+        store.dispatch(.counter(.inc))
+        #expect(store.state.counter.count == 1)
+    }
+}
+#endif

--- a/Tests/SwiftRexArchitectureTests/ScopeTests.swift
+++ b/Tests/SwiftRexArchitectureTests/ScopeTests.swift
@@ -2,11 +2,13 @@
 import CoreFP
 @testable import SwiftRex
 @testable import SwiftRexArchitecture
+import SwiftUI
 import Testing
 
-// A child feature reduced to the essentials Scope needs: a behavior + (Action, State, Environment).
-// No @Feature required — Scope takes the behavior + optics as values.
-private enum SCCounter {
+// A child feature (a real @Feature so it conforms to `Feature`: behavior + view). Scope derives both
+// its lifted behavior and its view from it.
+@Feature(type: .internalOnly, strategy: .observationSimple)
+enum SCCounter {
     struct State: Sendable, Equatable { var count = 0 }
     enum Action: Sendable, Equatable { case inc, pull, add(Int) }
     struct Environment: Sendable { var step: Int }
@@ -15,14 +17,22 @@ private enum SCCounter {
         .handle { action, _ in
             switch action {
             case .inc:        .reduce { $0.count += 1 }
-            case .pull:       .produce { ctx in Effect.just(.add(ctx.environment.step)) } // reads env
+            case .pull:       .produce { ctx in Effect.just(.add(ctx.environment.step)) }  // reads env
             case .add(let n): .reduce { $0.count += n }
             }
         }
     }
+    typealias Content = SCCounterView
 }
 
-// @Prisms/@Lenses require >= fileprivate (they reject `private`).
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@BoundTo(SCCounter.self, strategy: .observationSimple)
+struct SCCounterView: View { var body: some View { Text("\(viewStore.state.count)") } }
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension SCCounter: Feature {}   // one-line conformance
+
+// @Prisms/@Lenses require >= fileprivate.
 // swiftlint:disable private_over_fileprivate
 @Prisms
 fileprivate enum SCAction: Sendable, Equatable {
@@ -45,90 +55,63 @@ private struct SCWorld: Sendable {
 @Suite("Scope")
 @MainActor
 struct ScopeTests {
-    // The Scope literal itself is a compile-time proof of wiring: it would not compile if the
-    // action case, state slot, or env-narrowing didn't line up with SCCounter's own types.
-    private func counterScope() -> Scope<SCAction, SCState, SCWorld> {
-        Scope(behavior: SCCounter.behavior(), action: \.counter, state: \.counter, environment: { _ in .init(step: 0) })
+    // The Scope literal is a compile-time proof of wiring — it wouldn't compile if the action case,
+    // state slot, or env-narrowing didn't line up with SCCounter's own types.
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    private func counterScope() -> Scope<SCAction, SCState, SCWorld, SCCounter> {
+        Scope<SCAction, SCState, SCWorld, SCCounter>(SCCounter.self, action: \.counter, state: \.counter, environment: { _ in .init(step: 0) })
     }
 
-    @Test func presentScopeLiftsActionAndState() {
-        let store = Store(initial: SCState(), behavior: counterScope().lifted, environment: SCWorld())
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func behaviorLiftsActionAndState() {
+        let store = Store(initial: SCState(), behavior: counterScope().behavior, environment: SCWorld())
         store.dispatch(.counter(.inc))
-        #expect(store.state.counter.count == 1) // action prism + state key path both applied
+        #expect(store.state.counter.count == 1)   // action prism + state key path both applied
     }
 
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @Test func envIsNarrowedFromWorld() async {
-        let scope = Scope<SCAction, SCState, SCWorld>(
-            behavior: SCCounter.behavior(),
+        let scope = Scope<SCAction, SCState, SCWorld, SCCounter>(
+            SCCounter.self,
             action: \.counter,
-            state: \.counter,
-            environment: { SCCounter.Environment(step: $0.step) } // narrow SCWorld.step
+            state: \SCState.counter,
+            environment: { (w: SCWorld) in SCCounter.Environment(step: w.step) }
         )
-        let store = Store(initial: SCState(), behavior: scope.lifted, environment: SCWorld(step: 7))
-        store.dispatch(.counter(.pull)) // effect reads env.step=7 → .add(7)
+        let store = Store(initial: SCState(), behavior: scope.behavior, environment: SCWorld(step: 7))
+        store.dispatch(.counter(.pull))            // effect reads env.step=7 → .add(7)
         await Task.yield()
         #expect(store.state.counter.count == 7)
     }
 
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
     @Test func envAsKeyPathConvenience() async {
-        let scope = Scope<SCAction, SCState, SCWorld>(
-            behavior: SCCounter.behavior(),
+        let scope = Scope<SCAction, SCState, SCWorld, SCCounter>(
+            SCCounter.self,
             action: \.counter,
-            state: \.counter,
-            environment: \.counterEnv // KeyPath<SCWorld, SCCounter.Environment>
+            state: \SCState.counter,
+            environment: \SCWorld.counterEnv
         )
-        let store = Store(initial: SCState(), behavior: scope.lifted, environment: SCWorld(step: 3))
+        let store = Store(initial: SCState(), behavior: scope.behavior, environment: SCWorld(step: 3))
         store.dispatch(.counter(.pull))
         await Task.yield()
-        #expect(store.state.counter.count == 3) // env-narrow via key path reached the effect
+        #expect(store.state.counter.count == 3)   // env-narrow via key path reached the effect
     }
 
-    @Test func optionalScopeRunsWhenSome() {
-        let scope = Scope<SCAction, SCState, SCWorld>(
-            behavior: SCCounter.behavior(),
-            action: \.sheet,
-            state: \.sheet, // WritableKeyPath<SCState, SCCounter.State?>
-            environment: { _ in .init(step: 0) }
-        )
-        var initial = SCState(); initial.sheet = SCCounter.State(count: 5)
-        let store = Store(initial: initial, behavior: scope.lifted, environment: SCWorld())
-        store.dispatch(.sheet(.inc))
-        #expect(store.state.sheet?.count == 6)
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func scopeBuildsTheChildView() {
+        // Scope drives BOTH: .behavior (above) and .view here — env supplied from the world.
+        let store = Store(initial: SCState(), behavior: counterScope().behavior, environment: SCWorld())
+        _ = counterScope().view(from: store, world: SCWorld())
     }
 
-    @Test func optionalScopeSkipsWhenNil() {
-        let scope = Scope<SCAction, SCState, SCWorld>(
-            behavior: SCCounter.behavior(),
-            action: \.sheet,
-            state: \.sheet,
-            environment: { _ in .init(step: 0) }
-        )
-        let store = Store(initial: SCState(), behavior: scope.lifted, environment: SCWorld()) // sheet nil
-        store.dispatch(.sheet(.inc))
-        #expect(store.state.sheet == nil) // child behavior never runs while slice is nil
-    }
-
-    @Test func scopesFoldIntoOneAppBehavior() {
-        let app = Behavior.combine([counterScope().lifted])
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func scopesRegistryFoldsBehaviors() {
+        let app = Scopes(counterScope().behavior).behavior
         let store = Store(initial: SCState(), behavior: app, environment: SCWorld())
         store.dispatch(.counter(.inc))
         #expect(store.state.counter.count == 1)
     }
-
-    @Test func scopesRegistryFoldsAllBehaviors() {
-        let sheetScope = Scope<SCAction, SCState, SCWorld>(
-            behavior: SCCounter.behavior(),
-            action: \.sheet,
-            state: \.sheet,
-            environment: { _ in .init(step: 0) }
-        )
-        let registry = Scopes(counterScope(), sheetScope)
-        var initial = SCState(); initial.sheet = SCCounter.State()
-        let store = Store(initial: initial, behavior: registry.behavior, environment: SCWorld())
-        store.dispatch(.counter(.inc))
-        store.dispatch(.sheet(.inc))
-        #expect(store.state.counter.count == 1)   // both registered behaviors run
-        #expect(store.state.sheet?.count == 1)
-    }
+    // (Optional/modal children register their behavior via `liftOptional` — covered in the behavior
+    // tests; `Scope` here is present-state and drives both behavior and view.)
 }
 #endif

--- a/Tests/SwiftRexArchitectureTests/StoreBindingsTests.swift
+++ b/Tests/SwiftRexArchitectureTests/StoreBindingsTests.swift
@@ -29,11 +29,11 @@ struct StoreBindingsTests {
             initial: S(),
             behavior: Reducer.reduce { (action: A, state: inout S) in
                 switch action {
-                case .setName(let n):       state.name = n
+                case .setName(let n): state.name = n
                 case .presentEditor(let v): state.editor = v
-                case .dismissEditor:        state.editor = nil
-                case .select(let item):     state.selected = item
-                case .deselect:             state.selected = nil
+                case .dismissEditor: state.editor = nil
+                case .select(let item): state.selected = item
+                case .deselect: state.selected = nil
                 }
             }.asBehavior(),
             environment: ()
@@ -93,6 +93,78 @@ struct StoreBindingsTests {
         item.wrappedValue = nil // SwiftUI clearing the sheet
         await Task.yield()
         #expect(store.state.selected == nil)
+    }
+}
+
+// MARK: - Stack (path) + selection bindings
+
+@Suite("StoreType navigation bindings — path & selection")
+@MainActor
+struct StoreNavBindingsTests {
+    private enum Route: Hashable, Sendable { case a, b, c }
+    private enum Tab: Hashable, Sendable { case home, search, profile }
+
+    private struct S: Sendable, Equatable {
+        var path: [Route] = []
+        var tab: Tab = .home
+        var sidebar: Route?
+    }
+    private enum A: Sendable, Equatable {
+        case setPath([Route])
+        case selectTab(Tab)
+        case selectSidebar(Route?)
+    }
+
+    private func makeStore() -> Store<A, S, Void> {
+        Store(
+            initial: S(),
+            behavior: Reducer.reduce { (action: A, state: inout S) in
+                switch action {
+                case .setPath(let p): state.path = p
+                case .selectTab(let t): state.tab = t
+                case .selectSidebar(let r): state.sidebar = r
+                }
+            }.asBehavior(),
+            environment: ()
+        )
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func pathReadsAndDispatchesWholeNewPath() async {
+        let store = makeStore()
+        store.dispatch(.setPath([.a]))
+        await Task.yield()
+        let path = store.path(\.path, set: A.setPath)
+        #expect(path.wrappedValue == [.a])
+        path.wrappedValue = [.a, .b] // SwiftUI push
+        await Task.yield()
+        #expect(store.state.path == [.a, .b])
+        path.wrappedValue = [.a] // SwiftUI pop / back-swipe
+        await Task.yield()
+        #expect(store.state.path == [.a])
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func selectionDispatchesOnEveryChange() async {
+        let store = makeStore()
+        let tab = store.selection(\.tab, set: A.selectTab)
+        #expect(tab.wrappedValue == .home)
+        tab.wrappedValue = .search // selecting a tab is a real state change (not dismiss-only)
+        await Task.yield()
+        #expect(store.state.tab == .search)
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @Test func optionalSelectionHandlesNilAndValue() async {
+        let store = makeStore()
+        let sidebar = store.selection(\.sidebar, set: A.selectSidebar)
+        #expect(sidebar.wrappedValue == nil)
+        sidebar.wrappedValue = .c
+        await Task.yield()
+        #expect(store.state.sidebar == .c)
+        sidebar.wrappedValue = nil // clearing the sidebar selection
+        await Task.yield()
+        #expect(store.state.sidebar == nil)
     }
 }
 #endif

--- a/Tests/SwiftRexTests/BehaviorTests/BehaviorCombineArrayTests.swift
+++ b/Tests/SwiftRexTests/BehaviorTests/BehaviorCombineArrayTests.swift
@@ -1,0 +1,25 @@
+@testable import SwiftRex
+import Testing
+
+@Suite("Behavior.combine(array)")
+@MainActor
+struct BehaviorCombineArrayTests {
+    private struct S: Sendable, Equatable { var a = 0; var b = 0; var log = "" }
+    private enum A: Sendable { case go }
+
+    @Test func foldsAllInOrder() {
+        let r1 = Behavior<A, S, Void>.reduce { _, s in s.a += 1; s.log += "1" }
+        let r2 = Behavior<A, S, Void>.reduce { _, s in s.b += 1; s.log += "2" }
+        let store = Store(initial: S(), behavior: .combine([r1, r2]), environment: ())
+        store.dispatch(.go)
+        #expect(store.state.a == 1)
+        #expect(store.state.b == 1)
+        #expect(store.state.log == "12")   // left-to-right order preserved
+    }
+
+    @Test func emptyIsIdentity() {
+        let store = Store(initial: S(), behavior: Behavior<A, S, Void>.combine([]), environment: ())
+        store.dispatch(.go)
+        #expect(store.state == S())        // no-op
+    }
+}


### PR DESCRIPTION
## What
Reintroduces a feature protocol (your suggestion) as a **single `Feature` protocol**, and makes **`Scope` drive both** a feature's behavior and its view from one declaration. Stacked on #189.

## The protocol
```swift
public protocol Feature {
    associatedtype Action: Sendable, State: Sendable, Environment: Sendable, Body: View
    static func behavior() -> Behavior<Action, State, Environment>
    @MainActor static func view(store: any StoreType<Action, State>, environment: Environment) -> Body
}
```
- **One protocol**, not `ViewFactory: HasBehavior` (that refinement was absurd, and two parallel protocols also broke associated-type inference — a single one is a single source, infers cleanly).
- Exposes only the liftable/viewable surface — never `ViewState`/`ViewAction` (the retirement reason).
- `view` takes **`any StoreType`** (existential), not `some StoreType` (generic): a generic method returning `some View` can't bind `Body`; the existential can. A `Store` boxes in — **non-breaking** (whole suite green).

## Scope drives both
```swift
let detailScope = Scope(Detail.self, action: \.detail, state: \.detail, environment: \.detailEnv)
detailScope.behavior                          // Behavior<AppAction, AppState, World>  (renamed from `lifted`)
detailScope.view(from: store, world: world)   // Detail's view, env supplied — for a router @ViewBuilder switch
```
Present-state children; optional/modal children register via `liftOptional` and hand-wire the view. `Scopes` folds the (homogeneous) `.behavior` values.

## Findings (these reverse the two choices you made this morning — with evidence)
1. **Auto-generating the conformance is impossible for the view side** — a Swift limitation: an extension macro can't infer `Body` from a member-macro-generated `some View` method (proven: `@Feature` auto-conforms a Body-less protocol fine, but not `Feature`; **manual** `extension X: Feature {}` works). So it's a one-line manual conformance (like `: View`).
2. Delivered as an **additive PR** (not a 6-branch stack rewrite), but `Scope` **is** now the Feature-generic drive-both you asked for.

Green: 520 tests + swiftlint `--strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)