### PR TITLE
chore: bump ReactiveConcurrency to 0.5.0

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -4,7 +4,7 @@
 |---------|---------|---------|---------|
 | [FP](https://github.com/luizmb/FP) | ≥1.14.0 | Apache 2.0 | Functional programming utilities |
 | [Hourglass](https://github.com/luizmb/Hourglass) | ≥0.7.0 | Apache 2.0 | Clock utilities and time-based AsyncStream operators |
-| [ReactiveConcurrency](https://github.com/luizmb/ReactiveConcurrency) | ≥0.2.0 | Apache 2.0 | Reactive streams over Swift Concurrency (trait) |
+| [ReactiveConcurrency](https://github.com/luizmb/ReactiveConcurrency) | ≥0.5.0 | Apache 2.0 | Reactive streams over Swift Concurrency (trait) |
 | [RxSwift](https://github.com/ReactiveX/RxSwift) | ≥6.10.0 | MIT | Rx reactive backend (opt-in trait) |
 | [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift) | ≥7.2.0 | MIT | ReactiveSwift backend (opt-in trait) |
 | [swift-syntax](https://github.com/swiftlang/swift-syntax) | ≥603.0.1 | Apache 2.0 | Macro implementation (SwiftRexMacros) |

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "64b6fc95a66df84bb94778642e6127320b6e814c9f2b67407bf2b57d5066718a",
+  "originHash" : "928c5a50768c460aa07b8de614e635e4a5201925228320cf60e83781293faf44",
   "pins" : [
     {
       "identity" : "fp",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/ReactiveConcurrency.git",
       "state" : {
-        "revision" : "4b712d4d311177182a109c7e3fb5f802fe80a648",
-        "version" : "0.3.0"
+        "revision" : "ede44828e09819eb4cb5c13d65e06f212c830bed",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .package(url: "https://github.com/luizmb/Hourglass.git", from: "0.7.0"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.2.0"),
-        .package(url: "https://github.com/luizmb/ReactiveConcurrency.git", from: "0.3.0"),
+        .package(url: "https://github.com/luizmb/ReactiveConcurrency.git", from: "0.5.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.0")
     ],


### PR DESCRIPTION
## What
Bumps the `ReactiveConcurrency` dependency `0.3.0 → 0.5.0` (latest release).

## Why
FP (1.14.0) and Hourglass (0.7.0) are already current on `main`; ReactiveConcurrency was the last own-lib dependency behind its latest tag. Keeps the SwiftRex dependency graph consistent (RC 0.5.0 itself pins Hourglass 0.7.0 + FP 1.14.0) — which also helps consumers that track `main`.

## Changes
- `Package.swift`: `ReactiveConcurrency` `from: "0.3.0"` → `"0.5.0"`; `Package.resolved` updated.

Verified: `swift build`/`swift test --enable-all-traits` pass on Swift 6.3.2.