### PR TITLE
refactor: reorder Supervision generics to Action-first

### DIFF
--- a/Sources/SwiftRex/Behavior/Behavior.swift
+++ b/Sources/SwiftRex/Behavior/Behavior.swift
@@ -69,7 +69,7 @@ public struct Behavior<Action: Sendable, State: Sendable, Environment: Sendable>
     /// The action-clock unit a `.reaction` consequence carries.
     typealias ReactionUnit = @MainActor @Sendable (Action, PreReducerContext<State>) -> Reaction<Action, State, Environment>
     /// The state-clock unit a `.supervision` consequence carries.
-    typealias SupervisionUnit = @MainActor @Sendable (State) -> Supervision<Environment, Action>
+    typealias SupervisionUnit = @MainActor @Sendable (State) -> Supervision<Action, Environment>
 
     /// The per-feature consequences, in composition order — the free monoid. ``identity`` is the
     /// empty list and ``combine(_:_:)`` concatenates; `handle`/`supervisor` are folded views over it.
@@ -89,7 +89,7 @@ public struct Behavior<Action: Sendable, State: Sendable, Environment: Sendable>
     /// for a state (Elm's `Sub`) — or `nil` when this behavior has **no** supervision at all. The
     /// Store reconciles it after every change. *Derived* from the presence of supervisions, never a
     /// flag that can drift.
-    package let supervisor: (@MainActor @Sendable (_ state: State) -> Supervision<Environment, Action>)?
+    package let supervisor: (@MainActor @Sendable (_ state: State) -> Supervision<Action, Environment>)?
 
     /// Whether this behavior has **any** `.supervision` — `true` iff `supervisor != nil`. The
     /// ``Store`` reconciles state-driven channels only when this holds, so a behavior that never
@@ -143,7 +143,7 @@ public struct Behavior<Action: Sendable, State: Sendable, Environment: Sendable>
     /// the lifts to carry the state-driven axis through a transform (`nil` when nothing supervises).
     init(
         handle: @escaping @MainActor @Sendable (Action, PreReducerContext<State>) -> Reaction<Action, State, Environment>,
-        supervisor: (@MainActor @Sendable (State) -> Supervision<Environment, Action>)?
+        supervisor: (@MainActor @Sendable (State) -> Supervision<Action, Environment>)?
     ) {
         self.init(consequences: [.reaction(handle)] + (supervisor.map { [.supervision($0)] } ?? []))
     }
@@ -203,7 +203,7 @@ extension Behavior {
     /// })
     /// ```
     public static func supervise(
-        _ keep: @escaping @MainActor @Sendable (State) -> Supervision<Environment, Action>
+        _ keep: @escaping @MainActor @Sendable (State) -> Supervision<Action, Environment>
     ) -> Self {
         Behavior(consequences: [.supervision(keep)])
     }
@@ -229,7 +229,7 @@ extension Behavior {
 
     /// Adds a state-driven concern, combining it with `self` — `b.supervise { … }` ≡ `b <> .supervise { … }`.
     public func supervise(
-        _ keep: @escaping @MainActor @Sendable (State) -> Supervision<Environment, Action>
+        _ keep: @escaping @MainActor @Sendable (State) -> Supervision<Action, Environment>
     ) -> Self { .combine(self, .supervise(keep)) }
 }
 

--- a/Sources/SwiftRex/Behavior/Consequence.swift
+++ b/Sources/SwiftRex/Behavior/Consequence.swift
@@ -188,5 +188,5 @@ public enum Consequence<Action: Sendable, State: Sendable, Environment: Sendable
     /// An **action-clock** consequence: react to an action with a ``Reaction``.
     case reaction(@MainActor @Sendable (Action, PreReducerContext<State>) -> Reaction<Action, State, Environment>)
     /// A **state-clock** consequence: supervise the channels a state should keep alive.
-    case supervision(@MainActor @Sendable (State) -> Supervision<Environment, Action>)
+    case supervision(@MainActor @Sendable (State) -> Supervision<Action, Environment>)
 }

--- a/Sources/SwiftRex/Middleware/Middleware.swift
+++ b/Sources/SwiftRex/Middleware/Middleware.swift
@@ -26,7 +26,7 @@ public struct Middleware<Action: Sendable, State: Sendable, Environment: Sendabl
     /// The action-clock unit a `.reaction` consequence carries.
     typealias ReactionUnit = @MainActor @Sendable (Action, PreReducerContext<State>) -> Reaction<Action, State, Environment>
     /// The state-clock unit a `.supervision` consequence carries.
