### PR TITLE
chore(deps): bump FP to 2.2.0, ReactiveConcurrency to 1.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "5e95098a28af0201c063e3a74a24fb8c32382ecef48822f8c9595295b73c23f6",
+  "originHash" : "076791c83d73fe0c60294f84a2bfad440075200df17c55887efa933d8bb3adf0",
   "pins" : [
     {
       "identity" : "fp",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/luizmb/FP.git",
       "state" : {
-        "revision" : "d72df5ffaa2ec6b26d8fcbd624e3b66fa3d811c9",
-        "version" : "2.1.0"
+        "revision" : "3ff729badf4be84773f9681350e63513dddd4339",
+        "version" : "2.2.0"
       }
     },
     {
@@ -17,6 +17,33 @@
       "state" : {
         "revision" : "c122a98281bdd61a1c231c111fe643e49a6eaa9c",
         "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "reactiveconcurrency",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/luizmb/ReactiveConcurrency.git",
+      "state" : {
+        "revision" : "35ac52966c4c514bca05ed23bd3f2f621ea77e0f",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+      "state" : {
+        "revision" : "a44317ce38b5bcce173b03f5d36cfdc939e1768b",
+        "version" : "7.2.1"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "132aea4f236ccadc51590b38af0357a331d51fa2",
+        "version" : "6.10.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -35,11 +35,11 @@ let package = Package(
         .default(enabledTraits: [])
     ],
     dependencies: [
-        .package(url: "https://github.com/luizmb/FP.git", from: "2.1.0"),
+        .package(url: "https://github.com/luizmb/FP.git", from: "2.2.0"),
         .package(url: "https://github.com/luizmb/Hourglass.git", from: "1.0.1"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.10.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.2.0"),
-        .package(url: "https://github.com/luizmb/ReactiveConcurrency.git", from: "1.0.1"),
+        .package(url: "https://github.com/luizmb/ReactiveConcurrency.git", from: "1.1.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.0")
     ],


### PR DESCRIPTION
## Summary
- Bump FP dependency from 2.1.0 to 2.2.0
- Bump ReactiveConcurrency dependency from 1.0.1 to 1.1.0

## Test plan
- [x] `swift build --enable-all-traits` succeeds
- [x] `swift test --enable-all-traits` — 545/545 passing