### PR TITLE
fix(release): pass release notes via --notes-file, not shell interpolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,9 +262,11 @@ jobs:
           ReactiveConcurrency bridges are available via SPM only."
           fi
 
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          echo "$BODY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Write to a file and consume it via `gh release create --notes-file`.
+          # Never interpolate the body into a shell string: it contains fenced code
+          # blocks, and backticks inside a double-quoted bash argument trigger command
+          # substitution (this is what broke the v1.0.0 promotion).
+          printf '%s\n' "$BODY" > "$GITHUB_WORKSPACE/RELEASE_NOTES.md"
 
       - name: List Artifacts
         run: |
@@ -275,7 +277,7 @@ jobs:
         run: |
           gh release create "${{ github.ref_name }}" \
             --title "Release ${{ github.ref_name }}" \
-            --notes "${{ steps.notes.outputs.body }}" \
+            --notes-file "$GITHUB_WORKSPACE/RELEASE_NOTES.md" \
             artifacts/*/*.zip
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What
Fixes the Promote → Create Release step so the release notes are passed to `gh release create` via `--notes-file` instead of being interpolated into the shell command.

## Why
The v1.0.0 promotion ([run 28878902225](https://github.com/SwiftRex/SwiftRex/actions/runs/28878902225)) failed at the final `Create Release` step with `no matches found for \`navigation\``. The step inlined the generated notes directly into a double-quoted shell argument:

```yaml
--notes "${{ steps.notes.outputs.body }}"
```

The notes body contains a fenced ```` ```swift ```` install block, and **backticks inside a double-quoted bash string trigger command substitution**. So the runner tried to execute the fenced snippet, hit a bare `navigation` token, tried to glob it, found no file, and exited 1. The tag `v1.0.0` and the XCFrameworks were built fine — only the GitHub Release object failed to create.

## Changes
- `Generate Release Notes` now writes the body to `$GITHUB_WORKSPACE/RELEASE_NOTES.md` (via `printf`) instead of `$GITHUB_OUTPUT`.
- `Create Release` consumes it with `--notes-file`, so notes are never interpreted by the shell regardless of content.

The v1.0.0 release itself has been staged manually as a draft (with the RC XCFrameworks attached) so it isn't blocked on this fix; this PR ensures future promotions don't hit the same bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)