### PR TITLE
chore(deps): bump FP 2.0.1, Hourglass 1.0.1, ReactiveConcurrency 1.0.0; drop XCFrameworks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,79 +74,11 @@ jobs:
       - name: Test
         run: swift test --enable-all-traits 2>&1
 
-  rc-build-xcframework:
-    name: RC - Build XCFramework
-    if: startsWith(github.ref, 'refs/heads/release/')
-    runs-on: macos-26
-    needs: rc-test
-    strategy:
-      matrix:
-        framework: [SwiftRex, SwiftRexOperators, SwiftRexSwiftConcurrency, SwiftRexCombine, SwiftRexSwiftUI]
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.5.app
-
-      - name: Resolve Package Dependencies
-        run: swift package resolve
-
-      - name: Build Library in Release Configuration
-        run: |
-          set -x
-          swift build -c release --target ${{ matrix.framework }} -v
-          echo "✓ Build succeeded"
-
-      - name: Create XCFramework Structure
-        run: |
-          XCFWK_PATH="build/${{ matrix.framework }}/${{ matrix.framework }}.xcframework"
-          mkdir -p "$XCFWK_PATH"
-
-          # Copy Swift module files
-          for ext in swiftmodule swiftdoc abi.json swiftsourceinfo; do
-            if [ -f ".build/release/Modules/${{ matrix.framework }}.$ext" ]; then
-              cp ".build/release/Modules/${{ matrix.framework }}.$ext" "$XCFWK_PATH/"
-              echo "✓ Copied ${{ matrix.framework }}.$ext"
-            fi
-          done
-
-          echo "✓ XCFramework structure created"
-
-      - name: Verify XCFramework Created
-        run: |
-          XCFWK_PATH="build/${{ matrix.framework }}/${{ matrix.framework }}.xcframework"
-
-          if [ -d "$XCFWK_PATH" ]; then
-            echo "✓ XCFramework structure created"
-            ls -lah "$XCFWK_PATH"
-            find "$XCFWK_PATH" -type f
-          else
-            echo "✗ XCFramework not found"
-            find build -type d -o -type f | head -50
-            exit 1
-          fi
-
-      - name: Archive XCFramework
-        run: |
-          cd build/${{ matrix.framework }}
-          zip -r ${{ matrix.framework }}.xcframework.zip ${{ matrix.framework }}.xcframework
-          cd ../..
-          ls -lh build/${{ matrix.framework }}/${{ matrix.framework }}.xcframework.zip
-
-      - name: Upload XCFramework Artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.framework }}-xcframework
-          path: build/${{ matrix.framework }}/${{ matrix.framework }}.xcframework.zip
-          retention-days: 90
-
   rc-notify-status:
     name: RC - Notify Status
     if: startsWith(github.ref, 'refs/heads/release/')
     runs-on: ubuntu-latest
-    needs: [rc-test, rc-test-linux, rc-build-xcframework]
+    needs: [rc-test, rc-test-linux]
     steps:
       - name: Extract Version
         id: version
@@ -161,8 +93,7 @@ jobs:
           echo "::notice::Release Candidate ${{ steps.version.outputs.version }} is ready for promotion"
           echo ""
           echo "Next steps:"
-          echo "1. Verify the XCFramework artifacts above"
-          echo "2. When ready, run the 'Promote RC to Release' workflow"
+          echo "1. When ready, run the 'Promote RC to Release' workflow"
 
       - name: Failure Notification
         if: failure()
