### PR TITLE
Bump ReactiveConcurrency to 0.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "97514313ea9d2bd582ad12a2e6fae5670138aa4d5ed47cdca0118741a6a76ab3",
+  "originHash" : "f8cb8c70d25020d04d5d45f1b95ba83c35b8171f38992e7c86aa55af5202dbe2",
   "pins" : [
     {
       "identity" : "fp",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/ReactiveConcurrency.git",
       "state" : {
-        "revision" : "df0d8b95ff45c850a2a902f1fa17976244ba2822",
-        "version" : "0.2.0"
+        "revision" : "4b712d4d311177182a109c7e3fb5f802fe80a648",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .package(url: "https://github.com/luizmb/Hourglass.git", from: "0.6.2"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.2.0"),
-        .package(url: "https://github.com/luizmb/ReactiveConcurrency.git", from: "0.2.0"),
+        .package(url: "https://github.com/luizmb/ReactiveConcurrency.git", from: "0.3.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.0")
     ],


### PR DESCRIPTION
## What
Bump the `ReactiveConcurrency` floor `0.2.0` → `0.3.0`.

## Why
RC 0.3.0 ships `@Sendable`-complete transformer operators and removes `ZIO`. SwiftRex's `SwiftRexReactiveConcurrency` bridge doesn't reference `ZIO`, so this is a clean floor bump to keep the graph consistent for downstream apps resolving both packages.

## Changes
- `Package.swift`: `ReactiveConcurrency` `from: 0.3.0` (+ `Package.resolved`).

Traited build (`--enable-all-traits`) green; 520 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)