### PR TITLE
feat(core): Transceiver/Rig protocols + conform StoreType/Behavior/Reducer (Stage 1)

### DIFF
--- a/Sources/SwiftRex/Store/StoreType.swift
+++ b/Sources/SwiftRex/Store/StoreType.swift
@@ -58,7 +58,7 @@
 /// - Note: `StoreType` does not require `AnyObject`, so struct conformers (``StoreProjection``)
 ///   are allowed.
 @MainActor
-public protocol StoreType<Action, State>: Sendable {
+public protocol StoreType<Action, State>: Sendable, Transceiver {
     /// The action type this store accepts.
     associatedtype Action: Sendable
     /// The state type this store manages.

--- a/Sources/SwiftRex/Transceiver.swift
+++ b/Sources/SwiftRex/Transceiver.swift
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/// The `(Action, State)` two-way channel — the pure, type-level interface of a feature or a store, with
+/// `Action` flowing **in** (uplink) and `State` flowing **out** (downlink). ``Rig`` refines it with an
+/// `Environment`; a ``Store`` / ``StoreProjection`` realizes it at runtime as a ``StoreType``; a ``Relay``
+/// re-indexes one `Transceiver` into another.
+///
+/// Category theory: a `Transceiver` is a **profunctor** `Action ⇸ State` — contravariant in `Action`,
+/// covariant in `State` — concretely a Moore/Mealy **transducer**.
+public protocol Transceiver<Action, State> {
+    /// The action type — transmitted **in** (uplink).
+    associatedtype Action: Sendable
+    /// The state type — received **out** (downlink).
+    associatedtype State: Sendable
+}
+
+/// A ``Transceiver`` that also reaches the world — the `(Action, State, Environment)` triad. `Environment`
+/// is the antenna / backhaul: the feature's live line to effects and dependencies.
+///
+/// Category theory: the ``Transceiver`` profunctor in the Kleisli category of the effect monad, with a
+/// `Reader` carrying the `Environment`.
+public protocol Rig<Action, State, Environment>: Transceiver {
+    /// The environment (dependencies) type — the line to the world.
+    associatedtype Environment: Sendable
+}
+
+// A `Behavior` reduces, produces effects, and supervises over its `(Action, State, Environment)` — a `Rig`.
+extension Behavior: Rig {}
+
+// A `Reducer` folds actions into state over its `(Action, State)` — a `Transceiver`.
+extension Reducer: Transceiver {
+    public typealias Action = ActionType
+    public typealias State = StateType
+}

--- a/Sources/SwiftRexArchitecture/FeatureProtocol.swift
+++ b/Sources/SwiftRexArchitecture/FeatureProtocol.swift
@@ -4,21 +4,12 @@
     import SwiftRex
     import SwiftUI
 
-    /// The domain triad every feature shares — its `Action`, `State`, and `Environment` — with no
-    /// capability attached. Both ``HasBehavior`` and ``ViewFactory`` refine it, so the liftable wiring
-    /// (``Scope``) can be expressed over the triad alone: a `Scope` lifts whatever the child provides —
-    /// a behavior, a view, or both — because all three only need the triad to embed into a parent.
-    ///
-    /// It is the type-level *recipe* (`Environment` not yet applied), the dual of ``StoreType`` — the
-    /// runtime surface where `Environment` has been applied and erased, leaving only `(Action, State)`.
-    public protocol FeatureDomain {
-        /// The feature's action type.
-        associatedtype Action: Sendable
-        /// The feature's state type.
-        associatedtype State: Sendable
-        /// The feature's environment (dependencies) type.
-        associatedtype Environment: Sendable
-    }
+    /// The domain triad every feature shares — its `Action`, `State`, and `Environment`. It is the
+    /// `SwiftRex.Architecture` spelling of the core ``SwiftRex/Rig`` (a ``SwiftRex/Transceiver`` that also
+    /// reaches the world): both ``HasBehavior`` and ``ViewFactory`` refine it, so the liftable wiring
+    /// (``Scope``) can be expressed over the triad alone — a `Scope` lifts whatever the child provides,
+    /// a behavior, a view, or both.
+    public typealias FeatureDomain = Rig
 
     /// A feature that produces a ``Behavior`` — the composable, liftable behavior capability. A
     /// logic-only feature (no view) can conform to just this.

--- a/Tests/SwiftRexTests/TransceiverRigTests.swift
+++ b/Tests/SwiftRexTests/TransceiverRigTests.swift
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+@testable import SwiftRex
+import Testing
+
+@Suite("Transceiver / Rig")
+struct TransceiverRigTests {
+    private func acceptTransceiver<T: Transceiver>(_: T.Type) {}
+    private func acceptRig<R: Rig>(_: R.Type) {}
+
+    // Compiling is the proof: the core types plug into the radio spine — anything with `(Action, State)`
+    // is a `Transceiver`, and anything that also reaches the world (`+ Environment`) is a `Rig`.
+    @Test func coreTypesConform() {
+        acceptTransceiver(Store<Int, Int, Void>.self)      // StoreType: Transceiver
+        acceptTransceiver(Reducer<Int, Int>.self)          // Reducer: Transceiver
+        acceptTransceiver(Behavior<Int, Int, Void>.self)   // Rig refines Transceiver
+        acceptRig(Behavior<Int, Int, Void>.self)           // Behavior: Rig
+    }
+}


### PR DESCRIPTION
## What
Stage 1 of the radio-metaphor unification: introduce the two type-level domain protocols and conform the core types. Purely additive — nothing changes behaviorally.

## Why
Linking an `Action` and a `State` (store projection, SwiftUI bindings, presentation, view projection, feature lift) is one recurring operation. Reifying it needs a shared vocabulary for "a two-way `(Action, State)` channel" and "that + `Environment`". This stage lays the protocols and makes the existing core types instances of them, so later stages can generalize projection/bindings/presentation over `any Transceiver` and rename `Scope`.

## Changes
- **`Transceiver<Action, State>`** (core) — the `(Action, State)` two-way channel; a **profunctor** `Action ⇸ State` (Action in / *uplink*, State out / *downlink*).
- **`Rig<Action, State, Environment>: Transceiver`** (core) — a `Transceiver` that also reaches the world (`Environment` = the antenna/backhaul).
- Conformances: **`StoreType: Transceiver`** (⇒ `Store`, `StoreProjection`, `ViewStore`, `TrackedViewStore`, `StoreBuffer`), **`Behavior: Rig`**, **`Reducer: Transceiver`**.
- **`FeatureDomain` → `typealias FeatureDomain = Rig`** (SwiftRex.Architecture) — every existing `: FeatureDomain` and `Scope<Global: FeatureDomain>` keeps compiling unchanged.
- A conformance test (`Store`/`Reducer`/`Behavior` plug into `Transceiver`/`Rig`).

Next: `Relay` (= `dimap`) over any `Transceiver`; then `Gateway` (rename of `Scope`) over any `Rig`.

Validated: `swift test --enable-all-traits` → **525 pass, 0 failures**; `swiftlint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)