### PR TITLE
Bump ReactiveConcurrency to 0.2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "06ee577977bf52d63ea1a1505f616e404b427e3a23052120075acadf44b86efd",
+  "originHash" : "97514313ea9d2bd582ad12a2e6fae5670138aa4d5ed47cdca0118741a6a76ab3",
   "pins" : [
     {
       "identity" : "fp",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/ReactiveConcurrency.git",
       "state" : {
-        "revision" : "e7c8f6dcf6ffa3d2a148f92081f7fbcc935077a1",
-        "version" : "0.1.0"
+        "revision" : "df0d8b95ff45c850a2a902f1fa17976244ba2822",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .package(url: "https://github.com/luizmb/Hourglass.git", from: "0.6.2"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.2.0"),
-        .package(url: "https://github.com/luizmb/ReactiveConcurrency.git", from: "0.1.0"),
+        .package(url: "https://github.com/luizmb/ReactiveConcurrency.git", from: "0.2.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.0")
     ],


### PR DESCRIPTION
## What
Bump the `ReactiveConcurrency` dependency floor from `0.1.0` to `0.2.0`.

## Why
RC 0.2.0 is released (FP 1.13 + Hourglass 0.6.2, Swift 6.3). The `SwiftRexReactiveConcurrency` bridge (trait-gated) should link the current version so downstream apps resolving both packages get a consistent graph.

## Changes
- `Package.swift`: `ReactiveConcurrency` `from: 0.1.0` → `0.2.0`.
- `Package.resolved` updated accordingly.

Traited build (`--enable-all-traits`) green; 520 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)