@@ -206,32 +137,12 @@ jobs:
   create-release:
     name: Promote - Create Release
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     needs: promote-test
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - name: Download RC Artifacts
-        run: |
-          TAG="${{ github.ref_name }}"
-          VERSION=${TAG#v}
-          BRANCH="release/$VERSION"
-
-          RUN_ID=$(gh api "repos/${{ github.repository }}/actions/runs?branch=${BRANCH}&status=success&per_page=20" \
-            --jq '[.workflow_runs[] | select(.name == "Release")] | first | .id')
-
-          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-            echo "::error::No successful RC build found for branch $BRANCH"
-            exit 1
-          fi
-
-          echo "::notice::Downloading artifacts from run $RUN_ID (branch: $BRANCH)"
-          mkdir -p artifacts
-          gh run download "$RUN_ID" --dir artifacts
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Generate Release Notes
         id: notes
@@ -253,13 +164,7 @@ jobs:
           ### Swift Package Manager
           \`\`\`swift
           .package(url: \"https://github.com/SwiftRex/SwiftRex.git\", from: \"${VERSION}\")
-          \`\`\`
-
-          ### XCFrameworks
-          See the attached \`.xcframework.zip\` files for pre-built binaries of the
-          dependency-free products (SwiftRex, SwiftRexOperators, SwiftRexSwiftConcurrency,
-          SwiftRexCombine, SwiftRexSwiftUI). The RxSwift, ReactiveSwift, and
-          ReactiveConcurrency bridges are available via SPM only."
+          \`\`\`"
           fi
 
           # Write to a file and consume it via `gh release create --notes-file`.
@@ -268,17 +173,11 @@ jobs:
           # substitution (this is what broke the v1.0.0 promotion).
           printf '%s\n' "$BODY" > "$GITHUB_WORKSPACE/RELEASE_NOTES.md"
 
-      - name: List Artifacts
-        run: |
-          echo "Found artifacts:"
-          find artifacts -name "*.zip" -exec ls -lh {} \;
-
       - name: Create Release
         run: |
           gh release create "${{ github.ref_name }}" \
             --title "Release ${{ github.ref_name }}" \
-            --notes-file "$GITHUB_WORKSPACE/RELEASE_NOTES.md" \
-            artifacts/*/*.zip
+            --notes-file "$GITHUB_WORKSPACE/RELEASE_NOTES.md"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/BenchmarkSuite/Package.resolved
+++ b/BenchmarkSuite/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "bdb49ea7182167f999da5d34f72209d898484d0ad532aeaea6a7ec3552ed35f2",
+  "originHash" : "ae260180a64d1c3e0ee3d901740ff6ccf08a3b968b6009717d93726a72b50fa6",
   "pins" : [
     {
       "identity" : "fp",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/FP.git",
       "state" : {
-        "revision" : "1b93d54ee5d35a9696c038b323563d2f22f60a2c",
-        "version" : "1.12.0"
+        "revision" : "cec6a5dfc9348797cb346b8faed22e4adb353fa5",
+        "version" : "2.0.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/Hourglass.git",
       "state" : {
-        "revision" : "ec2ff5aac99e59d2ea208e4d391fe54da8961608",
-        "version" : "0.6.2"
+        "revision" : "c122a98281bdd61a1c231c111fe643e49a6eaa9c",
+        "version" : "1.0.1"
       }
     },
     {
@@ -44,24 +44,6 @@
       "state" : {
         "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
         "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "reactiveswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
-      "state" : {
-        "revision" : "a44317ce38b5bcce173b03f5d36cfdc939e1768b",
-        "version" : "7.2.1"
-      }
-    },
-    {
-      "identity" : "rxswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveX/RxSwift.git",
-      "state" : {
-        "revision" : "132aea4f236ccadc51590b38af0357a331d51fa2",
-        "version" : "6.10.2"
       }
     },
     {

--- a/BenchmarkSuite/Package.swift
+++ b/BenchmarkSuite/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     platforms: [.macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9)],
     dependencies: [
         .package(path: ".."),
-        .package(url: "https://github.com/luizmb/FP.git", from: "1.12.0"),
+        .package(url: "https://github.com/luizmb/FP.git", from: "2.0.1"),
         .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.4.0")
     ],
     targets: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Bumped dependencies: FP → 1.14.0, Hourglass → 0.7.0.
+- Bumped dependencies to their first stable majors: FP → 2.0.1, Hourglass → 1.0.1,
+  ReactiveConcurrency → 1.0.0. No SwiftRex source changes were required — none of the majors'
+  breaking changes touch APIs SwiftRex consumes.
 - Tooling standardized to Swift 6.3 / Xcode 26.5; added SwiftFormat, SPDX headers, and Apache
   license attribution.
+
+### Removed
+- Dropped the XCFramework release path entirely — the pre-built binary artifacts were broken and
+  unused. SwiftRex is distributed via Swift Package Manager only. Removes the `rc-build-xcframework`
+  CI job and all XCFramework references from the README and the Installation article.
 
 ## [0.8.8] - 2026
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2,9 +2,9 @@
 
 | Package | Version | License | Purpose |
 |---------|---------|---------|---------|
-| [FP](https://github.com/luizmb/FP) | ≥1.14.0 | Apache 2.0 | Functional programming utilities |
-| [Hourglass](https://github.com/luizmb/Hourglass) | ≥0.7.0 | Apache 2.0 | Clock utilities and time-based AsyncStream operators |
-| [ReactiveConcurrency](https://github.com/luizmb/ReactiveConcurrency) | ≥0.5.0 | Apache 2.0 | Reactive streams over Swift Concurrency (trait) |
+| [FP](https://github.com/luizmb/FP) | ≥2.0.1 | Apache 2.0 | Functional programming utilities |
+| [Hourglass](https://github.com/luizmb/Hourglass) | ≥1.0.1 | Apache 2.0 | Clock utilities and time-based AsyncStream operators |
+| [ReactiveConcurrency](https://github.com/luizmb/ReactiveConcurrency) | ≥1.0.0 | Apache 2.0 | Reactive streams over Swift Concurrency (trait) |
 | [RxSwift](https://github.com/ReactiveX/RxSwift) | ≥6.10.0 | MIT | Rx reactive backend (opt-in trait) |
 | [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift) | ≥7.2.0 | MIT | ReactiveSwift backend (opt-in trait) |
 | [swift-syntax](https://github.com/swiftlang/swift-syntax) | ≥603.0.1 | Apache 2.0 | Macro implementation (SwiftRexMacros) |

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "928c5a50768c460aa07b8de614e635e4a5201925228320cf60e83781293faf44",
+  "originHash" : "2acb786d33970948fb848a2bd2e86e0395a72ae5231e38f173677d84d4bce10f",
   "pins" : [
     {
       "identity" : "fp",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/FP.git",
       "state" : {
-        "revision" : "d274138e9897e8daae26d4ca5a7e039b49c70ca2",
-        "version" : "1.14.0"
+        "revision" : "cec6a5dfc9348797cb346b8faed22e4adb353fa5",
+        "version" : "2.0.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/Hourglass.git",
       "state" : {
-        "revision" : "313f32dc368d39d13c4cc5540a076c8b7bc9d4f5",
-        "version" : "0.7.0"
+        "revision" : "c122a98281bdd61a1c231c111fe643e49a6eaa9c",
+        "version" : "1.0.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/ReactiveConcurrency.git",
       "state" : {
-        "revision" : "ede44828e09819eb4cb5c13d65e06f212c830bed",
-        "version" : "0.5.0"
+        "revision" : "ba29728cc6f3f4f7ded2ef149b1e3a546bf4a47c",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -35,11 +35,11 @@ let package = Package(
         .default(enabledTraits: [])
     ],
     dependencies: [
-        .package(url: "https://github.com/luizmb/FP.git", from: "1.14.0"),
-        .package(url: "https://github.com/luizmb/Hourglass.git", from: "0.7.0"),
+        .package(url: "https://github.com/luizmb/FP.git", from: "2.0.1"),
+        .package(url: "https://github.com/luizmb/Hourglass.git", from: "1.0.1"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.2.0"),
-        .package(url: "https://github.com/luizmb/ReactiveConcurrency.git", from: "0.5.0"),
+        .package(url: "https://github.com/luizmb/ReactiveConcurrency.git", from: "1.0.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.0")
     ],

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The three third-party bridges are each gated behind a [package trait](https://gi
 
 ![Enabling the ReactiveConcurrency trait for SwiftRex in Xcode's Package Dependencies (Traits column showing "default, ReactiveConcurrency")](Sources/SwiftRex/SwiftRex.docc/Resources/xcode-package-traits.png)
 
-Xcode project caveats (trait propagation in `project.pbxproj`, XcodeGen) and pre-built XCFrameworks are covered in the [Installation article](https://swiftrex.ios.lu/documentation/swiftrex/installation).
+Xcode project caveats (trait propagation in `project.pbxproj`, XcodeGen) are covered in the [Installation article](https://swiftrex.ios.lu/documentation/swiftrex/installation).
 
 # The core loop
 

--- a/Sources/SwiftRex/SwiftRex.docc/Installation.md
+++ b/Sources/SwiftRex/SwiftRex.docc/Installation.md
@@ -56,23 +56,6 @@ traits aren't dropped.
 > `project.pbxproj`. Keep `traits:` in `Package.swift` too (that's what the `swift` CLI uses).
 > XcodeGen does not emit package traits, so re-apply the block after each `xcodegen generate`.
 
-## XCFrameworks
-
-Pre-built XCFrameworks for the dependency-free products are attached to each
-[GitHub release](https://github.com/SwiftRex/SwiftRex/releases):
-
-| Framework | Contents |
-|---|---|
-| `SwiftRex.xcframework.zip` | Core store, reducers, behaviors, effects |
-| `SwiftRex.Operators.xcframework.zip` | Symbolic operators (`<>`, `\|>`, `>>>`, …) |
-| `SwiftRex.SwiftConcurrency.xcframework.zip` | async/await Effect bridges |
-| `SwiftRex.Combine.xcframework.zip` | Combine publisher bridge |
-| `SwiftRex.SwiftUI.xcframework.zip` | SwiftUI integration (`ViewStore`, `TrackedViewStore`, `ObservableObjectStore`, `asObservableObject`) |
-
-The third-party reactive bridges are trait-gated and depend on third-party frameworks — use SPM for
-those products. To integrate an XCFramework manually: download the `.zip` from the release, unzip it,
-and drag the `.xcframework` bundle into your target's **Frameworks, Libraries, and Embedded Content**.
-
 ## Topics
 
 ### Next


### PR DESCRIPTION
## What
Bump the three ecosystem dependencies to their first stable majors and remove the broken, unused XCFramework release path.

## Why
Dependabot's automated bumps (#211, #212) failed because the majors were treated as opaque breaking changes. Reviewing each changelog and letting the compiler confirm, none of the breaking changes actually touch APIs SwiftRex consumes — so this bumps all three together, cleanly. Separately, the pre-built XCFramework artifacts were broken and unused; SwiftRex is distributed via SPM only, so the whole path is removed.

## Changes

**Dependency bumps** (all breaking majors; **zero source changes required**)
- FP `1.14.0 → 2.0.1`
- Hourglass `0.7.0 → 1.0.1`
- ReactiveConcurrency `0.5.0 → 1.0.0`
- `Package.swift` + `Package.resolved` updated; `DEPENDENCIES.md` version table refreshed
- Verified: full rebuild `--build-tests --enable-all-traits` (0 errors), `swift test --enable-all-traits` (520 tests pass), `swiftlint --strict` (0 violations)

**XCFramework removal**
- `.github/workflows/release.yml`: deleted the `rc-build-xcframework` matrix job; dropped it from `rc-notify-status` needs; removed the artifact download/list/attach steps from `create-release` (now runs on `ubuntu-latest`, no macOS runner needed); removed the XCFrameworks block from generated release notes
- `README.md`: removed the pre-built XCFrameworks mention
- `Sources/SwiftRex/SwiftRex.docc/Installation.md`: removed the entire `## XCFrameworks` section
- `CHANGELOG.md`: documented the bumps and the XCFramework removal

Supersedes #211 and #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
