### PR TITLE
ci(docs): deploy DocC to swiftrex.ios.lu (+ fix broken --enable-all-traits ordering)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Generate Documentation
         run: |
           swift package \
-            --allow-writing-to-directory .docs \
             --enable-all-traits \
+            --allow-writing-to-directory .docs \
             generate-documentation \
             --target SwiftRex \
             --target SwiftRexOperators \
@@ -46,18 +46,23 @@ jobs:
             --target SwiftRexArchitecture \
             --enable-experimental-combined-documentation \
             --enable-experimental-overloaded-symbol-presentation \
+            --experimental-transform-for-static-hosting-with-content \
             --output-path .docs \
-            --transform-for-static-hosting \
-            --hosting-base-path SwiftRex
+            --transform-for-static-hosting
+            # No --hosting-base-path: this deploys to the dedicated subdomain
+            # https://swiftrex.ios.lu (site root), not a sub-path.
 
-      - name: Redirect site root to /documentation/
+      - name: Custom domain (CNAME)
+        run: echo swiftrex.ios.lu > .docs/CNAME
+
+      - name: Redirect site root to the SwiftRex landing page
         run: |
           cat > .docs/index.html <<'EOF'
           <!doctype html>
-          <meta http-equiv="refresh" content="0; url=./documentation/">
-          <link rel="canonical" href="./documentation/">
+          <meta http-equiv="refresh" content="0; url=./documentation/swiftrex/">
+          <link rel="canonical" href="./documentation/swiftrex/">
           <title>SwiftRex — Documentation</title>
-          <a href="./documentation/">Redirecting to documentation…</a>
+          <a href="./documentation/swiftrex/">Redirecting to documentation…</a>
           EOF
 
       - name: Configure Pages


### PR DESCRIPTION
## What
Reconfigures the Documentation workflow to publish the DocC site to the dedicated **swiftrex.ios.lu** subdomain, and fixes a flag-ordering bug that was breaking the workflow.

## Why
- **Bug:** `--enable-all-traits` was placed *after* `--allow-writing-to-directory`. It's a `swift package` global option, not a plugin-sandbox flag, so it was rejected with `Unknown option '--enable-all-traits'` — the Documentation workflow never ran green.
- Moving hosting from the old `swiftrex.github.io/SwiftRex/…` path site to the **swiftrex.ios.lu** custom domain (GitHub Pages), matching how the other libraries publish DocC.

## Changes
- Fix flag order: `--enable-all-traits` now precedes `--allow-writing-to-directory`.
- Drop `--hosting-base-path SwiftRex` → deploy at the subdomain **root** (not `/SwiftRex/`).
- Add a `CNAME` (swiftrex.ios.lu) to the Pages artifact so the custom domain persists.
- Add `--experimental-transform-for-static-hosting-with-content` — bakes content into each HTML page (the modern static-hosting path; a real landing at root, not a JS-only shell).
- Site-root redirect now targets `/documentation/swiftrex/` (the `SwiftRex.md` landing article).

## Tests
- [x] Validated locally end-to-end (single target): the corrected flag combo builds and produces the full static site (`documentation/`, `css`, `data`, root `index`), no flag errors.

## Follow-up (separate, tracked)
The README still points its **banner + diagram images** and ~6 **doc links** at the old `swiftrex.github.io/SwiftRex/…` site; those need repointing (images restored in-repo from history, links → `swiftrex.ios.lu/documentation/…`). Sequenced after #202 to avoid README churn.