-    typealias SupervisionUnit = @MainActor @Sendable (State) -> Supervision<Environment, Action>
+    typealias SupervisionUnit = @MainActor @Sendable (State) -> Supervision<Action, Environment>
 
     /// The consequences — effect-producing reactions and supervisions; never a mutation.
     package let consequences: [Consequence<Action, State, Environment>]
@@ -42,7 +42,7 @@ public struct Middleware<Action: Sendable, State: Sendable, Environment: Sendabl
 
     /// The **state** side: unions every supervision into the complete ``Supervision`` for a state, or
     /// `nil` when the middleware never supervises (the phase-5 bypass). Derived, never a drifting flag.
-    package let supervisor: (@MainActor @Sendable (_ state: State) -> Supervision<Environment, Action>)?
+    package let supervisor: (@MainActor @Sendable (_ state: State) -> Supervision<Action, Environment>)?
 
     /// Whether this middleware supervises any channels — `true` iff `supervisor != nil`.
     package var supervises: Bool { supervisor != nil }
@@ -92,7 +92,7 @@ public struct Middleware<Action: Sendable, State: Sendable, Environment: Sendabl
             _ action: Action,
             _ context: PreReducerContext<State>
         ) -> Reader<PostReducerContext<State, Environment>, Effect<Action>>,
-        supervisor: (@MainActor @Sendable (State) -> Supervision<Environment, Action>)? = nil
+        supervisor: (@MainActor @Sendable (State) -> Supervision<Action, Environment>)? = nil
     ) {
         self.init(
             consequences: [.reaction { action, context in Reaction(mutation: .unchanged, produce: handle(action, context)) }]
@@ -116,7 +116,7 @@ extension Middleware {
     /// }
     /// ```
     public static func supervise(
-        _ keep: @escaping @MainActor @Sendable (State) -> Supervision<Environment, Action>
+        _ keep: @escaping @MainActor @Sendable (State) -> Supervision<Action, Environment>
     ) -> Self {
         Middleware(consequences: [.supervision(keep)])
     }
@@ -128,7 +128,7 @@ extension Middleware {
 
     /// Adds a state-driven concern, combining it with `self` — `m.supervise { … }` ≡ `m <> .supervise { … }`.
     public func supervise(
-        _ keep: @escaping @MainActor @Sendable (State) -> Supervision<Environment, Action>
+        _ keep: @escaping @MainActor @Sendable (State) -> Supervision<Action, Environment>
     ) -> Self { .combine(self, .supervise(keep)) }
 }
 

--- a/Sources/SwiftRex/Reaction/Supervision.swift
+++ b/Sources/SwiftRex/Reaction/Supervision.swift
@@ -26,7 +26,7 @@ public typealias Keep<Action: Sendable> = [Channel<Action>]
 ///     Supervision { env in state.connected ? [Channel(id: "socket") { dispatch in … }] : [] }
 /// }
 /// ```
-public typealias Supervision<Environment: Sendable, Action: Sendable> =
+public typealias Supervision<Action: Sendable, Environment: Sendable> =
     Reader<Environment, Keep<Action>>
 
 /// The return of a ``Middleware``/``Behavior``'s **action** side (`produce`): a deferred


### PR DESCRIPTION
## What
Reorders `Supervision`'s generic parameters so `Action` comes first, completing the canonical **Action, State, Environment** ordering across the whole public API.

## Why
After #208 reordered `Reaction` and `Consequence`, `Supervision<Environment, Action>` was the last public type with `Action` not first. Doing it now, while there is no released version, avoids ever shipping the inconsistency.

## Changes
- `Supervision<Environment, Action>` → `Supervision<Action, Environment>` (no `State` param — `supervise`'s `Reader` takes only the `Environment`).
- Nominal reorder only; the underlying `Reader<Environment, Keep<Action>>` is unchanged. All 11 explicit spellings are in Sources; README/DocC use the inferred `Supervision { env in … }` form, so no doc changes were needed.

Verified: `SwiftRexTests` compiles clean and the core/supervise suites pass with `--enable-all-traits`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)