### PR TITLE
refactor(core): move Transceiver/Rig conformances into their type files

### DIFF
--- a/Sources/SwiftRex/Behavior/Behavior.swift
+++ b/Sources/SwiftRex/Behavior/Behavior.swift
@@ -289,3 +289,8 @@ extension Behavior: Monoid {
         Behavior(consequences: values.flatMap(\.consequences))
     }
 }
+
+// MARK: - Rig conformance
+
+/// A `Behavior` reduces, produces effects, and supervises over its `(Action, State, Environment)` — a ``Rig``.
+extension Behavior: Rig {}

--- a/Sources/SwiftRex/Reducer/Reducer.swift
+++ b/Sources/SwiftRex/Reducer/Reducer.swift
@@ -327,3 +327,11 @@ extension Reducer {
         sconcat(first, others)
     }
 }
+
+// MARK: - Transceiver conformance
+
+/// A `Reducer` folds actions into state over its `(Action, State)` — a ``Transceiver``.
+extension Reducer: Transceiver {
+    public typealias Action = ActionType
+    public typealias State = StateType
+}

--- a/Sources/SwiftRex/Transceiver.swift
+++ b/Sources/SwiftRex/Transceiver.swift
@@ -24,11 +24,5 @@ public protocol Rig<Action, State, Environment>: Transceiver {
     associatedtype Environment: Sendable
 }
 
-// A `Behavior` reduces, produces effects, and supervises over its `(Action, State, Environment)` — a `Rig`.
-extension Behavior: Rig {}
-
-// A `Reducer` folds actions into state over its `(Action, State)` — a `Transceiver`.
-extension Reducer: Transceiver {
-    public typealias Action = ActionType
-    public typealias State = StateType
-}
+// Conformances live with their types: `StoreType: Transceiver` (StoreType.swift), `Behavior: Rig`
+// (Behavior.swift), `Reducer: Transceiver` (Reducer.swift).


### PR DESCRIPTION
## What
Move the `Behavior: Rig` and `Reducer: Transceiver` conformances out of `Transceiver.swift` and into the conforming types' own files.

## Why
A type's conformance belongs with the type, not with the protocol. `Transceiver.swift` should hold only the `Transceiver`/`Rig` protocol definitions.

## Changes
- `Behavior: Rig` → **Behavior.swift**
- `Reducer: Transceiver` → **Reducer.swift**
- `Transceiver.swift` now holds only the two protocols (with a pointer comment to where the conformances live). `StoreType: Transceiver` was already declared in `StoreType.swift`.

No behavior change. `swift test --enable-all-traits` → **533 pass, 0 failures**; `swiftlint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)