### PR TITLE
docs(nav): system/UIKit content + URLs — completes the navigation catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1748,7 +1748,9 @@ Navigation is a **function of state** — one store, routes in state, native Swi
 | **Selection** (1-of-N, all alive) | `Sel` | `selection(_:set:)` | `navigationSelection` | `TabView`, `.page`/carousel, `NavigationSplitView` |
 | **Scene set** | keyed sub-states | `hasScene(_:in:)` + projection | open/close actions | `WindowGroup(for:)`, multi-window (one store) |
 
-A **`Scope`** declares a child feature's wiring once and drives **both** its `behavior` and its `view` (`Scope(Detail.self, action: \.detail, state: \.detail, environment: \.detailEnv)`). A hand-written **router** (`@ViewBuilder view(for:)`, no `AnyView`) resolves a route to the child view, supplying the environment the env-free view body can't — the navigation crux. Effect lifecycle is state-driven: a supervisor reacting to route state cancels a screen's effects when it leaves. Full walkthrough: the **State-Driven Navigation** DocC article.
+A **`Scope`** declares a child feature's wiring once and drives **both** its `behavior` and its `view` (`Scope(Detail.self, action: \.detail, state: \.detail, environment: \.detailEnv)`). A hand-written **router** (`@ViewBuilder view(for:)`, no `AnyView`) resolves a route to the child view, supplying the environment the env-free view body can't — the navigation crux. Effect lifecycle is state-driven: a supervisor reacting to route state cancels a screen's effects when it leaves.
+
+System UI and UIKit screens — share sheet, photo/document pickers, web views, `SFSafariViewController` — are the **optional/modal** shape with a `UIViewControllerRepresentable` as the presented content (its `Coordinator` dispatches results back as actions). URLs sit at the boundary, not in a shape: an **incoming** deep link is an action source (`.onOpenURL { dispatch }`), while **opening an external** URL is a fire-and-forget effect over an injected `openURL` dependency. Full walkthrough: the **State-Driven Navigation** DocC article.
 
 # Testing
 

--- a/Sources/SwiftRex/SwiftRex.docc/Navigation.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Navigation.md
@@ -110,6 +110,39 @@ var body: some Scene {
 
 `openWindow(value: DocID(…))` / `dismissWindow` are triggered by dispatching actions that add or remove a scene's sub-state — the window set is a function of state.
 
+### System & UIKit content — share sheet, pickers, web, Safari
+
+Interruptive system UI and UIKit screens aren't a new shape — they're the **optional/modal** shape with a `UIViewControllerRepresentable`/`UIViewRepresentable` as the presented *content*. State drives *whether* it shows (`item`/`presence`, dismiss-only as always); the representable's `Coordinator` dispatches actions back for its results, so an outcome flows in as an ordinary action.
+
+```swift
+.sheet(item: store.item(\.sharing, dismiss: .doneSharing)) { payload in
+    ActivityView(items: payload.items)              // UIViewControllerRepresentable(UIActivityViewController)
+}
+.sheet(isPresented: store.presence(\.picker, dismiss: .cancelPicker)) {
+    PhotoPicker { images in store.dispatch(.picked(images)) }   // Coordinator dispatches the result
+}
+.fullScreenCover(item: store.item(\.browsing, dismiss: .closeBrowser)) { page in
+    WebView(url: page.url)                          // WKWebView / SwiftUI WebView, or SFSafariViewController
+}
+```
+
+The rule is unchanged: presentation is a function of state (the binding only *dismisses*); UIKit *results* come back as actions via the representable's `Coordinator` → `store.dispatch`. A web view's own in-page back/forward is the web view's business — if you want it in state, that's just the web feature's `State`. `ShareLink` (a tap-to-share view with no presented state) needs none of this — use it directly.
+
+## URLs — deep links in, external opens out
+
+A URL is never a navigation *shape* by itself; it sits at one of two boundaries:
+
+- **Incoming** (deep link / universal link) — an *action source*. Turn the URL into an action; the reducer sets navigation state; the app navigates like any other transition:
+  ```swift
+  RootView(store: store, router: router).onOpenURL { url in store.dispatch(.openedURL(url)) }
+  // reducer: case .openedURL(let u): state.path = route(for: u)
+  ```
+- **Outgoing** (open an external URL — Safari, Mail, Maps) — a *side effect*, not navigation: your app backgrounds, nothing is presented. Inject an `openURL` dependency in `World` and produce a fire-and-forget effect (pure and testable), or call SwiftUI's `@Environment(\.openURL)` from a button for a trivial case:
+  ```swift
+  // World: let openURL: @Sendable (URL) -> Void
+  case .tappedSupport: .produce { ctx in Effect.fireAndForget { ctx.environment.openURL(supportURL) } }
+  ```
+
 ## Scope — declare the wiring once, drive both sides
 
 A ``Scope`` captures how a child ``Feature`` embeds into the app store — action prism, state key path, environment narrowing — and derives **both** its lifted ``Scope/behavior`` and its ``Scope/view(from:world:)``. Constructing one is a **compile-time proof** the feature is wired; a missing state slot, action case, or env mapping is a compile error at the literal.


### PR DESCRIPTION
## What
Documents the last navigation cases so the catalog is genuinely exhaustive — **docs only, no new primitives** (they all reduce to existing shapes or to effects).

## The cases
- **System & UIKit content** — share sheet, photo/document pickers, web views (`WKWebView`/SwiftUI `WebView`), `SFSafariViewController`: these are the **optional/modal** shape with a `UIViewControllerRepresentable`/`UIViewRepresentable` as the presented *content*. State drives whether it shows; the representable's `Coordinator` dispatches its result back as an action. `ShareLink` (no presented state) is used directly.
- **URLs** are a boundary, not a shape:
  - **incoming** deep/universal links → an *action source* (`.onOpenURL { dispatch(…) }`) that sets nav state;
  - **outgoing** external opens → a *fire-and-forget effect* over an injected `openURL` `World` dependency (leaving the app is a side effect, not navigation).

## Changes
- `Navigation.docc`: two new sections (System & UIKit content; URLs).
- README navigation subsection: a paragraph covering both.

Verified `Effect.fireAndForget` exists (SwiftConcurrency); swiftlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)